### PR TITLE
Improve settings search recommendations

### DIFF
--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -185,7 +185,10 @@ function formatReleaseNotesForDisplay(notes: string | null): string | null {
 }
 
 export function SettingsModal(): JSX.Element {
-  const appInfo = getZenBridge().getAppInfo()
+  const zenBridge = getZenBridge()
+  const appInfo = zenBridge.getAppInfo()
+  const supportsRemoteWorkspace =
+    appInfo.runtime === 'desktop' && zenBridge.getCapabilities().supportsRemoteWorkspace
   const setSettingsOpen = useStore((s) => s.setSettingsOpen)
   const vimMode = useStore((s) => s.vimMode)
   const setVimMode = useStore((s) => s.setVimMode)
@@ -620,6 +623,14 @@ export function SettingsModal(): JSX.Element {
     })
   }, [])
 
+  const leaderKeyHintsTargetId = vimMode ? 'leader-key-hints' : 'vim-mode'
+  const leaderHintBehaviorTargetId =
+    vimMode && whichKeyHints ? 'leader-hint-behavior' : leaderKeyHintsTargetId
+  const leaderHintDurationTargetId =
+    vimMode && whichKeyHints && whichKeyHintMode === 'timed'
+      ? 'leader-hint-duration'
+      : leaderHintBehaviorTargetId
+
   const categories: SettingsCategory[] = [
     {
       id: 'appearance',
@@ -643,7 +654,8 @@ export function SettingsModal(): JSX.Element {
           id: 'theme-variant',
           title: 'Theme variant',
           description: 'Choose a family-specific contrast, flavor, or variant.',
-          keywords: ['variant', 'contrast', 'flavor']
+          keywords: ['variant', 'contrast', 'flavor'],
+          available: visibleVariants.length > 1
         },
         {
           id: 'dark-sidebar',
@@ -776,19 +788,22 @@ export function SettingsModal(): JSX.Element {
           id: 'leader-key-hints',
           title: 'Leader key hints',
           description: 'Show a which-key style guide after pressing the Leader key so the next available actions stay visible.',
-          keywords: ['leader', 'which-key']
+          keywords: ['leader', 'which-key'],
+          targetId: leaderKeyHintsTargetId
         },
         {
           id: 'leader-hint-behavior',
           title: 'Leader hint behavior',
           description: 'Timed auto-hides after a short delay. Sticky keeps the leader overlay open until you dismiss it.',
-          keywords: ['leader', 'sticky', 'timed']
+          keywords: ['leader', 'sticky', 'timed'],
+          targetId: leaderHintBehaviorTargetId
         },
         {
           id: 'leader-hint-duration',
           title: 'Leader hint duration',
           description: 'How long the leader overlay stays visible, and how long the pending leader sequence remains armed.',
-          keywords: ['leader', 'timeout', 'delay']
+          keywords: ['leader', 'timeout', 'delay'],
+          targetId: leaderHintDurationTargetId
         },
         {
           id: 'vault-text-search-backend',
@@ -1240,7 +1255,8 @@ export function SettingsModal(): JSX.Element {
           id: 'saved-remote-workspaces',
           title: 'Saved Remote Workspaces',
           description: 'Keep multiple ZenNotes servers and vaults ready to reconnect.',
-          keywords: ['remote', 'server', 'workspace', 'connect']
+          keywords: ['remote', 'server', 'workspace', 'connect'],
+          available: supportsRemoteWorkspace
         },
         {
           id: 'primary-notes-location',
@@ -1340,7 +1356,7 @@ export function SettingsModal(): JSX.Element {
                   Open Local Vault…
                 </button>
               )}
-              {appInfo.runtime === 'desktop' && getZenBridge().getCapabilities().supportsRemoteWorkspace && (
+              {supportsRemoteWorkspace && (
                 <button
                   onClick={() => void connectRemoteWorkspace()}
                   className="shrink-0 rounded-xl border border-paper-300/70 bg-paper-100/80 px-3.5 py-2 text-xs font-medium text-ink-800 transition-colors hover:bg-paper-200"
@@ -1351,7 +1367,7 @@ export function SettingsModal(): JSX.Element {
             </div>
           </Section>
 
-          {appInfo.runtime === 'desktop' && getZenBridge().getCapabilities().supportsRemoteWorkspace && (
+          {supportsRemoteWorkspace && (
             <Section
               title="Saved Remote Workspaces"
               description="Keep multiple ZenNotes servers and vaults ready to reconnect without re-entering URLs or tokens."

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -66,6 +66,27 @@ interface SettingsCategory extends SettingsSearchCategory<SettingsCategoryId> {
   content: JSX.Element
 }
 
+function settingsSearchTargetProps(
+  settingId: string | undefined
+): { 'data-settings-search-id'?: string } {
+  return settingId ? { 'data-settings-search-id': settingId } : {}
+}
+
+function findSettingsSearchTarget(root: HTMLElement, targetId: string): HTMLElement | null {
+  for (const element of root.querySelectorAll<HTMLElement>('[data-settings-search-id]')) {
+    if (element.dataset.settingsSearchId === targetId) return element
+  }
+  return null
+}
+
+function clearSettingsSearchHighlights(root: HTMLElement): void {
+  root
+    .querySelectorAll<HTMLElement>('[data-settings-search-highlight="true"]')
+    .forEach((element) => {
+      delete element.dataset.settingsSearchHighlight
+    })
+}
+
 function resolveVaultTextSearchBackend(
   preferred: VaultTextSearchBackendPreference,
   capabilities: VaultTextSearchCapabilities | null
@@ -517,6 +538,7 @@ export function SettingsModal(): JSX.Element {
   }
 
   const ref = useRef<HTMLDivElement | null>(null)
+  const settingsSearchHighlightTimerRef = useRef<number | null>(null)
   const [activeCategory, setActiveCategory] = useState<SettingsCategoryId>('appearance')
   const [activeSearchResultId, setActiveSearchResultId] = useState<string | null>(null)
   const [navQuery, setNavQuery] = useState('')
@@ -564,6 +586,40 @@ export function SettingsModal(): JSX.Element {
     return () => window.removeEventListener('keydown', onKey)
   }, [setSettingsOpen])
 
+  useEffect(() => {
+    return () => {
+      if (settingsSearchHighlightTimerRef.current != null) {
+        window.clearTimeout(settingsSearchHighlightTimerRef.current)
+      }
+    }
+  }, [])
+
+  const jumpToSettingsSearchTarget = useCallback((targetId: string): void => {
+    if (settingsSearchHighlightTimerRef.current != null) {
+      window.clearTimeout(settingsSearchHighlightTimerRef.current)
+      settingsSearchHighlightTimerRef.current = null
+    }
+
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        const root = ref.current
+        if (!root) return
+
+        const target = findSettingsSearchTarget(root, targetId)
+        if (!target) return
+
+        clearSettingsSearchHighlights(root)
+        target.dataset.settingsSearchHighlight = 'true'
+        target.scrollIntoView({ block: 'center', behavior: 'smooth' })
+
+        settingsSearchHighlightTimerRef.current = window.setTimeout(() => {
+          delete target.dataset.settingsSearchHighlight
+          settingsSearchHighlightTimerRef.current = null
+        }, 2000)
+      })
+    })
+  }, [])
+
   const categories: SettingsCategory[] = [
     {
       id: 'appearance',
@@ -608,7 +664,7 @@ export function SettingsModal(): JSX.Element {
             description="Pick the visual system ZenNotes uses across the app."
           >
             <div className="flex flex-col gap-5 px-5 py-5">
-              <div>
+              <div {...settingsSearchTargetProps('theme-family')}>
                 <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.18em] text-ink-500">
                   Family
                 </div>
@@ -630,7 +686,7 @@ export function SettingsModal(): JSX.Element {
                 </div>
               </div>
 
-              <div>
+              <div {...settingsSearchTargetProps('theme-mode')}>
                 <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.18em] text-ink-500">
                   Mode
                 </div>
@@ -653,7 +709,7 @@ export function SettingsModal(): JSX.Element {
               </div>
 
               {visibleVariants.length > 1 && (
-                <div>
+                <div {...settingsSearchTargetProps('theme-variant')}>
                   <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.18em] text-ink-500">
                     {themeFamily === 'gruvbox'
                       ? 'Contrast'
@@ -690,12 +746,14 @@ export function SettingsModal(): JSX.Element {
               label="Dark sidebar"
               description="Tint the sidebar one step darker than the canvas so the chrome reads as a separate surface."
               value={darkSidebar}
+              settingId="dark-sidebar"
               onChange={setDarkSidebar}
             />
             <ToggleRow
               label="Sidebar arrows"
               description="Show disclosure arrows for collapsible folders and sidebar sections."
               value={showSidebarChevrons}
+              settingId="sidebar-arrows"
               onChange={setShowSidebarChevrons}
             />
           </Section>
@@ -809,6 +867,7 @@ export function SettingsModal(): JSX.Element {
               label="Vim mode"
               description="First-class Vim motions in the markdown editor."
               value={vimMode}
+              settingId="vim-mode"
               onChange={setVimMode}
             />
             {vimMode ? (
@@ -817,6 +876,7 @@ export function SettingsModal(): JSX.Element {
                   label="Leader key hints"
                   description="Show a which-key style guide after pressing the Leader key so the next available actions stay visible."
                   value={whichKeyHints}
+                  settingId="leader-key-hints"
                   onChange={setWhichKeyHints}
                 />
                 {whichKeyHints && (
@@ -825,6 +885,7 @@ export function SettingsModal(): JSX.Element {
                       label="Leader hint behavior"
                       description="Timed auto-hides after a short delay. Sticky keeps the leader overlay open until you dismiss it."
                       value={whichKeyHintMode}
+                      settingId="leader-hint-behavior"
                       options={[
                         { value: 'timed', label: 'Timed' },
                         { value: 'sticky', label: 'Sticky' }
@@ -840,6 +901,7 @@ export function SettingsModal(): JSX.Element {
                         max={3000}
                         step={100}
                         format={(v) => `${(v / 1000).toFixed(1)}s`}
+                        settingId="leader-hint-duration"
                         onChange={setWhichKeyHintTimeoutMs}
                       />
                     )}
@@ -861,6 +923,7 @@ export function SettingsModal(): JSX.Element {
               label="Vault text search backend"
               description="Auto prefers fzf when available, then ripgrep, and falls back to the built-in searcher."
               value={vaultTextSearchBackend}
+              settingId="vault-text-search-backend"
               options={[
                 { value: 'auto', label: 'Auto' },
                 { value: 'builtin', label: 'Built-in' },
@@ -874,6 +937,7 @@ export function SettingsModal(): JSX.Element {
               description="Optional. Leave blank to use `rg` from your PATH."
               value={ripgrepBinaryPath ?? ''}
               placeholder="/custom/bin/rg"
+              settingId="ripgrep-binary-path"
               onChange={(next) => setRipgrepBinaryPath(next)}
             />
             <TextInputRow
@@ -881,6 +945,7 @@ export function SettingsModal(): JSX.Element {
               description="Optional. Leave blank to use `fzf` from your PATH."
               value={fzfBinaryPath ?? ''}
               placeholder="/custom/bin/fzf"
+              settingId="fzf-binary-path"
               onChange={(next) => setFzfBinaryPath(next)}
             />
             <InlineNote>
@@ -906,30 +971,35 @@ export function SettingsModal(): JSX.Element {
               label="Live preview"
               description="Hide markdown syntax on lines you're not editing. Turn off to always see raw #, **, [[…]], and other source text."
               value={livePreview}
+              settingId="live-preview"
               onChange={setLivePreview}
             />
             <ToggleRow
               label="Note tabs"
               description="Open notes in tabs and allow split-friendly tab workflows. Turn off to keep the simpler single-note behavior."
               value={tabsEnabled}
+              settingId="note-tabs"
               onChange={setTabsEnabled}
             />
             <ToggleRow
               label="Word wrap"
               description="Wrap long lines to the editor width. Turn off to scroll horizontally instead."
               value={wordWrap}
+              settingId="word-wrap"
               onChange={setWordWrap}
             />
             <ToggleRow
               label="Smooth preview scroll"
               description="Animate Ctrl+D / Ctrl+U half-page jumps in preview mode. Turn off for an instant snap that keeps position predictable."
               value={previewSmoothScroll}
+              settingId="smooth-preview-scroll"
               onChange={setPreviewSmoothScroll}
             />
             <SegmentedRow
               label="PDFs in edit mode"
               description="Compact keeps the editor focused. Full inlines the PDF viewer under your cursor."
               value={pdfEmbedInEditMode}
+              settingId="pdfs-in-edit-mode"
               options={[
                 { value: 'compact', label: 'Compact' },
                 { value: 'full', label: 'Full' }
@@ -940,6 +1010,7 @@ export function SettingsModal(): JSX.Element {
               label="Date-titled Quick Notes"
               description="New Quick Notes use YYYY-MM-DD instead of timestamp-style titles."
               value={quickNoteDateTitle}
+              settingId="date-titled-quick-notes"
               onChange={setQuickNoteDateTitle}
             />
             <TextInputRow
@@ -947,6 +1018,7 @@ export function SettingsModal(): JSX.Element {
               description="Used when naming new Quick Notes. Leave blank for a bare timestamp or date."
               value={quickNoteTitlePrefix ?? ''}
               placeholder="Quick Note"
+              settingId="quick-note-prefix"
               onChange={setQuickNoteTitlePrefix}
             />
           </Section>
@@ -955,7 +1027,7 @@ export function SettingsModal(): JSX.Element {
             title="Quick capture"
             description="Floating capture window for thoughts you want in the vault without leaving whatever you're doing."
           >
-            <QuickCaptureHotkeyRow />
+            <QuickCaptureHotkeyRow settingId="quick-capture-hotkey" />
           </Section>
         </div>
       )
@@ -974,7 +1046,7 @@ export function SettingsModal(): JSX.Element {
         }
       ],
       content: (
-        <div className="h-full">
+        <div className="h-full" {...settingsSearchTargetProps('shortcut-editor')}>
           <KeymapSettings
             vimMode={vimMode}
             overrides={keymapOverrides}
@@ -1056,6 +1128,7 @@ export function SettingsModal(): JSX.Element {
               description="Used for the sidebar, menus, and window chrome."
               value={interfaceFont}
               options={systemFonts}
+              settingId="interface-font"
               onChange={setInterfaceFont}
             />
             <FontRow
@@ -1063,6 +1136,7 @@ export function SettingsModal(): JSX.Element {
               description="Used for editing and reading views."
               value={textFont}
               options={systemFonts}
+              settingId="text-font"
               onChange={setTextFont}
             />
             <FontRow
@@ -1070,6 +1144,7 @@ export function SettingsModal(): JSX.Element {
               description="Used for code blocks, inline code, and frontmatter."
               value={monoFont}
               options={systemFonts}
+              settingId="monospace-font"
               onChange={setMonoFont}
             />
           </Section>
@@ -1086,6 +1161,7 @@ export function SettingsModal(): JSX.Element {
               max={32}
               step={1}
               unit="px"
+              settingId="font-size"
               onChange={setEditorFontSize}
             />
             <SliderRow
@@ -1095,6 +1171,7 @@ export function SettingsModal(): JSX.Element {
               min={1.2}
               max={2.4}
               step={0.05}
+              settingId="line-height"
               onChange={setEditorLineHeight}
               format={(v) => v.toFixed(2)}
             />
@@ -1106,6 +1183,7 @@ export function SettingsModal(): JSX.Element {
               max={1400}
               step={20}
               unit="px"
+              settingId="reading-width"
               onChange={setPreviewMaxWidth}
             />
             <SliderRow
@@ -1116,12 +1194,14 @@ export function SettingsModal(): JSX.Element {
               max={1600}
               step={20}
               unit="px"
+              settingId="editor-width"
               onChange={setEditorMaxWidth}
             />
             <SegmentedRow
               label="Content alignment"
               description="Center note content within the column or left-align it to the pane edge."
               value={contentAlign}
+              settingId="content-alignment"
               options={[
                 { value: 'center', label: 'Center' },
                 { value: 'left', label: 'Left' }
@@ -1132,6 +1212,7 @@ export function SettingsModal(): JSX.Element {
               label="Line numbers"
               description="Show editor gutter numbers. Relative uses Vim-style numbering with the current line shown normally."
               value={lineNumberMode}
+              settingId="line-numbers"
               options={[
                 { value: 'off', label: 'Off' },
                 { value: 'absolute', label: 'Absolute' },
@@ -1216,7 +1297,10 @@ export function SettingsModal(): JSX.Element {
             title="Location"
             description="ZenNotes reads markdown directly from the selected vault folder."
           >
-            <div className="flex items-center justify-between gap-4 px-5 py-5">
+            <div
+              className="flex items-center justify-between gap-4 px-5 py-5"
+              {...settingsSearchTargetProps('vault-location')}
+            >
               <div className="min-w-0">
                 <div className="text-sm font-medium text-ink-900">
                   {workspaceMode === 'remote' ? 'Remote workspace' : 'Vault location'}
@@ -1271,6 +1355,7 @@ export function SettingsModal(): JSX.Element {
             <Section
               title="Saved Remote Workspaces"
               description="Keep multiple ZenNotes servers and vaults ready to reconnect without re-entering URLs or tokens."
+              settingId="saved-remote-workspaces"
             >
               <div className="space-y-3 px-5 py-5">
                 <div className="flex items-center justify-between gap-4">
@@ -1356,6 +1441,7 @@ export function SettingsModal(): JSX.Element {
               label="Primary notes location"
               description="`Inbox` keeps ZenNotes' original lifecycle structure. `Vault root` surfaces top-level markdown files and folders directly."
               value={vaultSettings.primaryNotesLocation}
+              settingId="primary-notes-location"
               options={[
                 { value: 'inbox', label: 'Inbox' },
                 { value: 'root', label: 'Vault root' }
@@ -1377,6 +1463,7 @@ export function SettingsModal(): JSX.Element {
               label="Enable daily notes"
               description="Adds a dedicated daily-notes workflow without changing ordinary note creation."
               value={vaultSettings.dailyNotes.enabled}
+              settingId="enable-daily-notes"
               onChange={(enabled) =>
                 void persistVaultSettings({
                   ...vaultSettings,
@@ -1392,6 +1479,7 @@ export function SettingsModal(): JSX.Element {
               description="Stored inside your primary notes area. The default is `Daily Notes`."
               value={vaultSettings.dailyNotes.directory}
               placeholder={DEFAULT_DAILY_NOTES_DIRECTORY}
+              settingId="daily-notes-directory"
               onChange={(next) =>
                 void persistVaultSettings({
                   ...vaultSettings,
@@ -1402,7 +1490,10 @@ export function SettingsModal(): JSX.Element {
                 })
               }
             />
-            <div className="flex items-center justify-between gap-4 px-5 py-4">
+            <div
+              className="flex items-center justify-between gap-4 px-5 py-4"
+              {...settingsSearchTargetProps('open-todays-daily-note')}
+            >
               <div className="min-w-0">
                 <div className="text-sm font-medium text-ink-900">Open today's daily note</div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
@@ -1434,6 +1525,7 @@ export function SettingsModal(): JSX.Element {
               description="Shown in the sidebar, breadcrumbs, commands, and note actions."
               value={systemFolderLabels.inbox ?? ''}
               placeholder={DEFAULT_SYSTEM_FOLDER_LABELS.inbox}
+              settingId="inbox-label"
               onChange={(next) => setSystemFolderLabel('inbox', next)}
             />
             <TextInputRow
@@ -1441,6 +1533,7 @@ export function SettingsModal(): JSX.Element {
               description="Display name for the quick-capture area."
               value={systemFolderLabels.quick ?? ''}
               placeholder={DEFAULT_SYSTEM_FOLDER_LABELS.quick}
+              settingId="quick-notes-label"
               onChange={(next) => setSystemFolderLabel('quick', next)}
             />
             <TextInputRow
@@ -1448,6 +1541,7 @@ export function SettingsModal(): JSX.Element {
               description="Display name for cold-storage notes."
               value={systemFolderLabels.archive ?? ''}
               placeholder={DEFAULT_SYSTEM_FOLDER_LABELS.archive}
+              settingId="archive-label"
               onChange={(next) => setSystemFolderLabel('archive', next)}
             />
             <TextInputRow
@@ -1455,6 +1549,7 @@ export function SettingsModal(): JSX.Element {
               description="Display name for deleted-note recovery."
               value={systemFolderLabels.trash ?? ''}
               placeholder={DEFAULT_SYSTEM_FOLDER_LABELS.trash}
+              settingId="trash-label"
               onChange={(next) => setSystemFolderLabel('trash', next)}
             />
             <InlineNote>
@@ -1570,14 +1665,17 @@ export function SettingsModal(): JSX.Element {
         }
       ],
       content: (
-        <Section title="ZenNotes">
+        <Section title="ZenNotes" settingId="zen-notes-version">
           <div className="px-5 py-5">
             <div className="min-w-0 text-sm leading-6 text-ink-600">
               <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-center">
                 <span className="font-medium text-ink-900">ZenNotes</span>
                 <span className="text-xs text-ink-500">v{appInfo.version}</span>
               </div>
-              <div className="mx-auto mt-5 max-w-[44rem] rounded-2xl border border-paper-300/65 bg-paper-50/65 p-4 text-left shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
+              <div
+                className="mx-auto mt-5 max-w-[44rem] rounded-2xl border border-paper-300/65 bg-paper-50/65 p-4 text-left shadow-[0_10px_30px_rgba(15,23,42,0.04)]"
+                {...settingsSearchTargetProps('updates')}
+              >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-ink-500">
@@ -1692,7 +1790,10 @@ export function SettingsModal(): JSX.Element {
                 </a>{' '}
                 for company and product details.
               </p>
-              <div className="mt-4 flex flex-col items-center gap-1.5 border-t border-paper-300/55 pt-4 text-center">
+              <div
+                className="mt-4 flex flex-col items-center gap-1.5 border-t border-paper-300/55 pt-4 text-center"
+                {...settingsSearchTargetProps('lumary-labs')}
+              >
                 <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-ink-500">
                   Built by
                 </span>
@@ -1791,6 +1892,9 @@ export function SettingsModal(): JSX.Element {
                     onClick={() => {
                       setActiveCategory(result.category.id)
                       setActiveSearchResultId(result.id)
+                      if (result.type === 'setting') {
+                        jumpToSettingsSearchTarget(result.targetId)
+                      }
                     }}
                     className={[
                       'w-full rounded-xl px-3 py-2.5 text-left transition-colors',
@@ -2177,14 +2281,16 @@ function KeymapRecorderModal({
 function Section({
   title,
   description,
+  settingId,
   children
 }: {
   title: string
   description?: string
+  settingId?: string
   children: React.ReactNode
 }): JSX.Element {
   return (
-    <section className="space-y-3">
+    <section className="space-y-3" {...settingsSearchTargetProps(settingId)}>
       <div>
         <div className="text-[11px] font-medium uppercase tracking-[0.2em] text-ink-500">
           {title}
@@ -2230,7 +2336,7 @@ function formatAcceleratorForDisplay(accelerator: string): string {
     .join(mac ? '' : '+')
 }
 
-function QuickCaptureHotkeyRow(): JSX.Element {
+function QuickCaptureHotkeyRow({ settingId }: { settingId?: string } = {}): JSX.Element {
   const [current, setCurrent] = useState<string>('')
   const [recording, setRecording] = useState(false)
   const [draft, setDraft] = useState<string>('')
@@ -2287,7 +2393,10 @@ function QuickCaptureHotkeyRow(): JSX.Element {
 
   const display = draft || current
   return (
-    <div className="flex flex-col gap-2 px-5 py-4">
+    <div
+      className="flex flex-col gap-2 px-5 py-4"
+      {...settingsSearchTargetProps(settingId)}
+    >
       <div className="flex items-center justify-between gap-5">
         <div className="min-w-0">
           <div className="text-sm font-medium text-ink-900">Quick capture hotkey</div>
@@ -2374,16 +2483,21 @@ function TextInputRow({
   description,
   value,
   placeholder,
+  settingId,
   onChange
 }: {
   label: string
   description?: string
   value: string
   placeholder?: string
+  settingId?: string
   onChange: (next: string | null) => void
 }): JSX.Element {
   return (
-    <div className="flex items-center justify-between gap-5 px-5 py-4">
+    <div
+      className="flex items-center justify-between gap-5 px-5 py-4"
+      {...settingsSearchTargetProps(settingId)}
+    >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
         {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
@@ -2406,12 +2520,14 @@ function FontRow({
   description,
   value,
   options,
+  settingId,
   onChange
 }: {
   label: string
   description?: string
   value: string | null
   options: string[]
+  settingId?: string
   onChange: (next: string | null) => void
 }): JSX.Element {
   const [open, setOpen] = useState(false)
@@ -2528,7 +2644,10 @@ function FontRow({
   }
 
   return (
-    <div className="flex items-center justify-between gap-5 px-5 py-4">
+    <div
+      className="flex items-center justify-between gap-5 px-5 py-4"
+      {...settingsSearchTargetProps(settingId)}
+    >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
         {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
@@ -2645,6 +2764,7 @@ function SliderRow({
   step,
   unit,
   format,
+  settingId,
   onChange
 }: {
   label: string
@@ -2655,11 +2775,15 @@ function SliderRow({
   step: number
   unit?: string
   format?: (v: number) => string
+  settingId?: string
   onChange: (next: number) => void
 }): JSX.Element {
   const display = (format ? format(value) : String(value)) + (unit && !format ? unit : '')
   return (
-    <div className="flex items-center justify-between gap-5 px-5 py-4">
+    <div
+      className="flex items-center justify-between gap-5 px-5 py-4"
+      {...settingsSearchTargetProps(settingId)}
+    >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
         {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
@@ -2691,6 +2815,7 @@ function NumberRow({
   step,
   unit,
   format,
+  settingId,
   onChange
 }: {
   label: string
@@ -2701,12 +2826,16 @@ function NumberRow({
   step: number
   unit?: string
   format?: (v: number) => string
+  settingId?: string
   onChange: (next: number) => void
 }): JSX.Element {
   const display = (format ? format(value) : String(value)) + (unit ?? '')
   const clamp = (n: number): number => Math.min(max, Math.max(min, n))
   return (
-    <div className="flex items-center justify-between gap-4 px-6 py-3">
+    <div
+      className="flex items-center justify-between gap-4 px-6 py-3"
+      {...settingsSearchTargetProps(settingId)}
+    >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
         {description && <div className="text-xs text-ink-500">{description}</div>}
@@ -2738,15 +2867,20 @@ function ToggleRow({
   label,
   description,
   value,
+  settingId,
   onChange
 }: {
   label: string
   description?: string
   value: boolean
+  settingId?: string
   onChange: (next: boolean) => void
 }): JSX.Element {
   return (
-    <label className="flex cursor-pointer items-center justify-between gap-5 px-5 py-4">
+    <label
+      className="flex cursor-pointer items-center justify-between gap-5 px-5 py-4"
+      {...settingsSearchTargetProps(settingId)}
+    >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
         {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
@@ -2777,16 +2911,21 @@ function SegmentedRow<T extends string>({
   description,
   value,
   options,
+  settingId,
   onChange
 }: {
   label: string
   description?: string
   value: T
   options: { value: T; label: string }[]
+  settingId?: string
   onChange: (next: T) => void
 }): JSX.Element {
   return (
-    <div className="flex items-center justify-between gap-5 px-5 py-4">
+    <div
+      className="flex items-center justify-between gap-5 px-5 py-4"
+      {...settingsSearchTargetProps(settingId)}
+    >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
         {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
@@ -2864,7 +3003,11 @@ function CliSettings(): JSX.Element {
   if (status == null) {
     return (
       <div className="space-y-6">
-        <Section title="Command-Line Tool" description="Install the `zen` shell command for terminal-based note workflows.">
+        <Section
+          title="Command-Line Tool"
+          description="Install the `zen` shell command for terminal-based note workflows."
+          settingId="zen-command-line-tool"
+        >
           <InlineNote>Checking install status…</InlineNote>
         </Section>
       </div>
@@ -2874,7 +3017,11 @@ function CliSettings(): JSX.Element {
   if (!status.supportedPlatform) {
     return (
       <div className="space-y-6">
-        <Section title="Command-Line Tool" description="Install the `zen` shell command for terminal-based note workflows.">
+        <Section
+          title="Command-Line Tool"
+          description="Install the `zen` shell command for terminal-based note workflows."
+          settingId="zen-command-line-tool"
+        >
           <InlineNote>{status.reason ?? 'Not supported on this platform yet.'}</InlineNote>
         </Section>
       </div>
@@ -2896,6 +3043,7 @@ function CliSettings(): JSX.Element {
       <Section
         title="Command-Line Tool"
         description="The `zen` CLI talks to your vault directly from any terminal — perfect for scripts, cron jobs, editor plugins, shell pipelines, MCP, and launcher integrations like Raycast. Once installed, try `zen --help` or pipe text in: `pbpaste | zen capture`."
+        settingId="zen-command-line-tool"
       >
         <div className="flex flex-col gap-3 px-5 py-4">
           <div className="flex items-start justify-between gap-4">
@@ -3004,6 +3152,7 @@ function CliSettings(): JSX.Element {
       <Section
         title="Quick reference"
         description="A handful of the most useful commands. Quote paths with spaces, or pass them with `--path`. Run `zen --help` for the full list."
+        settingId="cli-quick-reference"
       >
         <div className="space-y-2 px-5 py-4 font-mono text-[12px] leading-6 text-ink-800">
           <div>zen list --tag idea</div>
@@ -3068,6 +3217,7 @@ function RaycastExtensionSettings({
       <Section
         title="Raycast Extension"
         description="Install the ZenNotes Raycast extension locally from this app instead of waiting for the Raycast Store review."
+        settingId="raycast-extension"
       >
         <InlineNote>Checking Raycast status…</InlineNote>
       </Section>
@@ -3094,6 +3244,7 @@ function RaycastExtensionSettings({
     <Section
       title="Raycast Extension"
       description="Install the ZenNotes Raycast extension locally from this app instead of waiting for the Raycast Store review."
+      settingId="raycast-extension"
     >
       <div className="flex flex-col gap-3 px-5 py-4">
         <div className="flex items-start justify-between gap-4">
@@ -3271,6 +3422,7 @@ function McpSettings(): JSX.Element {
       <Section
         title="Server"
         description="ZenNotes bundles a local MCP server that every client below connects to. It uses the packaged Electron binary in plain-Node mode, so no separate Node install is required."
+        settingId="mcp-server"
       >
         <div className="px-5 py-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
@@ -3319,6 +3471,7 @@ function McpSettings(): JSX.Element {
       <Section
         title="Integrations"
         description={"Pick the clients you want connected to this vault. Install writes a managed ZenNotes entry into that client\u2019s config; Uninstall removes just that entry."}
+        settingId="mcp-integrations"
       >
         {statuses == null ? (
           <InlineNote>{'Checking integration status\u2026'}</InlineNote>
@@ -3411,6 +3564,7 @@ function McpInstructionsEditor(): JSX.Element {
     <Section
       title="Instructions"
       description="The system prompt ZenNotes ships to any connected MCP client. Edit it to change how the AI writes, structures, and styles your notes. Changes take effect on the next MCP session."
+      settingId="mcp-instructions"
     >
       <div className="space-y-3 px-5 py-5">
         <div className="flex flex-wrap items-center justify-between gap-2">

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -37,6 +37,10 @@ import {
   getSystemFolderLabel
 } from '../lib/system-folder-labels'
 import { normalizeDailyNotesDirectory } from '../lib/vault-layout'
+import {
+  getSettingsSearchResults,
+  type SettingsSearchCategory
+} from '../lib/settings-search'
 import { getZenBridge } from '@zennotes/bridge-contract/bridge'
 import companyLogo from '../assets/lumary-labs-logo.svg'
 import { confirmApp } from './ConfirmHost'
@@ -54,7 +58,7 @@ type SettingsCategoryId =
 
 type ResolvedVaultTextSearchBackend = 'builtin' | 'ripgrep' | 'fzf'
 
-interface SettingsCategory {
+interface SettingsCategory extends SettingsSearchCategory<SettingsCategoryId> {
   id: SettingsCategoryId
   title: string
   description: string
@@ -514,6 +518,7 @@ export function SettingsModal(): JSX.Element {
 
   const ref = useRef<HTMLDivElement | null>(null)
   const [activeCategory, setActiveCategory] = useState<SettingsCategoryId>('appearance')
+  const [activeSearchResultId, setActiveSearchResultId] = useState<string | null>(null)
   const [navQuery, setNavQuery] = useState('')
   const availableVaultTextSearchTools = [
     vaultTextSearchCapabilities?.ripgrep ? 'ripgrep' : null,
@@ -565,6 +570,37 @@ export function SettingsModal(): JSX.Element {
       title: 'Appearance',
       description: 'Theme family, mode, and chrome surface styling.',
       keywords: ['theme', 'mode', 'variant', 'dark sidebar', 'surface', 'look'],
+      searchItems: [
+        {
+          id: 'theme-family',
+          title: 'Theme family',
+          description: 'Pick the visual system ZenNotes uses across the app.',
+          keywords: ['theme', 'family', 'apple', 'gruvbox', 'catppuccin', 'github', 'solarized', 'nord', 'tokyo night']
+        },
+        {
+          id: 'theme-mode',
+          title: 'Theme mode',
+          description: 'Choose light, dark, or automatic theme mode.',
+          keywords: ['light', 'dark', 'auto', 'mode']
+        },
+        {
+          id: 'theme-variant',
+          title: 'Theme variant',
+          description: 'Choose a family-specific contrast, flavor, or variant.',
+          keywords: ['variant', 'contrast', 'flavor']
+        },
+        {
+          id: 'dark-sidebar',
+          title: 'Dark sidebar',
+          description: 'Tint the sidebar one step darker than the canvas so the chrome reads as a separate surface.'
+        },
+        {
+          id: 'sidebar-arrows',
+          title: 'Sidebar arrows',
+          description: 'Show disclosure arrows for collapsible folders and sidebar sections.',
+          keywords: ['chevrons', 'disclosure']
+        }
+      ],
       content: (
         <div className="space-y-6">
           <Section
@@ -671,6 +707,98 @@ export function SettingsModal(): JSX.Element {
       title: 'Editor',
       description: 'Vim, leader hints, live preview, tabs, and writing behavior.',
       keywords: ['vim', 'leader', 'preview', 'tabs', 'wrap', 'pdf', 'quick note', 'quick capture', 'hotkey', 'shortcut', 'task', 'tasks'],
+      searchItems: [
+        {
+          id: 'vim-mode',
+          title: 'Vim mode',
+          description: 'First-class Vim motions in the markdown editor.',
+          keywords: ['vim', 'motions']
+        },
+        {
+          id: 'leader-key-hints',
+          title: 'Leader key hints',
+          description: 'Show a which-key style guide after pressing the Leader key so the next available actions stay visible.',
+          keywords: ['leader', 'which-key']
+        },
+        {
+          id: 'leader-hint-behavior',
+          title: 'Leader hint behavior',
+          description: 'Timed auto-hides after a short delay. Sticky keeps the leader overlay open until you dismiss it.',
+          keywords: ['leader', 'sticky', 'timed']
+        },
+        {
+          id: 'leader-hint-duration',
+          title: 'Leader hint duration',
+          description: 'How long the leader overlay stays visible, and how long the pending leader sequence remains armed.',
+          keywords: ['leader', 'timeout', 'delay']
+        },
+        {
+          id: 'vault-text-search-backend',
+          title: 'Vault text search backend',
+          description: 'Auto prefers fzf when available, then ripgrep, and falls back to the built-in searcher.',
+          keywords: ['search', 'backend', 'ripgrep', 'rg', 'fzf', 'built-in']
+        },
+        {
+          id: 'ripgrep-binary-path',
+          title: 'ripgrep binary path',
+          description: 'Optional. Leave blank to use `rg` from your PATH.',
+          keywords: ['search', 'rg', 'path']
+        },
+        {
+          id: 'fzf-binary-path',
+          title: 'fzf binary path',
+          description: 'Optional. Leave blank to use `fzf` from your PATH.',
+          keywords: ['search', 'path']
+        },
+        {
+          id: 'live-preview',
+          title: 'Live preview',
+          description: 'Hide markdown syntax on lines you are not editing.',
+          keywords: ['preview', 'markdown']
+        },
+        {
+          id: 'note-tabs',
+          title: 'Note tabs',
+          description: 'Open notes in tabs and allow split-friendly tab workflows.',
+          keywords: ['tabs']
+        },
+        {
+          id: 'word-wrap',
+          title: 'Word wrap',
+          description: 'Wrap long lines to the editor width. Turn off to scroll horizontally instead.',
+          keywords: ['wrap', 'line wrap']
+        },
+        {
+          id: 'smooth-preview-scroll',
+          title: 'Smooth preview scroll',
+          description: 'Animate Ctrl+D / Ctrl+U half-page jumps in preview mode.',
+          keywords: ['preview', 'scroll']
+        },
+        {
+          id: 'pdfs-in-edit-mode',
+          title: 'PDFs in edit mode',
+          description: 'Compact keeps the editor focused. Full inlines the PDF viewer under your cursor.',
+          keywords: ['pdf', 'embed']
+        },
+        {
+          id: 'date-titled-quick-notes',
+          title: 'Date-titled Quick Notes',
+          description: 'New Quick Notes use YYYY-MM-DD instead of timestamp-style titles.',
+          keywords: ['quick note', 'date', 'title']
+        },
+        {
+          id: 'quick-note-prefix',
+          title: 'Quick Note prefix',
+          description: 'Used when naming new Quick Notes.',
+          keywords: ['quick note', 'prefix']
+        },
+        {
+          id: 'quick-capture-hotkey',
+          title: 'Quick capture hotkey',
+          description: 'System-wide shortcut to open the floating capture window.',
+          keywords: ['quick capture', 'hotkey', 'shortcut']
+        }
+      ],
       content: (
         <div className="space-y-6">
           <Section
@@ -837,6 +965,14 @@ export function SettingsModal(): JSX.Element {
       title: 'Keymap',
       description: 'Remap global shortcuts, Vim bindings, and view navigation.',
       keywords: ['shortcuts', 'bindings', 'leader', 'vim', 'remap', 'keyboard'],
+      searchItems: [
+        {
+          id: 'shortcut-editor',
+          title: 'Shortcut editor',
+          description: 'Record a new key or sequence for the app’s keyboard-first actions.',
+          keywords: ['shortcuts', 'bindings', 'leader', 'vim', 'remap', 'keyboard']
+        }
+      ],
       content: (
         <div className="h-full">
           <KeymapSettings
@@ -853,6 +989,62 @@ export function SettingsModal(): JSX.Element {
       title: 'Typography',
       description: 'Fonts, line height, reading width, alignment, and line numbers.',
       keywords: ['font', 'size', 'line height', 'width', 'alignment', 'numbers'],
+      searchItems: [
+        {
+          id: 'interface-font',
+          title: 'Interface font',
+          description: 'Used for the sidebar, menus, and window chrome.',
+          keywords: ['font']
+        },
+        {
+          id: 'text-font',
+          title: 'Text font',
+          description: 'Used for editing and reading views.',
+          keywords: ['font']
+        },
+        {
+          id: 'monospace-font',
+          title: 'Monospace font',
+          description: 'Used for code blocks, inline code, and frontmatter.',
+          keywords: ['font', 'mono', 'code']
+        },
+        {
+          id: 'font-size',
+          title: 'Font size',
+          description: 'Editor and preview text size.',
+          keywords: ['size']
+        },
+        {
+          id: 'line-height',
+          title: 'Line height',
+          description: 'Editor and preview line spacing.',
+          keywords: ['spacing']
+        },
+        {
+          id: 'reading-width',
+          title: 'Reading width',
+          description: 'Maximum width for preview and split-preview content.',
+          keywords: ['width', 'preview']
+        },
+        {
+          id: 'editor-width',
+          title: 'Editor width',
+          description: 'Caps and centers the editor column so lines do not stretch edge-to-edge on large windows.',
+          keywords: ['width']
+        },
+        {
+          id: 'content-alignment',
+          title: 'Content alignment',
+          description: 'Center note content within the column or left-align it to the pane edge.',
+          keywords: ['alignment', 'center', 'left']
+        },
+        {
+          id: 'line-numbers',
+          title: 'Line numbers',
+          description: 'Show editor gutter numbers.',
+          keywords: ['numbers', 'gutter', 'relative', 'absolute']
+        }
+      ],
       content: (
         <div className="space-y-6">
           <Section
@@ -956,6 +1148,68 @@ export function SettingsModal(): JSX.Element {
       title: 'Vault',
       description: 'Current vault location and root-folder controls.',
       keywords: ['folder', 'root', 'location', 'open vault', 'change'],
+      searchItems: [
+        {
+          id: 'vault-location',
+          title: 'Vault location',
+          description: 'ZenNotes reads markdown directly from the selected vault folder.',
+          keywords: ['folder', 'root', 'location', 'open vault', 'change']
+        },
+        {
+          id: 'saved-remote-workspaces',
+          title: 'Saved Remote Workspaces',
+          description: 'Keep multiple ZenNotes servers and vaults ready to reconnect.',
+          keywords: ['remote', 'server', 'workspace', 'connect']
+        },
+        {
+          id: 'primary-notes-location',
+          title: 'Primary notes location',
+          description: 'Choose whether ZenNotes treats `inbox/` as the main notes area or uses the vault root directly.',
+          keywords: ['primary notes', 'inbox', 'vault root']
+        },
+        {
+          id: 'enable-daily-notes',
+          title: 'Enable daily notes',
+          description: 'Adds a dedicated daily-notes workflow without changing ordinary note creation.',
+          keywords: ['daily notes']
+        },
+        {
+          id: 'daily-notes-directory',
+          title: 'Daily notes directory',
+          description: 'Stored inside your primary notes area.',
+          keywords: ['daily notes', 'directory', 'folder']
+        },
+        {
+          id: 'open-todays-daily-note',
+          title: "Open today's daily note",
+          description: "Opens today's note if it exists, otherwise creates it.",
+          keywords: ['daily notes', 'today']
+        },
+        {
+          id: 'inbox-label',
+          title: 'Inbox label',
+          description: 'Shown in the sidebar, breadcrumbs, commands, and note actions.',
+          keywords: ['system folders', 'folder label']
+        },
+        {
+          id: 'quick-notes-label',
+          title: 'Quick Notes label',
+          description: 'Display name for the quick-capture area.',
+          keywords: ['system folders', 'folder label', 'quick']
+        },
+        {
+          id: 'archive-label',
+          title: 'Archive label',
+          description: 'Display name for cold-storage notes.',
+          keywords: ['system folders', 'folder label']
+        },
+        {
+          id: 'trash-label',
+          title: 'Trash label',
+          description: 'Display name for deleted-note recovery.',
+          keywords: ['system folders', 'folder label']
+        }
+      ],
       content: (
         <div className="space-y-6">
           <Section
@@ -1227,6 +1481,26 @@ export function SettingsModal(): JSX.Element {
         'agent',
         'model context protocol'
       ],
+      searchItems: [
+        {
+          id: 'mcp-server',
+          title: 'MCP server',
+          description: 'ZenNotes bundles a local MCP server that connected clients use.',
+          keywords: ['mcp', 'server', 'runtime', 'command']
+        },
+        {
+          id: 'mcp-integrations',
+          title: 'MCP integrations',
+          description: 'Pick the clients you want connected to this vault.',
+          keywords: ['mcp', 'claude', 'codex', 'client', 'install', 'uninstall']
+        },
+        {
+          id: 'mcp-instructions',
+          title: 'MCP instructions',
+          description: 'Edit the system prompt ZenNotes ships to any connected MCP client.',
+          keywords: ['mcp', 'prompt', 'instructions', 'system prompt']
+        }
+      ],
       content: <McpSettings />
     },
     {
@@ -1248,6 +1522,26 @@ export function SettingsModal(): JSX.Element {
         'capture',
         'developer'
       ],
+      searchItems: [
+        {
+          id: 'zen-command-line-tool',
+          title: 'zen command-line tool',
+          description: 'Install the `zen` shell command for terminal-based note workflows.',
+          keywords: ['cli', 'command line', 'terminal', 'shell', 'zen', 'install', 'path']
+        },
+        {
+          id: 'cli-quick-reference',
+          title: 'CLI quick reference',
+          description: 'A handful of the most useful `zen` commands.',
+          keywords: ['cli', 'help', 'commands', 'reference']
+        },
+        {
+          id: 'raycast-extension',
+          title: 'Raycast Extension',
+          description: 'Install the ZenNotes Raycast extension locally from this app.',
+          keywords: ['raycast', 'launcher', 'extension', 'install']
+        }
+      ],
       content: <CliSettings />
     },
     {
@@ -1255,6 +1549,26 @@ export function SettingsModal(): JSX.Element {
       title: 'About',
       description: 'App identity, version, updater status, and company information.',
       keywords: ['version', 'company', 'lumary', 'about', 'logo', 'updates'],
+      searchItems: [
+        {
+          id: 'zen-notes-version',
+          title: 'ZenNotes version',
+          description: 'App identity, current version, and product details.',
+          keywords: ['about', 'version', 'identity']
+        },
+        {
+          id: 'updates',
+          title: 'Updates',
+          description: 'Check GitHub releases for a newer ZenNotes build.',
+          keywords: ['release', 'download', 'install', 'updater']
+        },
+        {
+          id: 'lumary-labs',
+          title: 'Lumary Labs',
+          description: 'Company and product details.',
+          keywords: ['company', 'lumary', 'logo']
+        }
+      ],
       content: (
         <Section title="ZenNotes">
           <div className="px-5 py-5">
@@ -1412,16 +1726,14 @@ export function SettingsModal(): JSX.Element {
   ]
 
   const query = navQuery.trim().toLowerCase()
-  const filteredCategories = query
-    ? categories.filter((category) =>
-        [category.title, category.description, ...category.keywords].some((value) =>
-          value.toLowerCase().includes(query)
-        )
-      )
-    : categories
+  const searchResults = getSettingsSearchResults(categories, query)
+  const visibleSearchResult =
+    searchResults.find((result) => result.id === activeSearchResultId) ??
+    searchResults.find((result) => result.category.id === activeCategory) ??
+    searchResults[0] ??
+    null
   const visibleCategory =
-    filteredCategories.find((category) => category.id === activeCategory) ??
-    filteredCategories[0] ??
+    visibleSearchResult?.category ??
     null
 
   return (
@@ -1470,13 +1782,16 @@ export function SettingsModal(): JSX.Element {
 
           <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
             <nav className="space-y-1">
-              {filteredCategories.map((category) => {
-                const selected = visibleCategory?.id === category.id
+              {searchResults.map((result) => {
+                const selected = visibleSearchResult?.id === result.id
                 return (
                   <button
-                    key={category.id}
+                    key={result.id}
                     type="button"
-                    onClick={() => setActiveCategory(category.id)}
+                    onClick={() => {
+                      setActiveCategory(result.category.id)
+                      setActiveSearchResultId(result.id)
+                    }}
                     className={[
                       'w-full rounded-xl px-3 py-2.5 text-left transition-colors',
                       selected
@@ -1484,16 +1799,23 @@ export function SettingsModal(): JSX.Element {
                         : 'text-ink-600 hover:bg-paper-200/45 hover:text-ink-900'
                     ].join(' ')}
                   >
-                    <div className="text-sm font-medium">{category.title}</div>
+                    <div className="flex min-w-0 items-center justify-between gap-2">
+                      <div className="truncate text-sm font-medium">{result.title}</div>
+                      {result.type === 'setting' && (
+                        <span className="shrink-0 rounded-full border border-paper-300/60 bg-paper-100/70 px-2 py-0.5 text-[10px] font-medium text-ink-500">
+                          {result.category.title}
+                        </span>
+                      )}
+                    </div>
                     <div className="mt-1 line-clamp-2 text-[11px] leading-5 text-ink-500">
-                      {category.description}
+                      {result.description}
                     </div>
                   </button>
                 )
               })}
-              {filteredCategories.length === 0 && (
+              {searchResults.length === 0 && (
                 <div className="rounded-xl border border-dashed border-paper-300/70 px-3 py-4 text-sm text-ink-500">
-                  No settings sections match your search.
+                  No settings match your search.
                 </div>
               )}
             </nav>

--- a/packages/app-core/src/lib/settings-search.test.ts
+++ b/packages/app-core/src/lib/settings-search.test.ts
@@ -39,6 +39,7 @@ describe('getSettingsSearchResults', () => {
       id: 'editor:word-wrap',
       type: 'setting',
       title: 'Word wrap',
+      targetId: 'word-wrap',
       category: { id: 'editor', title: 'Editor' }
     })
   })

--- a/packages/app-core/src/lib/settings-search.test.ts
+++ b/packages/app-core/src/lib/settings-search.test.ts
@@ -61,4 +61,60 @@ describe('getSettingsSearchResults', () => {
     expect(results.map((result) => result.title)).toEqual(['Appearance', 'Editor'])
     expect(results.every((result) => result.type === 'category')).toBe(true)
   })
+
+  it('omits matching settings that are not currently available', () => {
+    const results = getSettingsSearchResults(
+      [
+        {
+          id: 'vault',
+          title: 'Vault',
+          description: 'Current vault location and root-folder controls.',
+          keywords: ['folder', 'root', 'location'],
+          searchItems: [
+            {
+              id: 'saved-remote-workspaces',
+              title: 'Saved Remote Workspaces',
+              description: 'Keep multiple ZenNotes servers and vaults ready to reconnect.',
+              keywords: ['remote', 'server', 'workspace'],
+              available: false
+            }
+          ]
+        }
+      ],
+      'remote'
+    )
+
+    expect(results).toEqual([])
+  })
+
+  it('uses an explicit target when a matching setting should jump to a visible prerequisite', () => {
+    const results = getSettingsSearchResults(
+      [
+        {
+          id: 'editor',
+          title: 'Editor',
+          description: 'Vim, leader hints, live preview, tabs, and writing behavior.',
+          keywords: ['vim', 'leader'],
+          searchItems: [
+            {
+              id: 'leader-hint-behavior',
+              title: 'Leader hint behavior',
+              description: 'Timed auto-hides after a short delay.',
+              keywords: ['leader', 'sticky', 'timed'],
+              targetId: 'leader-key-hints'
+            }
+          ]
+        }
+      ],
+      'behavior'
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      id: 'editor:leader-hint-behavior',
+      type: 'setting',
+      title: 'Leader hint behavior',
+      targetId: 'leader-key-hints'
+    })
+  })
 })

--- a/packages/app-core/src/lib/settings-search.test.ts
+++ b/packages/app-core/src/lib/settings-search.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { getSettingsSearchResults } from './settings-search'
+
+const categories = [
+  {
+    id: 'appearance',
+    title: 'Appearance',
+    description: 'Theme family, mode, and chrome surface styling.',
+    keywords: ['theme', 'mode'],
+    searchItems: [
+      {
+        id: 'dark-sidebar',
+        title: 'Dark sidebar',
+        description: 'Tint the sidebar one step darker than the canvas.'
+      }
+    ]
+  },
+  {
+    id: 'editor',
+    title: 'Editor',
+    description: 'Vim, leader hints, live preview, tabs, and writing behavior.',
+    keywords: ['vim', 'leader', 'preview', 'tabs', 'wrap'],
+    searchItems: [
+      {
+        id: 'word-wrap',
+        title: 'Word wrap',
+        description: 'Wrap long lines to the editor width.'
+      }
+    ]
+  }
+]
+
+describe('getSettingsSearchResults', () => {
+  it('surfaces the matching setting title instead of only the category title', () => {
+    const results = getSettingsSearchResults(categories, 'wrap')
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      id: 'editor:word-wrap',
+      type: 'setting',
+      title: 'Word wrap',
+      category: { id: 'editor', title: 'Editor' }
+    })
+  })
+
+  it('falls back to category results when a section itself matches', () => {
+    const results = getSettingsSearchResults(categories, 'appearance')
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      id: 'appearance:category',
+      type: 'category',
+      title: 'Appearance'
+    })
+  })
+
+  it('returns category navigation when the query is empty', () => {
+    const results = getSettingsSearchResults(categories, '')
+
+    expect(results.map((result) => result.title)).toEqual(['Appearance', 'Editor'])
+    expect(results.every((result) => result.type === 'category')).toBe(true)
+  })
+})

--- a/packages/app-core/src/lib/settings-search.ts
+++ b/packages/app-core/src/lib/settings-search.ts
@@ -28,6 +28,7 @@ export type SettingsSearchResult<
       type: 'setting'
       title: string
       description: string
+      targetId: string
       category: TCategory
       item: SettingsSearchItem
     }
@@ -76,6 +77,7 @@ function settingResult<TCategory extends SettingsSearchCategory>(
     type: 'setting',
     title: item.title,
     description: item.description ?? category.description,
+    targetId: item.id,
     category,
     item
   }

--- a/packages/app-core/src/lib/settings-search.ts
+++ b/packages/app-core/src/lib/settings-search.ts
@@ -1,0 +1,100 @@
+export interface SettingsSearchItem {
+  id: string
+  title: string
+  description?: string
+  keywords?: string[]
+}
+
+export interface SettingsSearchCategory<TCategoryId extends string = string> {
+  id: TCategoryId
+  title: string
+  description: string
+  keywords: string[]
+  searchItems?: SettingsSearchItem[]
+}
+
+export type SettingsSearchResult<
+  TCategory extends SettingsSearchCategory = SettingsSearchCategory
+> =
+  | {
+      id: string
+      type: 'category'
+      title: string
+      description: string
+      category: TCategory
+    }
+  | {
+      id: string
+      type: 'setting'
+      title: string
+      description: string
+      category: TCategory
+      item: SettingsSearchItem
+    }
+
+function includesQuery(value: string | undefined, query: string): boolean {
+  return value?.toLowerCase().includes(query) ?? false
+}
+
+function itemMatches(item: SettingsSearchItem, query: string): boolean {
+  return (
+    includesQuery(item.title, query) ||
+    includesQuery(item.description, query) ||
+    (item.keywords ?? []).some((keyword) => includesQuery(keyword, query))
+  )
+}
+
+function categoryMatches<TCategoryId extends string>(
+  category: SettingsSearchCategory<TCategoryId>,
+  query: string
+): boolean {
+  return (
+    includesQuery(category.title, query) ||
+    includesQuery(category.description, query) ||
+    category.keywords.some((keyword) => includesQuery(keyword, query))
+  )
+}
+
+function categoryResult<TCategory extends SettingsSearchCategory>(
+  category: TCategory
+): SettingsSearchResult<TCategory> {
+  return {
+    id: `${category.id}:category`,
+    type: 'category',
+    title: category.title,
+    description: category.description,
+    category
+  }
+}
+
+function settingResult<TCategory extends SettingsSearchCategory>(
+  category: TCategory,
+  item: SettingsSearchItem
+): SettingsSearchResult<TCategory> {
+  return {
+    id: `${category.id}:${item.id}`,
+    type: 'setting',
+    title: item.title,
+    description: item.description ?? category.description,
+    category,
+    item
+  }
+}
+
+export function getSettingsSearchResults<TCategory extends SettingsSearchCategory>(
+  categories: TCategory[],
+  query: string
+): SettingsSearchResult<TCategory>[] {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return categories.map(categoryResult)
+
+  return categories.flatMap((category) => {
+    const matchedItems = (category.searchItems ?? []).filter((item) =>
+      itemMatches(item, normalized)
+    )
+    if (matchedItems.length > 0) {
+      return matchedItems.map((item) => settingResult(category, item))
+    }
+    return categoryMatches(category, normalized) ? [categoryResult(category)] : []
+  })
+}

--- a/packages/app-core/src/lib/settings-search.ts
+++ b/packages/app-core/src/lib/settings-search.ts
@@ -3,6 +3,8 @@ export interface SettingsSearchItem {
   title: string
   description?: string
   keywords?: string[]
+  targetId?: string
+  available?: boolean
 }
 
 export interface SettingsSearchCategory<TCategoryId extends string = string> {
@@ -77,7 +79,7 @@ function settingResult<TCategory extends SettingsSearchCategory>(
     type: 'setting',
     title: item.title,
     description: item.description ?? category.description,
-    targetId: item.id,
+    targetId: item.targetId ?? item.id,
     category,
     item
   }
@@ -91,8 +93,8 @@ export function getSettingsSearchResults<TCategory extends SettingsSearchCategor
   if (!normalized) return categories.map(categoryResult)
 
   return categories.flatMap((category) => {
-    const matchedItems = (category.searchItems ?? []).filter((item) =>
-      itemMatches(item, normalized)
+    const matchedItems = (category.searchItems ?? []).filter(
+      (item) => item.available !== false && itemMatches(item, normalized)
     )
     if (matchedItems.length > 0) {
       return matchedItems.map((item) => settingResult(category, item))

--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -2410,16 +2410,32 @@ textarea,
 }
 
 [data-settings-search-id] {
-  transition:
-    background-color 160ms ease,
-    box-shadow 160ms ease;
+  scroll-margin-block: 24px;
+  transition: background-color 180ms ease;
 }
 
 [data-settings-search-highlight="true"] {
-  background: rgb(var(--z-accent) / 0.12);
-  box-shadow:
-    inset 3px 0 0 rgb(var(--z-accent) / 0.82),
-    inset 0 0 0 1px rgb(var(--z-accent) / 0.26);
+  background: rgb(var(--z-accent) / 0.055);
+  animation: settings-search-target-tint 2000ms ease-out;
+}
+
+@keyframes settings-search-target-tint {
+  0% {
+    background: rgb(var(--z-accent) / 0);
+  }
+  12%,
+  72% {
+    background: rgb(var(--z-accent) / 0.07);
+  }
+  100% {
+    background: rgb(var(--z-accent) / 0.025);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-settings-search-highlight="true"] {
+    animation: none;
+  }
 }
 
 /* ===========================================================================

--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -2409,6 +2409,19 @@ textarea,
   outline: none;
 }
 
+[data-settings-search-id] {
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+[data-settings-search-highlight="true"] {
+  background: rgb(var(--z-accent) / 0.12);
+  box-shadow:
+    inset 3px 0 0 rgb(var(--z-accent) / 0.82),
+    inset 0 0 0 1px rgb(var(--z-accent) / 0.26);
+}
+
 /* ===========================================================================
  * Vim navigation
  * =========================================================================*/


### PR DESCRIPTION
## Summary

- Add setting-level search metadata for the Settings modal.
- Render matched setting names in the settings search sidebar, with the parent section shown as context.
- Jump to the selected setting when a recommendation is clicked and highlight the target for two seconds.
- Add a regression test proving `wrap` returns `Word wrap` instead of only the `Editor` section.

## Why

Fixes #31 and fixes #32. The previous settings search only filtered top-level sections, so matching a specific setting surfaced the section/type name instead of the actual setting. Clicking a result also did not move the user to the actual control.

## Validation

- `npm run test:run --workspace @zennotes/app-core`
- `npm run typecheck --workspace @zennotes/app-core`
- `npm run typecheck --workspace @zennotes/desktop`
- `npm run typecheck --workspace @zennotes/web`
- `npm run build:nocheck --workspace @zennotes/web`
