### PR TITLE
fix: count words inside code blocks and inline code (#43)

### DIFF
--- a/packages/app-core/src/components/StatusBar.tsx
+++ b/packages/app-core/src/components/StatusBar.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useStore } from '../store'
 import type { NoteContent, NoteMeta } from '@shared/ipc'
 import { backlinksForNote } from '../lib/wikilinks'
+import { countWords } from '../lib/word-count'
 
 /**
  * Footer strip showing quick stats for the active note: backlinks,
@@ -17,12 +18,7 @@ export function StatusBar({ note }: { note: NoteContent }): JSX.Element {
 
   const { words, characters, minutes } = useMemo(() => {
     const body = note.body
-    const stripped = body
-      .replace(/^---\n[\s\S]*?\n---\n/, '')
-      .replace(/```[\s\S]*?```/g, ' ')
-      .replace(/`[^`\n]*`/g, ' ')
-    const wordArr = stripped.trim().split(/\s+/).filter(Boolean)
-    const w = wordArr.length
+    const w = countWords(body)
     const c = body.length
     const m = Math.max(1, Math.round(w / 200))
     return { words: w, characters: c, minutes: m }

--- a/packages/app-core/src/lib/word-count.test.ts
+++ b/packages/app-core/src/lib/word-count.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { countWords } from './word-count'
+
+describe('countWords', () => {
+  it('returns 0 for an empty string', () => {
+    expect(countWords('')).toBe(0)
+  })
+
+  it('returns 0 for whitespace-only input', () => {
+    expect(countWords('   \n\t  ')).toBe(0)
+  })
+
+  it('counts words separated by whitespace', () => {
+    expect(countWords('hello world')).toBe(2)
+  })
+
+  it('treats consecutive whitespace as a single separator', () => {
+    expect(countWords('  hello\n\nworld\t!  ')).toBe(3)
+  })
+
+  it('strips YAML frontmatter at the start of the document', () => {
+    const body = '---\ntitle: foo\ntags: [a, b]\n---\nhello world'
+    expect(countWords(body)).toBe(2)
+  })
+
+  it('handles CRLF line endings in frontmatter', () => {
+    const body = '---\r\ntitle: foo\r\n---\r\nhello world'
+    expect(countWords(body)).toBe(2)
+  })
+
+  it('does not strip --- horizontal rules in the body', () => {
+    const body = '# Heading\n\nfoo\n\n---\n\nbar'
+    expect(countWords(body)).toBe(5)
+  })
+
+  it('counts words inside fenced code blocks (issue #43)', () => {
+    const body = 'before\n\n```python\ndef hello():\n    return "world"\n```\n\nafter'
+    expect(countWords(body)).toBe(8)
+  })
+
+  it('counts words inside inline code (issue #43)', () => {
+    expect(countWords('use the `console.log` function')).toBe(4)
+  })
+})

--- a/packages/app-core/src/lib/word-count.ts
+++ b/packages/app-core/src/lib/word-count.ts
@@ -1,0 +1,13 @@
+/**
+ * Count words in a markdown body the way Obsidian does: strip the
+ * YAML frontmatter, then treat every whitespace-separated token as
+ * a word. Code blocks and inline code stay counted — Obsidian
+ * counts the words inside them and an earlier implementation
+ * stripping them caused issue #43 (huge undercounts on code-heavy
+ * notes).
+ */
+export function countWords(body: string): number {
+  const stripped = body.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '')
+  const matches = stripped.match(/\S+/g)
+  return matches?.length ?? 0
+}


### PR DESCRIPTION
## Summary

Fixes [#43](https://github.com/ZenNotes/zennotes/issues/43) — the StatusBar word count was massively undercounting code-heavy notes (the reporter saw 127,260 words in Obsidian vs 34,608 in ZenNotes).

Root cause: the inline regex in `StatusBar.tsx` stripped fenced code blocks and inline code spans *before* splitting on whitespace. Obsidian counts those tokens, so we should too.

The fix extracts the logic into a small `countWords` helper that only strips YAML frontmatter (which Obsidian also excludes), then counts every non-whitespace token. Behavior verified end-to-end against a test note: 52 words (buggy) → 76 words (fixed), matching a hand count.

## Test plan

- [x] Added `packages/app-core/src/lib/word-count.test.ts` — 9 vitest cases including the regression for issue #43 (words inside code blocks and inline code), CRLF frontmatter, `---` horizontal rules in body, empty input
- [x] `npx vitest run` — all 82 tests in `@zennotes/app-core` pass
- [x] `npx tsc --noEmit` — clean
- [x] Manual verification: opened the test note in the running dev build; status bar now shows 76 words (was 52 with the buggy regex)