### PR TITLE
feat: calendar sidebar panel for daily and weekly notes

### DIFF
--- a/packages/app-core/src/components/DailyNotesCalendar.tsx
+++ b/packages/app-core/src/components/DailyNotesCalendar.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useStore } from '../store'
+import {
+  normalizeVaultSettings,
+  noteFolderSubpath,
+  weeklyNoteTitle,
+} from '../lib/vault-layout'
+import { getISOWeek, getISOWeekYear } from '../lib/template-render'
+import { ChevronLeftIcon, ChevronRightIcon } from './icons'
+import { confirmApp } from '../lib/confirm-requests'
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1)
+}
+
+/** 6-row Monday-first grid for the month containing `anchor`. */
+function buildGrid(anchor: Date): Date[] {
+  const first = new Date(anchor.getFullYear(), anchor.getMonth(), 1)
+  const isoOffset = (first.getDay() + 6) % 7
+  const start = new Date(first.getFullYear(), first.getMonth(), 1 - isoOffset)
+  return Array.from({ length: 42 }, (_, i) => {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    return d
+  })
+}
+
+function isoDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function isoWeekStr(d: Date): string {
+  return `${getISOWeekYear(d)}-W${String(getISOWeek(d)).padStart(2, '0')}`
+}
+
+function monthLabel(d: Date): string {
+  return d.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
+}
+
+export function DailyNotesCalendar(): JSX.Element {
+  const notes = useStore((s) => s.notes)
+  const vaultSettings = useStore((s) => s.vaultSettings)
+  const openDailyNoteForDate = useStore((s) => s.openDailyNoteForDate)
+  const openWeeklyNoteForDate = useStore((s) => s.openWeeklyNoteForDate)
+
+  const settings = useMemo(() => normalizeVaultSettings(vaultSettings), [vaultSettings])
+  const dailyEnabled = settings.dailyNotes.enabled
+  const weeklyEnabled = settings.weeklyNotes.enabled
+  const dailySubpath = settings.dailyNotes.directory
+  const weeklySubpath = settings.weeklyNotes.directory
+
+  const today = useMemo(() => {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  }, [])
+
+  const [anchor, setAnchor] = useState(
+    () => new Date(today.getFullYear(), today.getMonth(), 1)
+  )
+
+  const notedDays = useMemo(() => {
+    const set = new Set<string>()
+    if (!dailyEnabled) return set
+    for (const note of notes) {
+      if (note.folder !== 'inbox') continue
+      if (noteFolderSubpath(note, settings) !== dailySubpath) continue
+      if (/^\d{4}-\d{2}-\d{2}$/.test(note.title)) set.add(note.title)
+    }
+    return set
+  }, [notes, settings, dailyEnabled, dailySubpath])
+
+  const notedWeeks = useMemo(() => {
+    const set = new Set<string>()
+    if (!weeklyEnabled) return set
+    for (const note of notes) {
+      if (note.folder !== 'inbox') continue
+      if (noteFolderSubpath(note, settings) !== weeklySubpath) continue
+      if (/^\d{4}-W\d{2}$/.test(note.title)) set.add(note.title)
+    }
+    return set
+  }, [notes, settings, weeklyEnabled, weeklySubpath])
+
+  const handleDayClick = useCallback(
+    async (day: Date, iso: string) => {
+      if (!dailyEnabled) return
+      if (notedDays.has(iso)) {
+        await openDailyNoteForDate(day)
+        return
+      }
+      const ok = await confirmApp({
+        title: 'New Daily Note',
+        description: `${iso} does not exist. Would you like to create it?`,
+        confirmLabel: 'Create',
+        cancelLabel: 'Never mind',
+      })
+      if (ok) await openDailyNoteForDate(day)
+    },
+    [dailyEnabled, notedDays, openDailyNoteForDate]
+  )
+
+  const handleWeekClick = useCallback(
+    async (monday: Date, weekIso: string) => {
+      if (!weeklyEnabled) return
+      if (notedWeeks.has(weekIso)) {
+        await openWeeklyNoteForDate(monday)
+        return
+      }
+      const label = weeklyNoteTitle(monday)
+      const ok = await confirmApp({
+        title: 'New Weekly Note',
+        description: `${label} does not exist. Would you like to create it?`,
+        confirmLabel: 'Create',
+        cancelLabel: 'Never mind',
+      })
+      if (ok) await openWeeklyNoteForDate(monday)
+    },
+    [weeklyEnabled, notedWeeks, openWeeklyNoteForDate]
+  )
+
+  const grid = useMemo(() => buildGrid(anchor), [anchor])
+  const todayIso = isoDateStr(today)
+  const todayWeekIso = isoWeekStr(today)
+  const anchorMonth = anchor.getMonth()
+
+  const rowMondays = useMemo(
+    () => grid.filter((_, i) => i % 7 === 0),
+    [grid]
+  )
+
+  return (
+    <div className="select-none px-2 pb-3">
+      <div className="flex items-center justify-between py-1">
+        <button
+          type="button"
+          onClick={() => setAnchor((a) => addMonths(a, -1))}
+          className="rounded p-0.5 text-ink-500 hover:text-ink-800 transition-colors"
+          aria-label="Previous month"
+        >
+          <ChevronLeftIcon className="h-3.5 w-3.5" />
+        </button>
+        <span className="text-[11px] font-medium text-ink-600">{monthLabel(anchor)}</span>
+        <button
+          type="button"
+          onClick={() => setAnchor((a) => addMonths(a, 1))}
+          className="rounded p-0.5 text-ink-500 hover:text-ink-800 transition-colors"
+          aria-label="Next month"
+        >
+          <ChevronRightIcon className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-[1.5rem_repeat(7,1fr)] gap-y-0.5">
+        <div className="text-[9px] font-medium uppercase text-ink-400 flex items-center justify-center">
+          W
+        </div>
+        {DAY_LABELS.map((label) => (
+          <div key={label} className="text-[9px] font-medium uppercase text-ink-400 text-center">
+            {label}
+          </div>
+        ))}
+
+        {rowMondays.map((monday, rowIdx) => {
+          const rowDays = grid.slice(rowIdx * 7, rowIdx * 7 + 7)
+          const weekIso = isoWeekStr(monday)
+          const weekNum = getISOWeek(monday)
+          const isThisWeek = weekIso === todayWeekIso
+          const hasWeekNote = notedWeeks.has(weekIso)
+
+          const weekCell = weeklyEnabled ? (
+            <button
+              key={`w${rowIdx}`}
+              type="button"
+              onClick={() => void handleWeekClick(monday, weekIso)}
+              className={[
+                'flex flex-col items-center rounded py-0.5 text-[11px] leading-tight transition-colors',
+                isThisWeek
+                  ? 'bg-accent/20 font-semibold text-accent'
+                  : 'text-ink-400 hover:bg-paper-200',
+              ].join(' ')}
+            >
+              <span>{weekNum}</span>
+              <span
+                className={[
+                  'mt-0.5 h-1 w-1 rounded-full',
+                  hasWeekNote
+                    ? isThisWeek ? 'bg-accent' : 'bg-ink-400'
+                    : 'invisible',
+                ].join(' ')}
+              />
+            </button>
+          ) : (
+            <div
+              key={`w${rowIdx}`}
+              className="text-[9px] text-ink-400 flex items-center justify-center"
+            >
+              {weekNum}
+            </div>
+          )
+
+          const dayCells = rowDays.map((day) => {
+            const iso = isoDateStr(day)
+            const isToday = iso === todayIso
+            const inMonth = day.getMonth() === anchorMonth
+            const hasNote = notedDays.has(iso)
+
+            return (
+              <button
+                key={iso}
+                type="button"
+                onClick={() => void handleDayClick(day, iso)}
+                disabled={!dailyEnabled}
+                className={[
+                  'flex flex-col items-center rounded py-0.5 text-[11px] leading-tight transition-colors',
+                  !dailyEnabled
+                    ? inMonth ? 'text-ink-600 cursor-default' : 'text-ink-400 cursor-default'
+                    : isToday
+                      ? 'bg-accent/20 font-semibold text-accent'
+                      : inMonth
+                        ? 'text-ink-700 hover:bg-paper-200'
+                        : 'text-ink-400 hover:bg-paper-200',
+                ].join(' ')}
+              >
+                <span>{day.getDate()}</span>
+                <span
+                  className={[
+                    'mt-0.5 h-1 w-1 rounded-full',
+                    hasNote
+                      ? isToday ? 'bg-accent' : 'bg-ink-400'
+                      : 'invisible',
+                  ].join(' ')}
+                />
+              </button>
+            )
+          })
+
+          return [weekCell, ...dayCells]
+        })}
+      </div>
+    </div>
+  )
+}

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -213,6 +213,8 @@ export function SettingsModal(): JSX.Element {
   const setRipgrepBinaryPath = useStore((s) => s.setRipgrepBinaryPath)
   const fzfBinaryPath = useStore((s) => s.fzfBinaryPath)
   const setFzfBinaryPath = useStore((s) => s.setFzfBinaryPath)
+  const calendarEnabled = useStore((s) => s.calendarEnabled)
+  const setCalendarEnabled = useStore((s) => s.setCalendarEnabled)
   const livePreview = useStore((s) => s.livePreview)
   const setLivePreview = useStore((s) => s.setLivePreview)
   const tabsEnabled = useStore((s) => s.tabsEnabled)
@@ -1379,6 +1381,12 @@ export function SettingsModal(): JSX.Element {
           keywords: ['weekly notes', 'this week']
         },
         {
+          id: 'calendar-enabled',
+          title: 'Enable calendar',
+          description: 'Shows a month grid in the sidebar for navigating daily and weekly notes.',
+          keywords: ['calendar', 'sidebar', 'daily notes', 'weekly notes']
+        },
+        {
           id: 'inbox-label',
           title: 'Inbox label',
           description: 'Shown in the sidebar, breadcrumbs, commands, and note actions.',
@@ -1713,6 +1721,19 @@ export function SettingsModal(): JSX.Element {
                 Open this week
               </button>
             </div>
+          </Section>
+
+          <Section
+            title="Calendar"
+            description="A calendar panel in the sidebar for navigating daily and weekly notes."
+          >
+            <ToggleRow
+              label="Enable calendar"
+              description="Shows a month grid in the sidebar for navigating daily and weekly notes."
+              value={calendarEnabled}
+              settingId="calendar-enabled"
+              onChange={setCalendarEnabled}
+            />
           </Section>
 
           <Section

--- a/packages/app-core/src/components/Sidebar.tsx
+++ b/packages/app-core/src/components/Sidebar.tsx
@@ -38,6 +38,7 @@ import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { ResizeHandle } from "./ResizeHandle";
 import { VaultBadge } from "./VaultBadge";
 import { confirmApp } from '../lib/confirm-requests'
+import { DailyNotesCalendar } from './DailyNotesCalendar'
 import { promptApp } from '../lib/prompt-requests'
 import { resolveQuickNoteTitle } from "../lib/quick-note-title";
 import { recordRendererPerf } from "../lib/perf";
@@ -378,6 +379,10 @@ export function Sidebar(): JSX.Element {
   const deleteTag = useStore((s) => s.deleteTag);
   const tagsCollapsed = useStore((s) => s.tagsCollapsed);
   const setTagsCollapsed = useStore((s) => s.setTagsCollapsed);
+  const calendarCollapsed = useStore((s) => s.calendarCollapsed);
+  const setCalendarCollapsed = useStore((s) => s.setCalendarCollapsed);
+  const { dailyNotes, weeklyNotes } = normalizeVaultSettings(vaultSettings);
+  const calendarVisible = dailyNotes.enabled || weeklyNotes.enabled;
   const showSidebarChevrons = useStore((s) => s.showSidebarChevrons);
   const createFolderAction = useStore((s) => s.createFolder);
   const renameFolderAction = useStore((s) => s.renameFolder);
@@ -2739,6 +2744,33 @@ export function Sidebar(): JSX.Element {
               groupByKind={groupByKind}
               showSidebarChevrons={showSidebarChevrons}
             />
+          )}
+
+          {/* Daily Notes Calendar */}
+          {calendarVisible && (
+            <div className="mt-5">
+              <button
+                type="button"
+                onClick={() => setCalendarCollapsed(!calendarCollapsed)}
+                title={calendarCollapsed ? "Show calendar" : "Hide calendar"}
+                aria-expanded={!calendarCollapsed}
+                className="flex w-full items-center gap-1 rounded px-2 pb-2 text-[11px] font-medium uppercase tracking-wide text-ink-500 transition-colors hover:text-ink-800"
+              >
+                {showSidebarChevrons && (
+                  <span
+                    aria-hidden
+                    className="inline-block transition-transform"
+                    style={{
+                      transform: calendarCollapsed ? "rotate(-90deg)" : "rotate(0deg)",
+                    }}
+                  >
+                    ▾
+                  </span>
+                )}
+                <span>Calendar</span>
+              </button>
+              {!calendarCollapsed && <DailyNotesCalendar />}
+            </div>
           )}
 
           {/* Tag pills */}

--- a/packages/app-core/src/components/Sidebar.tsx
+++ b/packages/app-core/src/components/Sidebar.tsx
@@ -381,8 +381,9 @@ export function Sidebar(): JSX.Element {
   const setTagsCollapsed = useStore((s) => s.setTagsCollapsed);
   const calendarCollapsed = useStore((s) => s.calendarCollapsed);
   const setCalendarCollapsed = useStore((s) => s.setCalendarCollapsed);
+  const calendarEnabled = useStore((s) => s.calendarEnabled);
   const { dailyNotes, weeklyNotes } = normalizeVaultSettings(vaultSettings);
-  const calendarVisible = dailyNotes.enabled || weeklyNotes.enabled;
+  const calendarVisible = calendarEnabled && (dailyNotes.enabled || weeklyNotes.enabled);
   const showSidebarChevrons = useStore((s) => s.showSidebarChevrons);
   const createFolderAction = useStore((s) => s.createFolder);
   const renameFolderAction = useStore((s) => s.renameFolder);

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -331,6 +331,8 @@ interface Prefs {
   tagsCollapsed: boolean
   /** Sidebar Calendar section collapsed. Persisted. */
   calendarCollapsed: boolean
+  /** Show the calendar panel in the sidebar. Persisted. */
+  calendarEnabled: boolean
   /** Last selected view inside the Tasks tab. List is the v1 default. */
   tasksViewMode: TasksViewMode
   /** Column source used when the Tasks Kanban view is active. */
@@ -427,6 +429,7 @@ const DEFAULT_PREFS: Prefs = {
   contentAlign: 'center',
   tagsCollapsed: false,
   calendarCollapsed: false,
+  calendarEnabled: true,
   tasksViewMode: 'list',
   kanbanGroupBy: 'status',
   kanbanColumnTitles: {},
@@ -613,6 +616,8 @@ function normalizePrefs(p: Partial<Prefs>): Prefs {
       typeof p.calendarCollapsed === 'boolean'
         ? p.calendarCollapsed
         : DEFAULT_PREFS.calendarCollapsed,
+    calendarEnabled:
+      typeof p.calendarEnabled === 'boolean' ? p.calendarEnabled : DEFAULT_PREFS.calendarEnabled,
     tasksViewMode:
       p.tasksViewMode && VALID_TASKS_VIEW_MODES.includes(p.tasksViewMode)
         ? p.tasksViewMode
@@ -1030,6 +1035,7 @@ function collectPrefs(s: {
   contentAlign: 'center' | 'left'
   tagsCollapsed: boolean
   calendarCollapsed: boolean
+  calendarEnabled: boolean
   tasksViewMode: TasksViewMode
   kanbanGroupBy: KanbanGroupBy
   kanbanColumnTitles: Record<string, string>
@@ -1083,6 +1089,7 @@ function collectPrefs(s: {
     contentAlign: s.contentAlign,
     tagsCollapsed: s.tagsCollapsed,
     calendarCollapsed: s.calendarCollapsed,
+    calendarEnabled: s.calendarEnabled,
     tasksViewMode: s.tasksViewMode,
     kanbanGroupBy: s.kanbanGroupBy,
     kanbanColumnTitles: s.kanbanColumnTitles,
@@ -1464,6 +1471,8 @@ interface Store {
   tagsCollapsed: boolean
   /** Sidebar Calendar section collapsed. Persisted. */
   calendarCollapsed: boolean
+  /** Show the calendar panel in the sidebar. Persisted. */
+  calendarEnabled: boolean
 
   /** Vault-wide Tasks view state. Populated lazily when the view is opened
    *  and kept incrementally fresh via the chokidar watcher while the view
@@ -1716,6 +1725,7 @@ interface Store {
   setContentAlign: (align: 'center' | 'left') => void
   setTagsCollapsed: (collapsed: boolean) => void
   setCalendarCollapsed: (collapsed: boolean) => void
+  setCalendarEnabled: (enabled: boolean) => void
   openDailyNoteForDate: (date: Date) => Promise<void>
   openWeeklyNoteForDate: (date: Date) => Promise<void>
   /** Mark the first-run onboarding as complete (or skipped). Persists. */
@@ -2553,6 +2563,7 @@ export const useStore = create<Store>((set, get) => {
   contentAlign: loadPrefs().contentAlign,
   tagsCollapsed: loadPrefs().tagsCollapsed,
   calendarCollapsed: loadPrefs().calendarCollapsed,
+  calendarEnabled: loadPrefs().calendarEnabled,
   tasksViewMode: loadPrefs().tasksViewMode,
   kanbanGroupBy: loadPrefs().kanbanGroupBy,
   kanbanColumnTitles: loadPrefs().kanbanColumnTitles,
@@ -4238,6 +4249,10 @@ export const useStore = create<Store>((set, get) => {
   },
   setCalendarCollapsed: (collapsed) => {
     set({ calendarCollapsed: collapsed })
+    savePrefs(collectPrefs(get()))
+  },
+  setCalendarEnabled: (enabled) => {
+    set({ calendarEnabled: enabled })
     savePrefs(collectPrefs(get()))
   },
   completeOnboarding: () => {

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -329,6 +329,8 @@ interface Prefs {
   /** Sidebar Tags section collapsed — keeps the tag pills hidden
    *  without removing the section entirely. */
   tagsCollapsed: boolean
+  /** Sidebar Calendar section collapsed. Persisted. */
+  calendarCollapsed: boolean
   /** Last selected view inside the Tasks tab. List is the v1 default. */
   tasksViewMode: TasksViewMode
   /** Column source used when the Tasks Kanban view is active. */
@@ -424,6 +426,7 @@ const DEFAULT_PREFS: Prefs = {
   noteRefs: {},
   contentAlign: 'center',
   tagsCollapsed: false,
+  calendarCollapsed: false,
   tasksViewMode: 'list',
   kanbanGroupBy: 'status',
   kanbanColumnTitles: {},
@@ -606,6 +609,10 @@ function normalizePrefs(p: Partial<Prefs>): Prefs {
         : DEFAULT_PREFS.contentAlign,
     tagsCollapsed:
       typeof p.tagsCollapsed === 'boolean' ? p.tagsCollapsed : DEFAULT_PREFS.tagsCollapsed,
+    calendarCollapsed:
+      typeof p.calendarCollapsed === 'boolean'
+        ? p.calendarCollapsed
+        : DEFAULT_PREFS.calendarCollapsed,
     tasksViewMode:
       p.tasksViewMode && VALID_TASKS_VIEW_MODES.includes(p.tasksViewMode)
         ? p.tasksViewMode
@@ -1022,6 +1029,7 @@ function collectPrefs(s: {
   noteRefs: Record<string, { path: string; kind: 'note' | 'asset' }>
   contentAlign: 'center' | 'left'
   tagsCollapsed: boolean
+  calendarCollapsed: boolean
   tasksViewMode: TasksViewMode
   kanbanGroupBy: KanbanGroupBy
   kanbanColumnTitles: Record<string, string>
@@ -1074,6 +1082,7 @@ function collectPrefs(s: {
     noteRefs: s.noteRefs,
     contentAlign: s.contentAlign,
     tagsCollapsed: s.tagsCollapsed,
+    calendarCollapsed: s.calendarCollapsed,
     tasksViewMode: s.tasksViewMode,
     kanbanGroupBy: s.kanbanGroupBy,
     kanbanColumnTitles: s.kanbanColumnTitles,
@@ -1453,6 +1462,8 @@ interface Store {
   /** Sidebar Tags section collapsed — hides the pill rail but keeps
    *  the section header visible as a toggle. Persisted. */
   tagsCollapsed: boolean
+  /** Sidebar Calendar section collapsed. Persisted. */
+  calendarCollapsed: boolean
 
   /** Vault-wide Tasks view state. Populated lazily when the view is opened
    *  and kept incrementally fresh via the chokidar watcher while the view
@@ -1704,6 +1715,9 @@ interface Store {
   setPdfEmbedInEditMode: (mode: 'compact' | 'full') => void
   setContentAlign: (align: 'center' | 'left') => void
   setTagsCollapsed: (collapsed: boolean) => void
+  setCalendarCollapsed: (collapsed: boolean) => void
+  openDailyNoteForDate: (date: Date) => Promise<void>
+  openWeeklyNoteForDate: (date: Date) => Promise<void>
   /** Mark the first-run onboarding as complete (or skipped). Persists. */
   completeOnboarding: () => void
   /** Re-open the first-run onboarding wizard. Persists. */
@@ -2538,6 +2552,7 @@ export const useStore = create<Store>((set, get) => {
   noteRefs: loadPrefs().noteRefs,
   contentAlign: loadPrefs().contentAlign,
   tagsCollapsed: loadPrefs().tagsCollapsed,
+  calendarCollapsed: loadPrefs().calendarCollapsed,
   tasksViewMode: loadPrefs().tasksViewMode,
   kanbanGroupBy: loadPrefs().kanbanGroupBy,
   kanbanColumnTitles: loadPrefs().kanbanColumnTitles,
@@ -4003,11 +4018,11 @@ export const useStore = create<Store>((set, get) => {
     savePrefs(collectPrefs(get()))
   },
 
-  openTodayDailyNote: async () => {
+  openDailyNoteForDate: async (date) => {
     const state = get()
     const settings = normalizeVaultSettings(state.vaultSettings)
     if (!settings.dailyNotes.enabled) return
-    const title = noteTitleForDate()
+    const title = noteTitleForDate(date)
     const subpath = normalizeDailyNotesDirectory(settings.dailyNotes.directory)
     const existing = state.notes.find(
       (note) =>
@@ -4028,11 +4043,15 @@ export const useStore = create<Store>((set, get) => {
     await get().createAndOpen('inbox', subpath, { title })
   },
 
-  openThisWeekWeeklyNote: async () => {
+  openTodayDailyNote: async () => {
+    await get().openDailyNoteForDate(new Date())
+  },
+
+  openWeeklyNoteForDate: async (date) => {
     const state = get()
     const settings = normalizeVaultSettings(state.vaultSettings)
     if (!settings.weeklyNotes.enabled) return
-    const title = weeklyNoteTitle()
+    const title = weeklyNoteTitle(date)
     const subpath = normalizeWeeklyNotesDirectory(settings.weeklyNotes.directory)
     const existing = state.notes.find(
       (note) =>
@@ -4051,6 +4070,10 @@ export const useStore = create<Store>((set, get) => {
       return
     }
     await get().createAndOpen('inbox', subpath, { title })
+  },
+
+  openThisWeekWeeklyNote: async () => {
+    await get().openWeeklyNoteForDate(new Date())
   },
 
   setTemplatePaletteOpen: (open) =>
@@ -4211,6 +4234,10 @@ export const useStore = create<Store>((set, get) => {
   },
   setTagsCollapsed: (collapsed) => {
     set({ tagsCollapsed: collapsed })
+    savePrefs(collectPrefs(get()))
+  },
+  setCalendarCollapsed: (collapsed) => {
+    set({ calendarCollapsed: collapsed })
     savePrefs(collectPrefs(get()))
   },
   completeOnboarding: () => {


### PR DESCRIPTION
Adds a collapsible calendar panel to the sidebar for navigating daily and weekly notes. Clicking a day opens or creates the daily note for that date; clicking a week number does the same for weekly notes. The panel only appears when daily or weekly notes are enabled, and can be turned off in Settings -> Calendar.

Ref #63 