### PR TITLE
feat(databases): CSV-backed databases — Table + Board, record pages, vim grid

### DIFF
--- a/apps/desktop/src/main/database-domain.test.ts
+++ b/apps/desktop/src/main/database-domain.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseCsv,
+  serializeCsv,
+  parseRows,
+  serializeRows,
+  inferFields,
+  buildDefaultViews,
+  type GenId
+} from '@shared/database-csv'
+import {
+  filterRows,
+  sortRows,
+  boardColumns,
+  splitMultiSelect,
+  joinMultiSelect
+} from '@shared/database-transforms'
+import { EMPTY_GROUP, type DbField, type DbRow } from '@shared/databases'
+
+/** Deterministic id factory for tests. */
+function counterGenId(): GenId {
+  let n = 0
+  return () => `id-${++n}`
+}
+
+const fieldsById = (fields: DbField[]): Map<string, DbField> =>
+  new Map(fields.map((f) => [f.id, f]))
+
+describe('parseCsv / serializeCsv round-trip', () => {
+  it('round-trips embedded commas, quotes, and newlines', () => {
+    const grid = [
+      ['id', 'name', 'note'],
+      ['1', 'a,b', 'he said "hi"'],
+      ['2', 'line1\nline2', 'plain'],
+      ['3', '', 'trailing space ']
+    ]
+    expect(parseCsv(serializeCsv(grid))).toEqual(grid)
+  })
+
+  it('parses CRLF and a leading BOM, drops blank lines', () => {
+    const text = '﻿id,name\r\n1,Alpha\r\n\r\n2,Beta\r\n'
+    expect(parseCsv(text)).toEqual([
+      ['id', 'name'],
+      ['1', 'Alpha'],
+      ['2', 'Beta']
+    ])
+  })
+
+  it('preserves empty trailing cells and a no-trailing-newline last row', () => {
+    expect(parseCsv('a,')).toEqual([['a', '']])
+    expect(parseCsv('a,b\nc,d')).toEqual([
+      ['a', 'b'],
+      ['c', 'd']
+    ])
+  })
+
+  it('round-trips a cell that is a single double-quote', () => {
+    const grid = [['x'], ['"']]
+    expect(parseCsv(serializeCsv(grid))).toEqual(grid)
+  })
+})
+
+describe('parseRows / serializeRows', () => {
+  const fields: DbField[] = [
+    { id: 'fid', name: 'id', type: 'text', hidden: true },
+    { id: 'fname', name: 'Name', type: 'text' },
+    { id: 'fdone', name: 'Done', type: 'checkbox' }
+  ]
+
+  it('keys cells by field id and round-trips', () => {
+    const csv = serializeCsv([
+      ['id', 'Name', 'Done'],
+      ['u1', 'Task A', 'true'],
+      ['u2', 'Task, B', 'false']
+    ])
+    const rows = parseRows(csv, fields, 'fid')
+    expect(rows).toEqual([
+      { id: 'u1', cells: { fid: 'u1', fname: 'Task A', fdone: 'true' } },
+      { id: 'u2', cells: { fid: 'u2', fname: 'Task, B', fdone: 'false' } }
+    ])
+    expect(serializeRows(rows, fields)).toEqual(csv)
+  })
+
+  it('synthesizes ids for rows missing one', () => {
+    const csv = 'id,Name,Done\n,No Id,true\n'
+    const rows = parseRows(csv, fields, 'fid', counterGenId())
+    expect(rows[0].id).toBe('id-1')
+    expect(rows[0].cells.fid).toBe('id-1')
+  })
+
+  it('matches columns by header name regardless of order', () => {
+    const csv = 'Name,Done,id\nReordered,true,u9\n'
+    const rows = parseRows(csv, fields, 'fid')
+    expect(rows[0]).toEqual({ id: 'u9', cells: { fid: 'u9', fname: 'Reordered', fdone: 'true' } })
+  })
+})
+
+describe('inferFields', () => {
+  it('infers number, checkbox, date, and text columns', () => {
+    const { fields, idFieldId } = inferFields(
+      ['id', 'Count', 'Done', 'Due', 'Title'],
+      [
+        ['1', '10', 'true', '2026-01-01', 'hello'],
+        ['2', '20', 'false', '2026-02-15', 'world']
+      ],
+      counterGenId()
+    )
+    const byName = new Map(fields.map((f) => [f.name, f]))
+    expect(byName.get('Count')!.type).toBe('number')
+    expect(byName.get('Done')!.type).toBe('checkbox')
+    expect(byName.get('Due')!.type).toBe('date')
+    expect(byName.get('Title')!.type).toBe('text')
+    // existing unique id column is used + hidden
+    expect(byName.get('id')!.id).toBe(idFieldId)
+    expect(byName.get('id')!.hidden).toBe(true)
+  })
+
+  it('synthesizes a leading id field when no id column exists', () => {
+    const { fields, idFieldId } = inferFields(['Name'], [['a'], ['b']], counterGenId())
+    expect(fields[0].name).toBe('id')
+    expect(fields[0].id).toBe(idFieldId)
+    expect(fields[0].hidden).toBe(true)
+    expect(fields).toHaveLength(2)
+  })
+
+  it('dedupes blank and duplicate headers', () => {
+    const { fields } = inferFields(['', 'Name', 'Name'], [], counterGenId())
+    const names = fields.map((f) => f.name)
+    // includes synthesized id + Column 1 + Name + Name (2)
+    expect(names).toContain('Column 1')
+    expect(names.filter((n) => n.startsWith('Name'))).toEqual(['Name', 'Name (2)'])
+  })
+
+  it('buildDefaultViews creates one table view with the id field hidden', () => {
+    const { fields, idFieldId } = inferFields(['id', 'Name'], [['1', 'a']], counterGenId())
+    const { views, activeViewId } = buildDefaultViews(fields, counterGenId())
+    expect(views).toHaveLength(1)
+    expect(views[0].type).toBe('table')
+    expect(views[0].id).toBe(activeViewId)
+    expect(views[0].hiddenFieldIds).toContain(idFieldId)
+    expect(views[0].columnOrder).toEqual(fields.map((f) => f.id))
+  })
+})
+
+describe('transforms', () => {
+  const fields: DbField[] = [
+    { id: 'name', name: 'Name', type: 'text' },
+    { id: 'count', name: 'Count', type: 'number' },
+    { id: 'due', name: 'Due', type: 'date' },
+    { id: 'status', name: 'Status', type: 'select' }
+  ]
+  const map = fieldsById(fields)
+  const rows: DbRow[] = [
+    { id: '1', cells: { name: 'Beta', count: '2', due: '2026-03-01', status: 'todo' } },
+    { id: '2', cells: { name: 'Alpha', count: '10', due: '2026-01-15', status: 'done' } },
+    { id: '3', cells: { name: 'Gamma', count: '1', due: '', status: '' } }
+  ]
+
+  it('sorts numerically, not lexically', () => {
+    const sorted = sortRows(rows, [{ fieldId: 'count', direction: 'asc' }], map)
+    expect(sorted.map((r) => r.cells.count)).toEqual(['1', '2', '10'])
+  })
+
+  it('sorts dates chronologically and pushes empty values last', () => {
+    const sorted = sortRows(rows, [{ fieldId: 'due', direction: 'asc' }], map)
+    expect(sorted.map((r) => r.id)).toEqual(['2', '1', '3'])
+  })
+
+  it('filters by contains and is', () => {
+    expect(filterRows(rows, [{ fieldId: 'name', op: 'contains', value: 'a' }], map).map((r) => r.id)).toEqual([
+      '1',
+      '2',
+      '3'
+    ])
+    expect(filterRows(rows, [{ fieldId: 'status', op: 'is', value: 'done' }], map).map((r) => r.id)).toEqual([
+      '2'
+    ])
+    expect(filterRows(rows, [{ fieldId: 'due', op: 'isEmpty' }], map).map((r) => r.id)).toEqual(['3'])
+  })
+
+  it('groups into board columns with an EMPTY_GROUP bucket', () => {
+    const cols = boardColumns(rows, fields[3], ['todo', 'done'])
+    expect(cols.map((c) => c.key)).toEqual(['todo', 'done', EMPTY_GROUP])
+    expect(cols[0].rows.map((r) => r.id)).toEqual(['1'])
+    expect(cols[1].rows.map((r) => r.id)).toEqual(['2'])
+    expect(cols[2].rows.map((r) => r.id)).toEqual(['3'])
+  })
+
+  it('splits and joins multiSelect cells', () => {
+    expect(splitMultiSelect('a, b ,c')).toEqual(['a', 'b', 'c'])
+    expect(joinMultiSelect(['a', 'b'])).toBe('a, b')
+    expect(splitMultiSelect('')).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/databases.test.ts
+++ b/apps/desktop/src/main/databases.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createDatabase, readDatabase, writeDatabaseRows } from './databases'
+
+const tmpDirs: string[] = []
+async function makeVault(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'zennotes-db-'))
+  tmpDirs.push(dir)
+  await mkdir(path.join(dir, 'inbox'), { recursive: true })
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })))
+})
+
+describe('createDatabase + readDatabase', () => {
+  it('creates a .csv + sidecar and reads it back', async () => {
+    const root = await makeVault()
+    const doc = await createDatabase(root, 'inbox', 'Projects')
+    expect(doc.path).toBe('inbox/Projects.csv')
+    expect(doc.title).toBe('Projects')
+    expect(doc.fields.map((f) => f.name)).toEqual(['id', 'Name'])
+    expect(doc.rows).toEqual([])
+    expect(doc.views).toHaveLength(1)
+
+    // both files exist on disk
+    await expect(readFile(path.join(root, 'inbox/Projects.csv'), 'utf8')).resolves.toContain('id,Name')
+    const sidecar = JSON.parse(
+      await readFile(path.join(root, 'inbox/Projects.csv.base.json'), 'utf8')
+    )
+    expect(sidecar.version).toBe(1)
+    expect(sidecar.fields).toHaveLength(2)
+
+    // re-open yields the same shape
+    const reopened = await readDatabase(root, 'inbox/Projects.csv')
+    expect(reopened.idFieldId).toBe(doc.idFieldId)
+  })
+
+  it('avoids filename collisions', async () => {
+    const root = await makeVault()
+    const a = await createDatabase(root, 'inbox', 'Notes')
+    const b = await createDatabase(root, 'inbox', 'Notes')
+    expect(a.path).not.toBe(b.path)
+  })
+})
+
+describe('writeDatabaseRows round-trip', () => {
+  it('persists rows (incl. embedded commas) and reads them back', async () => {
+    const root = await makeVault()
+    const doc = await createDatabase(root, 'inbox', 'Tasks')
+    const idField = doc.fields.find((f) => f.id === doc.idFieldId)!
+    const nameField = doc.fields.find((f) => f.name === 'Name')!
+
+    const written = await writeDatabaseRows(root, doc.path, [
+      { id: 'r1', cells: { [idField.id]: 'r1', [nameField.id]: 'Alpha, with comma' } },
+      { id: 'r2', cells: { [idField.id]: 'r2', [nameField.id]: 'Beta' } }
+    ])
+    expect(written.rows).toHaveLength(2)
+
+    const reread = await readDatabase(root, doc.path)
+    expect(reread.rows.map((r) => r.cells[nameField.id])).toEqual(['Alpha, with comma', 'Beta'])
+    expect(reread.rows.map((r) => r.id)).toEqual(['r1', 'r2'])
+  })
+})
+
+describe('adopting a plain CSV (no sidecar)', () => {
+  it('infers schema, materializes the sidecar + stable ids, and is stable on re-read', async () => {
+    const root = await makeVault()
+    await writeFile(
+      path.join(root, 'inbox/people.csv'),
+      'Name,Age,Active\nAda,36,true\nGrace,40,false\n',
+      'utf8'
+    )
+
+    const doc = await readDatabase(root, 'inbox/people.csv')
+    const byName = new Map(doc.fields.map((f) => [f.name, f]))
+    expect(byName.get('Age')!.type).toBe('number')
+    expect(byName.get('Active')!.type).toBe('checkbox')
+    expect(doc.rows).toHaveLength(2)
+
+    // sidecar was materialized
+    await expect(
+      readFile(path.join(root, 'inbox/people.csv.base.json'), 'utf8')
+    ).resolves.toContain('"version": 1')
+
+    // ids are stable across re-read (the CSV gained an id column)
+    const firstIds = doc.rows.map((r) => r.id)
+    const reread = await readDatabase(root, 'inbox/people.csv')
+    expect(reread.rows.map((r) => r.id)).toEqual(firstIds)
+    expect(firstIds.every((id) => id.length > 0)).toBe(true)
+  })
+})

--- a/apps/desktop/src/main/databases.test.ts
+++ b/apps/desktop/src/main/databases.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { createDatabase, readDatabase, writeDatabaseRows } from './databases'
+import { createDatabase, createRecordPage, readDatabase, writeDatabaseRows } from './databases'
 
 const tmpDirs: string[] = []
 async function makeVault(): Promise<string> {
@@ -19,30 +19,30 @@ afterEach(async () => {
 describe('createDatabase + readDatabase', () => {
   it('creates a .csv + sidecar and reads it back', async () => {
     const root = await makeVault()
-    const doc = await createDatabase(root, 'inbox', 'Projects')
-    expect(doc.path).toBe('inbox/Projects.csv')
+    const doc = await createDatabase(root, 'inbox', '', 'Projects')
+    expect(doc.path.endsWith('Projects.csv')).toBe(true)
     expect(doc.title).toBe('Projects')
     expect(doc.fields.map((f) => f.name)).toEqual(['id', 'Name'])
     expect(doc.rows).toEqual([])
     expect(doc.views).toHaveLength(1)
 
     // both files exist on disk
-    await expect(readFile(path.join(root, 'inbox/Projects.csv'), 'utf8')).resolves.toContain('id,Name')
+    await expect(readFile(path.join(root, doc.path), 'utf8')).resolves.toContain('id,Name')
     const sidecar = JSON.parse(
-      await readFile(path.join(root, 'inbox/Projects.csv.base.json'), 'utf8')
+      await readFile(path.join(root, `${doc.path}.base.json`), 'utf8')
     )
     expect(sidecar.version).toBe(1)
     expect(sidecar.fields).toHaveLength(2)
 
     // re-open yields the same shape
-    const reopened = await readDatabase(root, 'inbox/Projects.csv')
+    const reopened = await readDatabase(root, doc.path)
     expect(reopened.idFieldId).toBe(doc.idFieldId)
   })
 
   it('avoids filename collisions', async () => {
     const root = await makeVault()
-    const a = await createDatabase(root, 'inbox', 'Notes')
-    const b = await createDatabase(root, 'inbox', 'Notes')
+    const a = await createDatabase(root, 'inbox', '', 'Notes')
+    const b = await createDatabase(root, 'inbox', '', 'Notes')
     expect(a.path).not.toBe(b.path)
   })
 })
@@ -50,7 +50,7 @@ describe('createDatabase + readDatabase', () => {
 describe('writeDatabaseRows round-trip', () => {
   it('persists rows (incl. embedded commas) and reads them back', async () => {
     const root = await makeVault()
-    const doc = await createDatabase(root, 'inbox', 'Tasks')
+    const doc = await createDatabase(root, 'inbox', '', 'Tasks')
     const idField = doc.fields.find((f) => f.id === doc.idFieldId)!
     const nameField = doc.fields.find((f) => f.name === 'Name')!
 
@@ -63,6 +63,22 @@ describe('writeDatabaseRows round-trip', () => {
     const reread = await readDatabase(root, doc.path)
     expect(reread.rows.map((r) => r.cells[nameField.id])).toEqual(['Alpha, with comma', 'Beta'])
     expect(reread.rows.map((r) => r.id)).toEqual(['r1', 'r2'])
+  })
+})
+
+describe('createRecordPage', () => {
+  it('creates a page note in a per-database folder', async () => {
+    const root = await makeVault()
+    const doc = await createDatabase(root, 'inbox', '', 'Projects')
+    const noteRel = await createRecordPage(
+      root,
+      doc.path,
+      'My Task',
+      '---\nName: My Task\n---\n# My Task\n'
+    )
+    expect(noteRel.endsWith('.md')).toBe(true)
+    expect(noteRel).toContain('Projects/') // pages folder named after the db
+    await expect(readFile(path.join(root, noteRel), 'utf8')).resolves.toContain('# My Task')
   })
 })
 

--- a/apps/desktop/src/main/databases.ts
+++ b/apps/desktop/src/main/databases.ts
@@ -1,0 +1,223 @@
+/**
+ * Main-process IO for CSV-backed databases. Bridges the pure shared-domain
+ * logic (@shared/database-csv) to disk, mirroring the comments/tasks helpers:
+ * read/write the `.csv` + co-located `.csv.base.json` sidecar with the atomic
+ * writer, and adopt a plain CSV (no sidecar) by inferring its schema.
+ */
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import {
+  inferFields,
+  buildDefaultViews,
+  parseCsv,
+  parseRows,
+  serializeRows
+} from '@shared/database-csv'
+import {
+  DATABASE_SIDECAR_SUFFIX,
+  type DatabaseDoc,
+  type DatabaseSidecar,
+  type DatabaseSummary,
+  type DbField,
+  type DbRow,
+  type DbView
+} from '@shared/databases'
+import { databaseDataPath, databaseSidecarPath, writeFileAtomic } from './vault'
+
+const SCHEMA_SAMPLE_ROWS = 50
+
+function toPosix(p: string): string {
+  return p.replace(/\\/g, '/')
+}
+
+function titleFromPath(rel: string): string {
+  const base = toPosix(rel).split('/').filter(Boolean).pop() ?? rel
+  return base.replace(/\.csv$/i, '')
+}
+
+function isMissing(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException)?.code === 'ENOENT'
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar (schema + views)
+// ---------------------------------------------------------------------------
+
+/** Defensive parse of a sidecar JSON; returns null when missing or unusable. */
+function normalizeSidecar(raw: unknown): DatabaseSidecar | null {
+  if (!raw || typeof raw !== 'object') return null
+  const obj = raw as Record<string, unknown>
+  const fields = Array.isArray(obj.fields) ? (obj.fields as DbField[]) : null
+  if (!fields || fields.length === 0) return null
+  if (!fields.every((f) => f && typeof f.id === 'string' && typeof f.name === 'string')) return null
+  const fieldIds = new Set(fields.map((f) => f.id))
+  const idFieldId = typeof obj.idFieldId === 'string' && fieldIds.has(obj.idFieldId)
+    ? obj.idFieldId
+    : fields[0].id
+  let views = Array.isArray(obj.views) ? (obj.views as DbView[]) : []
+  views = views.filter((v) => v && typeof v.id === 'string' && (v.type === 'table' || v.type === 'board'))
+  if (views.length === 0) views = buildDefaultViews(fields).views
+  const activeViewId =
+    typeof obj.activeViewId === 'string' && views.some((v) => v.id === obj.activeViewId)
+      ? obj.activeViewId
+      : views[0].id
+  return { version: 1, idFieldId, fields, views, activeViewId }
+}
+
+async function readSidecar(root: string, rel: string): Promise<DatabaseSidecar | null> {
+  try {
+    const raw = await fs.readFile(databaseSidecarPath(root, rel), 'utf8')
+    return normalizeSidecar(JSON.parse(raw))
+  } catch (err) {
+    if (isMissing(err)) return null
+    if (err instanceof SyntaxError) return null
+    throw err
+  }
+}
+
+function hydrate(rel: string, sidecar: DatabaseSidecar, rows: DbRow[]): DatabaseDoc {
+  return {
+    ...sidecar,
+    path: toPosix(rel),
+    title: titleFromPath(rel),
+    rows
+  }
+}
+
+async function persistSidecar(root: string, rel: string, sidecar: DatabaseSidecar): Promise<void> {
+  await writeFileAtomic(databaseSidecarPath(root, rel), `${JSON.stringify(sidecar, null, 2)}\n`)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a database. If no sidecar exists, infer the schema from the CSV and
+ * adopt it: write the sidecar and re-materialize the CSV so every row gains a
+ * stable `id` (one-time migration when opening a plain CSV as a database).
+ */
+export async function readDatabase(root: string, rel: string): Promise<DatabaseDoc> {
+  const csvAbs = databaseDataPath(root, rel)
+  let csvText: string
+  try {
+    csvText = await fs.readFile(csvAbs, 'utf8')
+  } catch (err) {
+    if (isMissing(err)) throw new Error(`Database not found: ${rel}`)
+    throw err
+  }
+
+  const existing = await readSidecar(root, rel)
+  if (existing) {
+    const rows = parseRows(csvText, existing.fields, existing.idFieldId, randomUUID)
+    return hydrate(rel, existing, rows)
+  }
+
+  // Adopt a plain CSV: infer + materialize.
+  const grid = parseCsv(csvText)
+  const headers = grid[0] ?? []
+  const { fields, idFieldId } = inferFields(headers, grid.slice(1, 1 + SCHEMA_SAMPLE_ROWS), randomUUID)
+  const { views, activeViewId } = buildDefaultViews(fields, randomUUID)
+  const sidecar: DatabaseSidecar = { version: 1, idFieldId, fields, views, activeViewId }
+  const rows = parseRows(csvText, fields, idFieldId, randomUUID)
+  await persistSidecar(root, rel, sidecar)
+  await writeFileAtomic(csvAbs, serializeRows(rows, fields)) // canonicalize + persist ids
+  return hydrate(rel, sidecar, rows)
+}
+
+/** Persist rows to the CSV (schema/header come from the sidecar). */
+export async function writeDatabaseRows(
+  root: string,
+  rel: string,
+  rows: DbRow[]
+): Promise<DatabaseDoc> {
+  const sidecar = await readSidecar(root, rel)
+  if (!sidecar) throw new Error(`Database sidecar missing: ${rel}`)
+  await writeFileAtomic(databaseDataPath(root, rel), serializeRows(rows, sidecar.fields))
+  return hydrate(rel, sidecar, rows.map((r) => ({ ...r })))
+}
+
+/**
+ * Persist schema + views to the sidecar AND rewrite the CSV under the new
+ * header. The caller passes the authoritative in-memory rows (keyed by stable
+ * `field.id`), so field renames/reorders/adds/deletes never lose data — unlike
+ * re-reading the on-disk CSV, whose header may no longer match a renamed field.
+ */
+export async function writeDatabaseSchema(
+  root: string,
+  rel: string,
+  sidecar: DatabaseSidecar,
+  rows: DbRow[]
+): Promise<DatabaseDoc> {
+  const normalized = normalizeSidecar(sidecar)
+  if (!normalized) throw new Error(`Invalid database schema: ${rel}`)
+  await persistSidecar(root, rel, normalized)
+  await writeFileAtomic(databaseDataPath(root, rel), serializeRows(rows, normalized.fields))
+  return hydrate(rel, normalized, rows.map((r) => ({ ...r })))
+}
+
+/** Create a new empty database (`id` + `Name` fields) and return it hydrated. */
+export async function createDatabase(
+  root: string,
+  folder: string,
+  title?: string
+): Promise<DatabaseDoc> {
+  const safeTitle = (title ?? 'Untitled Database').trim() || 'Untitled Database'
+  const baseName = safeTitle.replace(/[\\/:*?"<>|]/g, '-')
+  // Resolve a non-colliding path under the folder.
+  let rel = `${folder}/${baseName}.csv`
+  let n = 2
+  for (;;) {
+    try {
+      await fs.access(databaseDataPath(root, rel))
+      rel = `${folder}/${baseName} ${n++}.csv`
+    } catch {
+      break
+    }
+  }
+
+  const idField: DbField = { id: randomUUID(), name: 'id', type: 'text', hidden: true }
+  const nameField: DbField = { id: randomUUID(), name: 'Name', type: 'text' }
+  const fields = [idField, nameField]
+  const { views, activeViewId } = buildDefaultViews(fields)
+  const sidecar: DatabaseSidecar = {
+    version: 1,
+    idFieldId: idField.id,
+    fields,
+    views,
+    activeViewId
+  }
+  await persistSidecar(root, rel, sidecar)
+  await writeFileAtomic(databaseDataPath(root, rel), serializeRows([], fields))
+  return hydrate(rel, sidecar, [])
+}
+
+/** List `.csv` databases in the vault (skips sidecars, trash, and `.zennotes`). */
+export async function listDatabases(root: string): Promise<DatabaseSummary[]> {
+  const out: DatabaseSummary[] = []
+  const walk = async (dirRel: string): Promise<void> => {
+    const dirAbs = dirRel ? path.join(root, dirRel) : root
+    let entries: import('node:fs').Dirent[]
+    try {
+      entries = await fs.readdir(dirAbs, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const name = entry.name
+      if (name.startsWith('.') || name === 'trash' || name === 'node_modules') continue
+      const childRel = dirRel ? `${dirRel}/${name}` : name
+      if (entry.isDirectory()) {
+        await walk(childRel)
+      } else if (
+        name.toLowerCase().endsWith('.csv') &&
+        !name.toLowerCase().endsWith(`.csv${DATABASE_SIDECAR_SUFFIX}`)
+      ) {
+        out.push({ path: toPosix(childRel), title: titleFromPath(childRel) })
+      }
+    }
+  }
+  await walk('')
+  return out.sort((a, b) => a.title.localeCompare(b.title))
+}

--- a/apps/desktop/src/main/databases.ts
+++ b/apps/desktop/src/main/databases.ts
@@ -23,7 +23,15 @@ import {
   type DbRow,
   type DbView
 } from '@shared/databases'
-import { databaseDataPath, databaseSidecarPath, writeFileAtomic } from './vault'
+import type { NoteFolder } from '@shared/ipc'
+import {
+  databaseDataPath,
+  databaseSidecarPath,
+  folderRoot,
+  sanitizeNoteTitle,
+  uniqueTitle,
+  writeFileAtomic
+} from './vault'
 
 const SCHEMA_SAMPLE_ROWS = 50
 
@@ -62,7 +70,15 @@ function normalizeSidecar(raw: unknown): DatabaseSidecar | null {
     typeof obj.activeViewId === 'string' && views.some((v) => v.id === obj.activeViewId)
       ? obj.activeViewId
       : views[0].id
-  return { version: 1, idFieldId, fields, views, activeViewId }
+  const pages =
+    obj.pages && typeof obj.pages === 'object'
+      ? (Object.fromEntries(
+          Object.entries(obj.pages as Record<string, unknown>).filter(
+            ([, v]) => typeof v === 'string'
+          )
+        ) as Record<string, string>)
+      : undefined
+  return { version: 1, idFieldId, fields, views, activeViewId, ...(pages ? { pages } : {}) }
 }
 
 async function readSidecar(root: string, rel: string): Promise<DatabaseSidecar | null> {
@@ -76,13 +92,46 @@ async function readSidecar(root: string, rel: string): Promise<DatabaseSidecar |
   }
 }
 
-function hydrate(rel: string, sidecar: DatabaseSidecar, rows: DbRow[]): DatabaseDoc {
+function hydrate(
+  rel: string,
+  sidecar: DatabaseSidecar,
+  rows: DbRow[],
+  pageHasContent?: Record<string, boolean>
+): DatabaseDoc {
   return {
     ...sidecar,
     path: toPosix(rel),
     title: titleFromPath(rel),
-    rows
+    rows,
+    ...(pageHasContent ? { pageHasContent } : {})
   }
+}
+
+/** True if a note has body content beyond its frontmatter + a single title heading. */
+function noteHasBody(text: string): boolean {
+  let body = text
+  const fm = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/.exec(body)
+  if (fm) body = body.slice(fm[0].length)
+  body = body.replace(/^\s*#[^\n]*\r?\n?/, '') // drop a single leading heading
+  return body.trim().length > 0
+}
+
+async function readPageContentFlags(
+  root: string,
+  pages?: Record<string, string>
+): Promise<Record<string, boolean> | undefined> {
+  if (!pages || Object.keys(pages).length === 0) return undefined
+  const flags: Record<string, boolean> = {}
+  await Promise.all(
+    Object.entries(pages).map(async ([rowId, notePath]) => {
+      try {
+        flags[rowId] = noteHasBody(await fs.readFile(databaseDataPath(root, notePath), 'utf8'))
+      } catch {
+        /* missing note → leave unset (treated as empty) */
+      }
+    })
+  )
+  return flags
 }
 
 async function persistSidecar(root: string, rel: string, sidecar: DatabaseSidecar): Promise<void> {
@@ -111,7 +160,8 @@ export async function readDatabase(root: string, rel: string): Promise<DatabaseD
   const existing = await readSidecar(root, rel)
   if (existing) {
     const rows = parseRows(csvText, existing.fields, existing.idFieldId, randomUUID)
-    return hydrate(rel, existing, rows)
+    const pageHasContent = await readPageContentFlags(root, existing.pages)
+    return hydrate(rel, existing, rows, pageHasContent)
   }
 
   // Adopt a plain CSV: infer + materialize.
@@ -157,21 +207,31 @@ export async function writeDatabaseSchema(
   return hydrate(rel, normalized, rows.map((r) => ({ ...r })))
 }
 
-/** Create a new empty database (`id` + `Name` fields) and return it hydrated. */
+/**
+ * Create a new empty database (`id` + `Name` fields) under `folder`/`subpath`
+ * and return it hydrated. Uses `folderRoot` so a root-mode vault creates at the
+ * vault root rather than inventing an `inbox/` directory.
+ */
 export async function createDatabase(
   root: string,
-  folder: string,
+  folder: NoteFolder,
+  subpath: string,
   title?: string
 ): Promise<DatabaseDoc> {
   const safeTitle = (title ?? 'Untitled Database').trim() || 'Untitled Database'
   const baseName = safeTitle.replace(/[\\/:*?"<>|]/g, '-')
-  // Resolve a non-colliding path under the folder.
-  let rel = `${folder}/${baseName}.csv`
+  const topAbs = await folderRoot(root, folder)
+  const cleanSub = toPosix(subpath).replace(/^\/+|\/+$/g, '')
+  const dirAbs = cleanSub ? path.join(topAbs, cleanSub) : topAbs
+  const dirRel = toPosix(path.relative(root, dirAbs))
+  const makeRel = (name: string): string => (dirRel ? `${dirRel}/${name}.csv` : `${name}.csv`)
+  // Resolve a non-colliding path under the directory.
+  let rel = makeRel(baseName)
   let n = 2
   for (;;) {
     try {
       await fs.access(databaseDataPath(root, rel))
-      rel = `${folder}/${baseName} ${n++}.csv`
+      rel = makeRel(`${baseName} ${n++}`)
     } catch {
       break
     }
@@ -191,6 +251,30 @@ export async function createDatabase(
   await persistSidecar(root, rel, sidecar)
   await writeFileAtomic(databaseDataPath(root, rel), serializeRows([], fields))
   return hydrate(rel, sidecar, [])
+}
+
+/**
+ * Create a "page" note for a database record under a per-database folder
+ * (`<db dir>/<DbName>/<title>.md`) with the given pre-composed body, and return
+ * its vault-relative path. The pages folder sits next to the `.csv`.
+ */
+export async function createRecordPage(
+  root: string,
+  csvPath: string,
+  title: string,
+  body: string
+): Promise<string> {
+  const posix = toPosix(csvPath)
+  const slash = posix.lastIndexOf('/')
+  const dbDir = slash >= 0 ? posix.slice(0, slash) : ''
+  const dbName = (slash >= 0 ? posix.slice(slash + 1) : posix).replace(/\.csv$/i, '')
+  const pagesDirRel = dbDir ? `${dbDir}/${dbName}` : dbName
+  const dirAbs = databaseDataPath(root, pagesDirRel) // resolveSafe + posix
+  await fs.mkdir(dirAbs, { recursive: true })
+  const finalTitle = await uniqueTitle(dirAbs, sanitizeNoteTitle(title))
+  const noteRel = `${pagesDirRel}/${finalTitle}.md`
+  await fs.writeFile(databaseDataPath(root, noteRel), body, 'utf8')
+  return noteRel
 }
 
 /** List `.csv` databases in the vault (skips sidecars, trash, and `.zennotes`). */

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -110,6 +110,7 @@ import {
   writeDatabaseRows,
   writeDatabaseSchema,
   createDatabase,
+  createRecordPage,
   listDatabases
 } from './databases'
 import type { DatabaseSidecar, DbRow } from '@shared/databases'
@@ -2191,10 +2192,21 @@ function registerIpc(): void {
     }
   )
 
-  handle(IPC.VAULT_CREATE_DATABASE, async (_e, folder: string, title?: string) => {
-    ensureLocalForDatabases()
-    return await createDatabase(requireVault().root, folder, title)
-  })
+  handle(
+    IPC.VAULT_CREATE_DATABASE,
+    async (_e, folder: NoteFolder, subpath: string, title?: string) => {
+      ensureLocalForDatabases()
+      return await createDatabase(requireVault().root, folder, subpath, title)
+    }
+  )
+
+  handle(
+    IPC.VAULT_CREATE_RECORD_PAGE,
+    async (_e, csvPath: string, title: string, body: string) => {
+      ensureLocalForDatabases()
+      return await createRecordPage(requireVault().root, csvPath, title, body)
+    }
+  )
 
   handle(IPC.VAULT_LIST_DATABASES, async () => {
     ensureLocalForDatabases()

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -105,6 +105,14 @@ import {
   setRemoteWorkspaceSecret
 } from './secret-store'
 import { scanAllTasks, scanTasksForPath } from './tasks'
+import {
+  readDatabase,
+  writeDatabaseRows,
+  writeDatabaseSchema,
+  createDatabase,
+  listDatabases
+} from './databases'
+import type { DatabaseSidecar, DbRow } from '@shared/databases'
 import { VaultWatcher } from './watcher'
 import { WindowVaultRegistry } from './window-vaults'
 import { renderTikz } from './tikz'
@@ -2156,6 +2164,41 @@ function registerIpc(): void {
     }
     const v = requireVault()
     return await scanTasksForPath(v.root, relPath)
+  })
+
+  // Databases are local-vault only for now (no remote-server endpoints yet).
+  const ensureLocalForDatabases = (): void => {
+    if (isRemoteWorkspaceActive()) {
+      throw new Error('Databases are not yet supported on remote vaults')
+    }
+  }
+
+  handle(IPC.VAULT_OPEN_DATABASE, async (_e, relPath: string) => {
+    ensureLocalForDatabases()
+    return await readDatabase(requireVault().root, relPath)
+  })
+
+  handle(IPC.VAULT_WRITE_DATABASE_ROWS, async (_e, relPath: string, rows: DbRow[]) => {
+    ensureLocalForDatabases()
+    return await writeDatabaseRows(requireVault().root, relPath, rows)
+  })
+
+  handle(
+    IPC.VAULT_WRITE_DATABASE_SCHEMA,
+    async (_e, relPath: string, sidecar: DatabaseSidecar, rows: DbRow[]) => {
+      ensureLocalForDatabases()
+      return await writeDatabaseSchema(requireVault().root, relPath, sidecar, rows)
+    }
+  )
+
+  handle(IPC.VAULT_CREATE_DATABASE, async (_e, folder: string, title?: string) => {
+    ensureLocalForDatabases()
+    return await createDatabase(requireVault().root, folder, title)
+  })
+
+  handle(IPC.VAULT_LIST_DATABASES, async () => {
+    ensureLocalForDatabases()
+    return await listDatabases(requireVault().root)
   })
 
   handle(IPC.VAULT_WRITE_NOTE, async (_e, relPath: string, body: string) => {

--- a/apps/desktop/src/main/vault.ts
+++ b/apps/desktop/src/main/vault.ts
@@ -33,6 +33,7 @@ import {
   VaultInfo
 } from '@shared/ipc'
 import { DEMO_TOUR_DIR } from '@shared/demo-tour'
+import { DATABASE_SIDECAR_SUFFIX } from '@shared/databases'
 import { DEMO_TOUR_ASSETS, DEMO_TOUR_NOTES } from './demo-tour-data'
 
 const CONFIG_FILE = 'zennotes.config.json'
@@ -571,6 +572,42 @@ export async function saveConfig(cfg: PersistedConfig): Promise<void> {
   }
 }
 
+/**
+ * Atomically write a file: temp file + fsync + `.bak` of the previous good
+ * copy + rename. Same durability as `saveConfig`, exposed for the databases
+ * feature (CSV + sidecar) where external editors and data loss matter.
+ */
+export async function writeFileAtomic(absPath: string, data: string): Promise<void> {
+  const tmp = `${absPath}.${process.pid}.${Date.now()}.tmp`
+  await fs.mkdir(path.dirname(absPath), { recursive: true })
+  const handle = await fs.open(tmp, 'w')
+  try {
+    await handle.writeFile(data, 'utf8')
+    try {
+      await handle.sync()
+    } catch (syncErr) {
+      console.warn('fsync failed for atomic write', syncErr)
+    }
+  } finally {
+    await handle.close()
+  }
+  try {
+    await fs.copyFile(absPath, `${absPath}.bak`)
+  } catch (err) {
+    if (!isMissingFileError(err)) console.warn('Failed to refresh backup', err)
+  }
+  try {
+    await fs.rename(tmp, absPath)
+  } catch (err) {
+    try {
+      await fs.unlink(tmp)
+    } catch {
+      /* ignore */
+    }
+    throw err
+  }
+}
+
 export async function updateConfig(
   updater: (cfg: PersistedConfig) => PersistedConfig | Promise<PersistedConfig>
 ): Promise<PersistedConfig> {
@@ -621,6 +658,16 @@ function noteCommentsRoot(root: string): string {
 
 function noteCommentsPath(root: string, rel: string): string {
   return resolveSafe(noteCommentsRoot(root), `${toPosix(rel)}${NOTE_COMMENTS_SUFFIX}`)
+}
+
+/** Absolute path of a database's `.csv` data file (a normal vault file). */
+export function databaseDataPath(root: string, rel: string): string {
+  return resolveSafe(root, toPosix(rel))
+}
+
+/** Absolute path of a database's co-located `.csv.base.json` sidecar. */
+export function databaseSidecarPath(root: string, rel: string): string {
+  return resolveSafe(root, `${toPosix(rel)}${DATABASE_SIDECAR_SUFFIX}`)
 }
 
 function cloneVaultSettings(settings: VaultSettings): VaultSettings {

--- a/apps/desktop/src/main/vault.ts
+++ b/apps/desktop/src/main/vault.ts
@@ -573,9 +573,10 @@ export async function saveConfig(cfg: PersistedConfig): Promise<void> {
 }
 
 /**
- * Atomically write a file: temp file + fsync + `.bak` of the previous good
- * copy + rename. Same durability as `saveConfig`, exposed for the databases
- * feature (CSV + sidecar) where external editors and data loss matter.
+ * Atomically write a file: temp file + fsync + rename. The rename is atomic, so
+ * readers never see a half-written file. Exposed for the databases feature
+ * (CSV + sidecar). No `.bak` is left behind — those files live next to the
+ * user's data and are just clutter.
  */
 export async function writeFileAtomic(absPath: string, data: string): Promise<void> {
   const tmp = `${absPath}.${process.pid}.${Date.now()}.tmp`
@@ -590,11 +591,6 @@ export async function writeFileAtomic(absPath: string, data: string): Promise<vo
     }
   } finally {
     await handle.close()
-  }
-  try {
-    await fs.copyFile(absPath, `${absPath}.bak`)
-  } catch (err) {
-    if (!isMissingFileError(err)) console.warn('Failed to refresh backup', err)
   }
   try {
     await fs.rename(tmp, absPath)
@@ -892,7 +888,7 @@ function shouldHidePrimaryRootEntry(name: string): boolean {
   return HIDDEN_PRIMARY_ROOT_NAMES.has(name)
 }
 
-async function folderRoot(root: string, folder: NoteFolder): Promise<string> {
+export async function folderRoot(root: string, folder: NoteFolder): Promise<string> {
   if (folder === 'inbox') return await primaryNotesRoot(root)
   return path.join(root, folder)
 }
@@ -2199,7 +2195,7 @@ export async function appendToNote(
   return await readMeta(root, abs, folder)
 }
 
-async function uniqueTitle(dir: string, baseTitle: string): Promise<string> {
+export async function uniqueTitle(dir: string, baseTitle: string): Promise<string> {
   let candidate = baseTitle
   let n = 1
   while (true) {
@@ -2372,7 +2368,7 @@ function pastedImageBuffer(data: PastedImageInput['data']): Buffer {
  * strip path separators, control chars, and reserved characters so a title
  * like "RFC / Design Doc" cannot escape into a nonexistent subdirectory.
  */
-function sanitizeNoteTitle(raw: string | undefined): string {
+export function sanitizeNoteTitle(raw: string | undefined): string {
   return (
     (raw ?? '')
       .replace(/[\\/:\u0000-\u001f*?"<>|]/g, '-')

--- a/apps/desktop/src/main/watcher.ts
+++ b/apps/desktop/src/main/watcher.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import chokidar, { FSWatcher } from 'chokidar'
 import type { NoteFolder, VaultChangeEvent, VaultChangeKind } from '@shared/ipc'
+import { databaseCsvPathFor } from '@shared/databases'
 import { folderForRelativePath } from './vault'
 
 const ATTACHMENTS_DIRS = new Set(['attachements', '_assets'])
@@ -76,6 +77,18 @@ export class VaultWatcher {
           path: commentsPath,
           folder: folderForRelativePath(commentsPath) ?? 'inbox',
           scope: 'comments'
+        })
+        return
+      }
+      // A `.csv` data file or its `.csv.base.json` sidecar — normalize both to
+      // the canonical `.csv` path so the renderer re-hydrates the right database.
+      const dbCsvPath = databaseCsvPathFor(toPosix(path.relative(this.root, absPath)))
+      if (dbCsvPath) {
+        onEvent({
+          kind,
+          path: dbCsvPath,
+          folder: folderForRelativePath(dbCsvPath) ?? 'inbox',
+          scope: 'database'
         })
         return
       }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -309,8 +309,10 @@ const api: ZenBridge = {
     rows: DbRow[]
   ): Promise<DatabaseDoc> =>
     ipcRenderer.invoke(IPC.VAULT_WRITE_DATABASE_SCHEMA, relPath, sidecar, rows),
-  createDatabase: (folder: string, title?: string): Promise<DatabaseDoc> =>
-    ipcRenderer.invoke(IPC.VAULT_CREATE_DATABASE, folder, title),
+  createDatabase: (folder: NoteFolder, subpath: string, title?: string): Promise<DatabaseDoc> =>
+    ipcRenderer.invoke(IPC.VAULT_CREATE_DATABASE, folder, subpath, title),
+  createRecordPage: (csvPath: string, title: string, body: string): Promise<string> =>
+    ipcRenderer.invoke(IPC.VAULT_CREATE_RECORD_PAGE, csvPath, title, body),
   listDatabases: (): Promise<DatabaseSummary[]> => ipcRenderer.invoke(IPC.VAULT_LIST_DATABASES),
   writeNote: (relPath: string, body: string): Promise<NoteMeta> =>
     ipcRenderer.invoke(IPC.VAULT_WRITE_NOTE, relPath, body),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,6 +46,7 @@ import type {
   VaultTextSearchToolPaths
 } from '@shared/ipc'
 import type { VaultTask } from '@shared/tasks'
+import type { DatabaseDoc, DatabaseSidecar, DatabaseSummary, DbRow } from '@shared/databases'
 import type {
   McpClientId,
   McpClientStatus,
@@ -298,6 +299,19 @@ const api: ZenBridge = {
   scanTasks: (): Promise<VaultTask[]> => ipcRenderer.invoke(IPC.VAULT_SCAN_TASKS),
   scanTasksForPath: (relPath: string): Promise<VaultTask[]> =>
     ipcRenderer.invoke(IPC.VAULT_SCAN_TASKS_FOR, relPath),
+  openDatabase: (relPath: string): Promise<DatabaseDoc> =>
+    ipcRenderer.invoke(IPC.VAULT_OPEN_DATABASE, relPath),
+  writeDatabaseRows: (relPath: string, rows: DbRow[]): Promise<DatabaseDoc> =>
+    ipcRenderer.invoke(IPC.VAULT_WRITE_DATABASE_ROWS, relPath, rows),
+  writeDatabaseSchema: (
+    relPath: string,
+    sidecar: DatabaseSidecar,
+    rows: DbRow[]
+  ): Promise<DatabaseDoc> =>
+    ipcRenderer.invoke(IPC.VAULT_WRITE_DATABASE_SCHEMA, relPath, sidecar, rows),
+  createDatabase: (folder: string, title?: string): Promise<DatabaseDoc> =>
+    ipcRenderer.invoke(IPC.VAULT_CREATE_DATABASE, folder, title),
+  listDatabases: (): Promise<DatabaseSummary[]> => ipcRenderer.invoke(IPC.VAULT_LIST_DATABASES),
   writeNote: (relPath: string, body: string): Promise<NoteMeta> =>
     ipcRenderer.invoke(IPC.VAULT_WRITE_NOTE, relPath, body),
   appendToNote: (relPath: string, body: string, position: 'start' | 'end'): Promise<NoteMeta> =>

--- a/apps/web/src/bridge/http-bridge.ts
+++ b/apps/web/src/bridge/http-bridge.ts
@@ -576,6 +576,9 @@ function writeDatabaseSchema(): Promise<DatabaseDoc> {
 function createDatabase(): Promise<DatabaseDoc> {
   return Promise.reject(new Error(DATABASES_WEB_MSG))
 }
+function createRecordPage(): Promise<string> {
+  return Promise.reject(new Error(DATABASES_WEB_MSG))
+}
 function listDatabases(): Promise<DatabaseSummary[]> {
   return Promise.resolve([])
 }
@@ -1132,6 +1135,7 @@ export const httpBridge: ZenBridge = {
   writeDatabaseRows,
   writeDatabaseSchema,
   createDatabase,
+  createRecordPage,
   listDatabases,
   writeNote,
   appendToNote,

--- a/apps/web/src/bridge/http-bridge.ts
+++ b/apps/web/src/bridge/http-bridge.ts
@@ -59,6 +59,7 @@ import type {
   VaultTextSearchToolPaths
 } from '@shared/ipc'
 import type { VaultTask } from '@shared/tasks'
+import type { DatabaseDoc, DatabaseSummary } from '@shared/databases'
 import type {
   McpClientId,
   McpClientStatus,
@@ -559,6 +560,24 @@ function scanTasks(): Promise<VaultTask[]> {
 
 function scanTasksForPath(relPath: string): Promise<VaultTask[]> {
   return jsonRequest<VaultTask[]>(`/tasks/for?path=${encodeURIComponent(relPath)}`)
+}
+
+// Databases are desktop-only for now (no server-side CSV endpoints yet).
+const DATABASES_WEB_MSG = 'Databases are only available in the desktop app right now.'
+function openDatabase(): Promise<DatabaseDoc> {
+  return Promise.reject(new Error(DATABASES_WEB_MSG))
+}
+function writeDatabaseRows(): Promise<DatabaseDoc> {
+  return Promise.reject(new Error(DATABASES_WEB_MSG))
+}
+function writeDatabaseSchema(): Promise<DatabaseDoc> {
+  return Promise.reject(new Error(DATABASES_WEB_MSG))
+}
+function createDatabase(): Promise<DatabaseDoc> {
+  return Promise.reject(new Error(DATABASES_WEB_MSG))
+}
+function listDatabases(): Promise<DatabaseSummary[]> {
+  return Promise.resolve([])
 }
 
 // --------------------------------------------------------------------
@@ -1109,6 +1128,11 @@ export const httpBridge: ZenBridge = {
   writeNoteComments,
   scanTasks,
   scanTasksForPath,
+  openDatabase,
+  writeDatabaseRows,
+  writeDatabaseSchema,
+  createDatabase,
+  listDatabases,
   writeNote,
   appendToNote,
   createNote,

--- a/packages/app-core/src/components/DatabaseBoardView.tsx
+++ b/packages/app-core/src/components/DatabaseBoardView.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState } from 'react'
+import type { DatabaseDoc, DbField, DbView } from '@shared/databases'
+import { EMPTY_GROUP } from '@shared/databases'
+import { boardColumns, filterRows } from '@shared/database-transforms'
+import { useStore } from '../store'
+import {
+  setCell,
+  ensureSelectOption,
+  updateView,
+  fieldsById,
+  formatDate,
+  optionLabel,
+  splitMultiSelect,
+  isCheckboxTrue
+} from '../lib/database-cells'
+import { PlusIcon } from './icons'
+
+interface Props {
+  csvPath: string
+  doc: DatabaseDoc
+  view: DbView
+}
+
+/**
+ * Board view: columns are the options of a `select` group-by field (+ an
+ * "(empty)" column). Dragging a card to a column sets that field on the row.
+ * Uses native HTML5 drag-and-drop.
+ */
+export function DatabaseBoardView({ csvPath, doc, view }: Props): JSX.Element {
+  const updateDatabaseRows = useStore((s) => s.updateDatabaseRows)
+  const updateDatabaseSchema = useStore((s) => s.updateDatabaseSchema)
+
+  const selectFields = doc.fields.filter((f) => f.type === 'select')
+  const groupField =
+    doc.fields.find((f) => f.id === view.groupByFieldId && f.type === 'select') ?? selectFields[0]
+
+  const map = useMemo(() => fieldsById(doc), [doc])
+  const visibleRows = useMemo(
+    () => filterRows(doc.rows, view.filters, map),
+    [doc.rows, view.filters, map]
+  )
+
+  const titleField = doc.fields.find((f) => f.id !== doc.idFieldId)
+  const cardFields = (view.cardFieldIds ?? doc.fields.map((f) => f.id))
+    .map((id) => map.get(id))
+    .filter((f): f is DbField => !!f && !f.hidden && f.id !== doc.idFieldId && f.id !== titleField?.id && f.id !== groupField?.id)
+
+  const [dragRow, setDragRow] = useState<string | null>(null)
+  const [overCol, setOverCol] = useState<string | null>(null)
+  const [addingOption, setAddingOption] = useState(false)
+  const [optionDraft, setOptionDraft] = useState('')
+
+  if (!groupField) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-ink-500">
+        <p>Group the board by a Select field.</p>
+        <p className="text-xs text-ink-400">Add a Select field in the Table view, then come back.</p>
+      </div>
+    )
+  }
+
+  const optionOrder = view.boardColumnOrder ?? groupField.options?.map((o) => o.value) ?? []
+  const columns = boardColumns(visibleRows, groupField, optionOrder)
+
+  const moveTo = (rowId: string, columnKey: string): void => {
+    const value = columnKey === EMPTY_GROUP ? '' : columnKey
+    updateDatabaseRows(csvPath, setCell(doc, rowId, groupField.id, value))
+  }
+
+  const columnLabel = (key: string): string =>
+    key === EMPTY_GROUP ? 'No ' + groupField.name.toLowerCase() : optionLabel(groupField, key)
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-2 px-4 py-2 text-xs text-ink-500">
+        <span>Group by</span>
+        <select
+          value={groupField.id}
+          onChange={(e) =>
+            updateDatabaseSchema(csvPath, updateView(doc, view.id, { groupByFieldId: e.target.value }))
+          }
+          className="rounded-md border border-paper-300 bg-paper-50 px-2 py-1 text-xs text-ink-900 outline-none focus:border-accent"
+        >
+          {selectFields.map((f) => (
+            <option key={f.id} value={f.id}>
+              {f.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto px-4 pb-4">
+        {columns.map((col) => (
+          <div
+            key={col.key}
+            onDragOver={(e) => {
+              e.preventDefault()
+              setOverCol(col.key)
+            }}
+            onDragLeave={() => setOverCol((c) => (c === col.key ? null : c))}
+            onDrop={() => {
+              if (dragRow) moveTo(dragRow, col.key)
+              setDragRow(null)
+              setOverCol(null)
+            }}
+            className={[
+              'flex w-72 shrink-0 flex-col rounded-lg border bg-paper-100/60',
+              overCol === col.key ? 'border-accent/60' : 'border-paper-300/60'
+            ].join(' ')}
+          >
+            <div className="flex shrink-0 items-center justify-between gap-2 border-b border-paper-300/45 px-3 py-2">
+              <span className="truncate text-xs font-semibold uppercase tracking-wide text-ink-600">
+                {columnLabel(col.key)}
+              </span>
+              <span className="text-xs text-ink-400">{col.rows.length}</span>
+            </div>
+            <div className="min-h-0 flex-1 space-y-1.5 overflow-y-auto p-2">
+              {col.rows.length === 0 ? (
+                <div className="rounded-md border border-dashed border-paper-300/60 px-2 py-3 text-center text-xs text-ink-400">
+                  empty
+                </div>
+              ) : (
+                col.rows.map((row) => (
+                  <div
+                    key={row.id}
+                    draggable
+                    onDragStart={() => setDragRow(row.id)}
+                    onDragEnd={() => setDragRow(null)}
+                    className={[
+                      'cursor-grab rounded-md border border-paper-300/60 bg-paper-100/85 px-2.5 py-1.5 active:cursor-grabbing',
+                      dragRow === row.id ? 'opacity-50' : 'hover:bg-paper-200/60'
+                    ].join(' ')}
+                  >
+                    <div className="truncate text-sm text-ink-900">
+                      {titleField ? row.cells[titleField.id] || '—' : '—'}
+                    </div>
+                    {cardFields.length > 0 && (
+                      <div className="mt-1 flex flex-wrap items-center gap-1.5 text-2xs text-ink-500">
+                        {cardFields.map((f) => {
+                          const v = row.cells[f.id] ?? ''
+                          if (!v && f.type !== 'checkbox') return null
+                          let content: string
+                          if (f.type === 'checkbox') content = isCheckboxTrue(v) ? '✓' : ''
+                          else if (f.type === 'date') content = formatDate(v)
+                          else if (f.type === 'multiSelect') content = splitMultiSelect(v).map((x) => optionLabel(f, x)).join(', ')
+                          else if (f.type === 'select') content = optionLabel(f, v)
+                          else content = v
+                          if (!content) return null
+                          return (
+                            <span key={f.id} className="truncate">
+                              {content}
+                            </span>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        ))}
+
+        {/* Add a new option (= a new column). */}
+        <div className="w-56 shrink-0">
+          {addingOption ? (
+            <input
+              autoFocus
+              value={optionDraft}
+              placeholder="New column…"
+              onChange={(e) => setOptionDraft(e.target.value)}
+              onBlur={() => {
+                if (optionDraft.trim()) {
+                  updateDatabaseSchema(csvPath, ensureSelectOption(doc, groupField.id, optionDraft.trim()))
+                }
+                setOptionDraft('')
+                setAddingOption(false)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.currentTarget.blur()
+                else if (e.key === 'Escape') {
+                  setOptionDraft('')
+                  setAddingOption(false)
+                }
+              }}
+              className="w-full rounded-md border border-paper-300 bg-paper-50 px-2 py-1.5 text-sm text-ink-900 outline-none focus:border-accent"
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setAddingOption(true)}
+              className="flex w-full items-center gap-1 rounded-lg border border-dashed border-paper-300/60 px-3 py-2 text-xs text-ink-500 hover:bg-paper-200/40 hover:text-ink-900"
+            >
+              <PlusIcon className="h-3.5 w-3.5" /> Add column
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app-core/src/components/DatabaseBoardView.tsx
+++ b/packages/app-core/src/components/DatabaseBoardView.tsx
@@ -13,7 +13,8 @@ import {
   splitMultiSelect,
   isCheckboxTrue
 } from '../lib/database-cells'
-import { PlusIcon } from './icons'
+import { PlusIcon, ArrowUpRightIcon } from './icons'
+import { IconButton } from './ui/Button'
 
 interface Props {
   csvPath: string
@@ -29,6 +30,7 @@ interface Props {
 export function DatabaseBoardView({ csvPath, doc, view }: Props): JSX.Element {
   const updateDatabaseRows = useStore((s) => s.updateDatabaseRows)
   const updateDatabaseSchema = useStore((s) => s.updateDatabaseSchema)
+  const openRecordPage = useStore((s) => s.openRecordPage)
 
   const selectFields = doc.fields.filter((f) => f.type === 'select')
   const groupField =
@@ -54,7 +56,7 @@ export function DatabaseBoardView({ csvPath, doc, view }: Props): JSX.Element {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-ink-500">
         <p>Group the board by a Select field.</p>
-        <p className="text-xs text-ink-400">Add a Select field in the Table view, then come back.</p>
+        <p className="text-xs text-ink-500">Add a Select field in the Table view, then come back.</p>
       </div>
     )
   }
@@ -112,11 +114,11 @@ export function DatabaseBoardView({ csvPath, doc, view }: Props): JSX.Element {
               <span className="truncate text-xs font-semibold uppercase tracking-wide text-ink-600">
                 {columnLabel(col.key)}
               </span>
-              <span className="text-xs text-ink-400">{col.rows.length}</span>
+              <span className="text-xs text-ink-500">{col.rows.length}</span>
             </div>
             <div className="min-h-0 flex-1 space-y-1.5 overflow-y-auto p-2">
               {col.rows.length === 0 ? (
-                <div className="rounded-md border border-dashed border-paper-300/60 px-2 py-3 text-center text-xs text-ink-400">
+                <div className="rounded-md border border-dashed border-paper-300/60 px-2 py-3 text-center text-xs text-ink-500">
                   empty
                 </div>
               ) : (
@@ -127,12 +129,26 @@ export function DatabaseBoardView({ csvPath, doc, view }: Props): JSX.Element {
                     onDragStart={() => setDragRow(row.id)}
                     onDragEnd={() => setDragRow(null)}
                     className={[
-                      'cursor-grab rounded-md border border-paper-300/60 bg-paper-100/85 px-2.5 py-1.5 active:cursor-grabbing',
+                      'group/card cursor-grab rounded-md border border-paper-300/60 bg-paper-100/85 px-2.5 py-1.5 active:cursor-grabbing',
                       dragRow === row.id ? 'opacity-50' : 'hover:bg-paper-200/60'
                     ].join(' ')}
                   >
-                    <div className="truncate text-sm text-ink-900">
-                      {titleField ? row.cells[titleField.id] || '—' : '—'}
+                    <div className="flex items-start justify-between gap-1">
+                      <div className="min-w-0 flex-1 truncate text-sm text-ink-900">
+                        {titleField ? row.cells[titleField.id] || '—' : '—'}
+                      </div>
+                      <IconButton
+                        size="sm"
+                        variant="ghost"
+                        className="shrink-0 opacity-0 group-hover/card:opacity-100"
+                        title="Open as page"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          void openRecordPage(csvPath, row.id)
+                        }}
+                      >
+                        <ArrowUpRightIcon className="h-3.5 w-3.5" />
+                      </IconButton>
                     </div>
                     {cardFields.length > 0 && (
                       <div className="mt-1 flex flex-wrap items-center gap-1.5 text-2xs text-ink-500">

--- a/packages/app-core/src/components/DatabaseTableView.tsx
+++ b/packages/app-core/src/components/DatabaseTableView.tsx
@@ -1,0 +1,359 @@
+import { useMemo, useRef, useState, useEffect } from 'react'
+import type { DatabaseDoc, DbField, DbRow, DbView, FieldType } from '@shared/databases'
+import { filterRows, sortRows } from '@shared/database-transforms'
+import { useStore } from '../store'
+import {
+  addRow,
+  setCell,
+  deleteRow,
+  renameField,
+  retypeField,
+  deleteField,
+  ensureSelectOption,
+  updateView,
+  fieldsById,
+  formatDate,
+  optionLabel,
+  splitMultiSelect,
+  isCheckboxTrue
+} from '../lib/database-cells'
+import { ContextMenu, type ContextMenuItem } from './ContextMenu'
+import { IconButton } from './ui/Button'
+import { MoreIcon, TrashIcon, PlusIcon } from './icons'
+
+const FIELD_TYPE_LABELS: Record<FieldType, string> = {
+  text: 'Text',
+  number: 'Number',
+  checkbox: 'Checkbox',
+  date: 'Date',
+  select: 'Select',
+  multiSelect: 'Multi-select'
+}
+
+interface Props {
+  csvPath: string
+  doc: DatabaseDoc
+  view: DbView
+}
+
+export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
+  const updateDatabaseRows = useStore((s) => s.updateDatabaseRows)
+  const updateDatabaseSchema = useStore((s) => s.updateDatabaseSchema)
+
+  const [editing, setEditing] = useState<{ rowId: string; fieldId: string } | null>(null)
+  const [renamingField, setRenamingField] = useState<string | null>(null)
+  const [fieldMenu, setFieldMenu] = useState<{ fieldId: string; x: number; y: number } | null>(null)
+
+  const map = useMemo(() => fieldsById(doc), [doc])
+  const columns = useMemo(() => {
+    const order = view.columnOrder ?? doc.fields.map((f) => f.id)
+    const hidden = new Set(view.hiddenFieldIds ?? [])
+    return order
+      .map((id) => map.get(id))
+      .filter((f): f is DbField => !!f && !f.hidden && !hidden.has(f.id))
+  }, [doc.fields, view.columnOrder, view.hiddenFieldIds, map])
+
+  const rows = useMemo(() => {
+    return sortRows(filterRows(doc.rows, view.filters, map), view.sorts, map)
+  }, [doc.rows, view.filters, view.sorts, map])
+
+  const commitCell = (rowId: string, field: DbField, value: string): void => {
+    if (field.type === 'select' || field.type === 'multiSelect') {
+      // Ensure each chosen value exists as an option (schema), then set the cell.
+      let next = doc
+      const values = field.type === 'multiSelect' ? splitMultiSelect(value) : value ? [value] : []
+      for (const v of values) next = ensureSelectOption(next, field.id, v)
+      next = setCell(next, rowId, field.id, value)
+      updateDatabaseSchema(csvPath, next)
+    } else {
+      updateDatabaseRows(csvPath, setCell(doc, rowId, field.id, value))
+    }
+  }
+
+  const sortIndicator = (fieldId: string): string => {
+    const s = view.sorts.find((x) => x.fieldId === fieldId)
+    return s ? (s.direction === 'asc' ? ' ↑' : ' ↓') : ''
+  }
+
+  const fieldMenuItems = (field: DbField): ContextMenuItem[] => [
+    { label: 'Sort ascending', onSelect: () => updateDatabaseSchema(csvPath, updateView(doc, view.id, { sorts: [{ fieldId: field.id, direction: 'asc' }] })) },
+    { label: 'Sort descending', onSelect: () => updateDatabaseSchema(csvPath, updateView(doc, view.id, { sorts: [{ fieldId: field.id, direction: 'desc' }] })) },
+    { label: 'Clear sort', disabled: view.sorts.length === 0, onSelect: () => updateDatabaseSchema(csvPath, updateView(doc, view.id, { sorts: [] })) },
+    { kind: 'separator' },
+    { label: 'Rename field', onSelect: () => setRenamingField(field.id) },
+    ...(Object.keys(FIELD_TYPE_LABELS) as FieldType[]).map((t) => ({
+      label: `Type: ${FIELD_TYPE_LABELS[t]}`,
+      hint: field.type === t ? '●' : undefined,
+      onSelect: () => updateDatabaseSchema(csvPath, retypeField(doc, field.id, t))
+    })),
+    { kind: 'separator' },
+    {
+      label: 'Delete field',
+      danger: true,
+      disabled: field.id === doc.idFieldId,
+      onSelect: () => updateDatabaseSchema(csvPath, deleteField(doc, field.id))
+    }
+  ]
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <table className="w-full border-collapse text-sm">
+        <thead className="sticky top-0 z-10 bg-paper-100">
+          <tr className="border-b border-paper-300/70">
+            <th className="w-8 border-r border-paper-300/40" />
+            {columns.map((field) => (
+              <th
+                key={field.id}
+                className="group/h min-w-[8rem] border-r border-paper-300/40 px-2 py-1.5 text-left font-medium text-ink-600"
+              >
+                {renamingField === field.id ? (
+                  <input
+                    autoFocus
+                    defaultValue={field.name}
+                    onFocus={(e) => e.currentTarget.select()}
+                    onBlur={(e) => {
+                      updateDatabaseSchema(csvPath, renameField(doc, field.id, e.currentTarget.value))
+                      setRenamingField(null)
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') e.currentTarget.blur()
+                      else if (e.key === 'Escape') setRenamingField(null)
+                    }}
+                    className="w-full rounded border border-accent bg-paper-50 px-1 py-0.5 text-sm text-ink-900 outline-none"
+                  />
+                ) : (
+                  <div className="flex items-center justify-between gap-1">
+                    <button
+                      type="button"
+                      onDoubleClick={() => setRenamingField(field.id)}
+                      className="min-w-0 flex-1 truncate text-left"
+                      title={`${field.name} · ${FIELD_TYPE_LABELS[field.type]}`}
+                    >
+                      {field.name}
+                      <span className="text-ink-400">{sortIndicator(field.id)}</span>
+                    </button>
+                    <IconButton
+                      size="sm"
+                      className="opacity-0 group-hover/h:opacity-100"
+                      title="Field options"
+                      onClick={(e) => {
+                        const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
+                        setFieldMenu({ fieldId: field.id, x: r.left, y: r.bottom })
+                      }}
+                    >
+                      <MoreIcon className="h-3.5 w-3.5" />
+                    </IconButton>
+                  </div>
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.id} className="group/row border-b border-paper-300/30 hover:bg-paper-200/30">
+              <td className="border-r border-paper-300/40 text-center align-middle">
+                <IconButton
+                  size="sm"
+                  variant="ghost"
+                  className="opacity-0 group-hover/row:opacity-100"
+                  title="Delete row"
+                  onClick={() => updateDatabaseRows(csvPath, deleteRow(doc, row.id))}
+                >
+                  <TrashIcon className="h-3.5 w-3.5" />
+                </IconButton>
+              </td>
+              {columns.map((field) => (
+                <td key={field.id} className="border-r border-paper-300/40 p-0 align-top">
+                  <Cell
+                    field={field}
+                    value={row.cells[field.id] ?? ''}
+                    editing={editing?.rowId === row.id && editing?.fieldId === field.id}
+                    onStartEdit={() => setEditing({ rowId: row.id, fieldId: field.id })}
+                    onEndEdit={() => setEditing(null)}
+                    onCommit={(v) => commitCell(row.id, field, v)}
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+          <tr>
+            <td colSpan={columns.length + 1} className="px-2 py-1.5">
+              <button
+                type="button"
+                onClick={() => updateDatabaseRows(csvPath, addRow(doc))}
+                className="flex items-center gap-1 rounded px-1.5 py-1 text-xs text-ink-500 hover:bg-paper-200 hover:text-ink-900"
+              >
+                <PlusIcon className="h-3.5 w-3.5" /> New row
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      {fieldMenu && (
+        <ContextMenu
+          x={fieldMenu.x}
+          y={fieldMenu.y}
+          items={fieldMenuItems(map.get(fieldMenu.fieldId)!)}
+          onClose={() => setFieldMenu(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+interface CellProps {
+  field: DbField
+  value: string
+  editing: boolean
+  onStartEdit: () => void
+  onEndEdit: () => void
+  onCommit: (value: string) => void
+}
+
+function Cell({ field, value, editing, onStartEdit, onEndEdit, onCommit }: CellProps): JSX.Element {
+  if (field.type === 'checkbox') {
+    const checked = isCheckboxTrue(value)
+    return (
+      <button
+        type="button"
+        onClick={() => onCommit(checked ? 'false' : 'true')}
+        className="flex h-full w-full items-center justify-center px-2 py-1.5"
+        title={checked ? 'Checked' : 'Unchecked'}
+      >
+        <span
+          className={[
+            'flex h-4 w-4 items-center justify-center rounded border',
+            checked ? 'border-accent bg-accent text-white' : 'border-paper-400 text-transparent'
+          ].join(' ')}
+        >
+          ✓
+        </span>
+      </button>
+    )
+  }
+
+  if (field.type === 'select' || field.type === 'multiSelect') {
+    return (
+      <SelectCell field={field} value={value} editing={editing} onStartEdit={onStartEdit} onEndEdit={onEndEdit} onCommit={onCommit} />
+    )
+  }
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        type={field.type === 'number' ? 'number' : field.type === 'date' ? 'date' : 'text'}
+        defaultValue={value}
+        onFocus={(e) => e.currentTarget.select()}
+        onBlur={(e) => {
+          onCommit(e.currentTarget.value)
+          onEndEdit()
+        }}
+        onKeyDown={(e) => {
+          e.stopPropagation()
+          if (e.key === 'Enter') e.currentTarget.blur()
+          else if (e.key === 'Escape') onEndEdit()
+        }}
+        className="w-full bg-paper-50 px-2 py-1.5 text-sm text-ink-900 outline-none ring-1 ring-inset ring-accent"
+      />
+    )
+  }
+
+  return (
+    <button type="button" onClick={onStartEdit} className="block h-full w-full px-2 py-1.5 text-left">
+      <span className="block truncate text-ink-900">{field.type === 'date' ? formatDate(value) : value}</span>
+    </button>
+  )
+}
+
+function SelectCell({ field, value, editing, onStartEdit, onEndEdit, onCommit }: CellProps): JSX.Element {
+  const multi = field.type === 'multiSelect'
+  const selected = multi ? splitMultiSelect(value) : value ? [value] : []
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [draft, setDraft] = useState('')
+
+  useEffect(() => {
+    if (!editing) return
+    const onDown = (e: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onEndEdit()
+    }
+    window.addEventListener('mousedown', onDown, true)
+    return () => window.removeEventListener('mousedown', onDown, true)
+  }, [editing, onEndEdit])
+
+  const toggle = (optValue: string): void => {
+    if (multi) {
+      const next = selected.includes(optValue)
+        ? selected.filter((v) => v !== optValue)
+        : [...selected, optValue]
+      onCommit(next.join(', '))
+    } else {
+      onCommit(selected[0] === optValue ? '' : optValue)
+      onEndEdit()
+    }
+  }
+
+  const chips = (
+    <div className="flex flex-wrap gap-1">
+      {selected.length === 0 ? (
+        <span className="text-ink-400">—</span>
+      ) : (
+        selected.map((v) => (
+          <span key={v} className="rounded-full bg-accent/15 px-2 py-0.5 text-2xs font-medium text-accent ring-1 ring-accent/30">
+            {optionLabel(field, v)}
+          </span>
+        ))
+      )}
+    </div>
+  )
+
+  if (!editing) {
+    return (
+      <button type="button" onClick={onStartEdit} className="block h-full w-full px-2 py-1.5 text-left">
+        {chips}
+      </button>
+    )
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <div className="px-2 py-1.5 ring-1 ring-inset ring-accent">{chips}</div>
+      <div className="absolute left-0 top-full z-50 mt-1 w-56 overflow-hidden rounded-lg border border-paper-300 bg-paper-100 py-1 shadow-float">
+        <div className="max-h-56 overflow-y-auto">
+          {(field.options ?? []).map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => toggle(opt.value)}
+              className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm hover:bg-paper-200"
+            >
+              <span className="truncate text-ink-900">{opt.label ?? opt.value}</span>
+              {selected.includes(opt.value) && <span className="text-accent">✓</span>}
+            </button>
+          ))}
+        </div>
+        <div className="border-t border-paper-300/60 p-1.5">
+          <input
+            value={draft}
+            placeholder="Add option…"
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              e.stopPropagation()
+              if (e.key === 'Enter' && draft.trim()) {
+                toggle(draft.trim().replace(/,/g, ' '))
+                setDraft('')
+              } else if (e.key === 'Escape') {
+                onEndEdit()
+              }
+            }}
+            className="w-full rounded border border-paper-300 bg-paper-50 px-2 py-1 text-sm text-ink-900 outline-none focus:border-accent"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app-core/src/components/DatabaseTableView.tsx
+++ b/packages/app-core/src/components/DatabaseTableView.tsx
@@ -1,4 +1,13 @@
-import { useMemo, useRef, useState, useEffect } from 'react'
+import {
+  useMemo,
+  useRef,
+  useState,
+  useEffect,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent
+} from 'react'
+import { createPortal } from 'react-dom'
 import type { DatabaseDoc, DbField, DbRow, DbView, FieldType } from '@shared/databases'
 import { filterRows, sortRows } from '@shared/database-transforms'
 import { useStore } from '../store'
@@ -19,7 +28,8 @@ import {
 } from '../lib/database-cells'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu'
 import { IconButton } from './ui/Button'
-import { MoreIcon, TrashIcon, PlusIcon } from './icons'
+import { MoreIcon, TrashIcon, PlusIcon, DocumentIcon, DocumentTextIcon, ArrowUpRightIcon } from './icons'
+import { focusEditorNormalMode } from '../lib/editor-focus'
 
 const FIELD_TYPE_LABELS: Record<FieldType, string> = {
   text: 'Text',
@@ -39,10 +49,26 @@ interface Props {
 export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
   const updateDatabaseRows = useStore((s) => s.updateDatabaseRows)
   const updateDatabaseSchema = useStore((s) => s.updateDatabaseSchema)
+  const openRecordPage = useStore((s) => s.openRecordPage)
+  const renameRecordPage = useStore((s) => s.renameRecordPage)
+
+  const titleFieldId = doc.fields.find((f) => f.id !== doc.idFieldId)?.id
 
   const [editing, setEditing] = useState<{ rowId: string; fieldId: string } | null>(null)
   const [renamingField, setRenamingField] = useState<string | null>(null)
   const [fieldMenu, setFieldMenu] = useState<{ fieldId: string; x: number; y: number } | null>(null)
+  const [rowMenu, setRowMenu] = useState<{ rowId: string; x: number; y: number } | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  // --- Vim-style keyboard grid ---------------------------------------------
+  // The grid is the focus owner; cells bubble their key events up to it. A
+  // `data-zen-db-grid` marker tells the global VimNav layer to yield so motions
+  // aren't stolen by sidebar/note-list navigation.
+  const gridRef = useRef<HTMLDivElement | null>(null)
+  const [active, setActive] = useState<{ row: number; col: number }>({ row: 0, col: 0 })
+  const gPending = useRef(false)
+  const dPending = useRef(false)
+  const prevEditing = useRef<typeof editing>(null)
 
   const map = useMemo(() => fieldsById(doc), [doc])
   const columns = useMemo(() => {
@@ -57,6 +83,29 @@ export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
     return sortRows(filterRows(doc.rows, view.filters, map), view.sorts, map)
   }, [doc.rows, view.filters, view.sorts, map])
 
+  const anySelected = selected.size > 0
+  const allSelected = rows.length > 0 && rows.every((r) => selected.has(r.id))
+  const toggleRow = (id: string): void =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  const toggleAll = (): void => setSelected(allSelected ? new Set() : new Set(rows.map((r) => r.id)))
+  const deleteSelected = (): void => {
+    let next = doc
+    for (const id of selected) next = deleteRow(next, id)
+    updateDatabaseRows(csvPath, next)
+    setSelected(new Set())
+  }
+
+  // Open a record's page note, then move the cursor into its editor (otherwise
+  // focus lingers on the table / sidebar after the tab swaps).
+  const openPage = (rowId: string): void => {
+    void openRecordPage(csvPath, rowId).then(() => focusEditorNormalMode())
+  }
+
   const commitCell = (rowId: string, field: DbField, value: string): void => {
     if (field.type === 'select' || field.type === 'multiSelect') {
       // Ensure each chosen value exists as an option (schema), then set the cell.
@@ -68,11 +117,170 @@ export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
     } else {
       updateDatabaseRows(csvPath, setCell(doc, rowId, field.id, value))
     }
+    // Keep the linked page note's filename in step with the title field.
+    if (field.id === titleFieldId && doc.pages?.[rowId]) {
+      void renameRecordPage(csvPath, rowId)
+    }
+  }
+
+  // Keep the active cell within bounds as rows/columns change.
+  useEffect(() => {
+    setActive((a) => ({
+      row: Math.max(0, Math.min(a.row, rows.length - 1)),
+      col: Math.max(0, Math.min(a.col, columns.length - 1))
+    }))
+  }, [rows.length, columns.length])
+
+  // Scroll the active cell into view as it moves.
+  useEffect(() => {
+    const el = gridRef.current?.querySelector('[data-active-cell="true"]') as HTMLElement | null
+    el?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  }, [active])
+
+  // When an inline edit ends (Esc/Enter blurs the input to <body>), return
+  // focus to the grid so motions resume. Skip if the user clicked elsewhere.
+  useEffect(() => {
+    if (prevEditing.current && !editing) {
+      const a = document.activeElement
+      if (a === document.body || (gridRef.current && a && gridRef.current.contains(a))) {
+        gridRef.current?.focus({ preventScroll: true })
+      }
+    }
+    prevEditing.current = editing
+  }, [editing])
+
+  // Focus the grid when a database tab first renders so vim motions work
+  // immediately (otherwise focus lingers on the sidebar / tab strip).
+  useEffect(() => {
+    gridRef.current?.focus({ preventScroll: true })
+  }, [csvPath])
+
+  const onGridKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>): void => {
+    if (editing) return // the cell's own input owns keys while editing
+    if (e.metaKey || e.ctrlKey || e.altKey) return // leave global shortcuts alone
+    const lastRow = rows.length - 1
+    const lastCol = columns.length - 1
+    const clampRow = (n: number): number => Math.max(0, Math.min(n, lastRow))
+    const clampCol = (n: number): number => Math.max(0, Math.min(n, lastCol))
+    const move = (row: number, col: number): void => {
+      e.preventDefault()
+      setActive({ row: clampRow(row), col: clampCol(col) })
+    }
+    const cell = (): { row: DbRow; field: DbField } | null => {
+      const row = rows[active.row]
+      const field = columns[active.col]
+      return row && field ? { row, field } : null
+    }
+    const toggleCheckbox = (row: DbRow, field: DbField): void =>
+      commitCell(row.id, field, isCheckboxTrue(row.cells[field.id] ?? '') ? 'false' : 'true')
+
+    // Reset pending multi-key sequences when a different key arrives.
+    if (gPending.current && e.key !== 'g') gPending.current = false
+    if (dPending.current && e.key !== 'd') dPending.current = false
+
+    switch (e.key) {
+      case 'j':
+      case 'ArrowDown':
+        return move(active.row + 1, active.col)
+      case 'k':
+      case 'ArrowUp':
+        return move(active.row - 1, active.col)
+      case 'h':
+      case 'ArrowLeft':
+        return move(active.row, active.col - 1)
+      case 'l':
+      case 'ArrowRight':
+        return move(active.row, active.col + 1)
+      case '0':
+      case '^':
+        return move(active.row, 0)
+      case '$':
+        return move(active.row, lastCol)
+      case 'G':
+        return move(lastRow, active.col)
+      case 'g':
+        e.preventDefault()
+        if (gPending.current) {
+          gPending.current = false
+          return move(0, active.col)
+        }
+        gPending.current = true
+        return
+      case 'd': {
+        e.preventDefault()
+        if (!dPending.current) {
+          dPending.current = true
+          return
+        }
+        dPending.current = false
+        const c = cell()
+        if (c) updateDatabaseRows(csvPath, deleteRow(doc, c.row.id))
+        return
+      }
+      case 'Enter':
+      case 'i': {
+        const c = cell()
+        if (!c) return
+        e.preventDefault()
+        if (c.field.type === 'checkbox') return toggleCheckbox(c.row, c.field)
+        setEditing({ rowId: c.row.id, fieldId: c.field.id })
+        return
+      }
+      case ' ': {
+        const c = cell()
+        if (!c) return
+        e.preventDefault()
+        if (c.field.type === 'checkbox') return toggleCheckbox(c.row, c.field)
+        return toggleRow(c.row.id)
+      }
+      case 'x': {
+        const c = cell()
+        if (!c) return
+        e.preventDefault()
+        return toggleRow(c.row.id)
+      }
+      case 'o': {
+        const c = cell()
+        if (!c) return
+        e.preventDefault()
+        return openPage(c.row.id)
+      }
+      case 'a': {
+        e.preventDefault()
+        updateDatabaseRows(csvPath, addRow(doc))
+        setActive((s) => ({ row: rows.length, col: s.col }))
+        return
+      }
+      case 'Escape':
+        e.preventDefault()
+        if (selected.size > 0) {
+          setSelected(new Set())
+          return
+        }
+        gridRef.current?.blur()
+        return
+      default:
+        return
+    }
   }
 
   const sortIndicator = (fieldId: string): string => {
     const s = view.sorts.find((x) => x.fieldId === fieldId)
     return s ? (s.direction === 'asc' ? ' ↑' : ' ↓') : ''
+  }
+
+  const rowMenuItems = (rowId: string): ContextMenuItem[] => {
+    const multi = selected.has(rowId) && selected.size > 1
+    return [
+      { label: 'Open page', onSelect: () => openPage(rowId) },
+      { kind: 'separator' },
+      {
+        label: multi ? `Delete ${selected.size} rows` : 'Delete row',
+        danger: true,
+        onSelect: () =>
+          multi ? deleteSelected() : updateDatabaseRows(csvPath, deleteRow(doc, rowId))
+      }
+    ]
   }
 
   const fieldMenuItems = (field: DbField): ContextMenuItem[] => [
@@ -96,15 +304,51 @@ export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
   ]
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto">
-      <table className="w-full border-collapse text-sm">
-        <thead className="sticky top-0 z-10 bg-paper-100">
-          <tr className="border-b border-paper-300/70">
-            <th className="w-8 border-r border-paper-300/40" />
+    <div className="flex min-h-0 flex-1 flex-col">
+      {anySelected && (
+        <div className="flex shrink-0 items-center gap-3 border-b border-paper-300/70 bg-paper-100 px-3 py-1.5 text-xs">
+          <span className="font-medium text-ink-700">{selected.size} selected</span>
+          <button
+            type="button"
+            onClick={deleteSelected}
+            className="flex items-center gap-1 rounded px-1.5 py-1 font-medium text-danger hover:bg-danger/10"
+          >
+            <TrashIcon className="h-3.5 w-3.5" /> Delete
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelected(new Set())}
+            className="text-ink-500 hover:text-ink-900"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+      <div
+        ref={gridRef}
+        tabIndex={0}
+        role="grid"
+        data-zen-db-grid
+        onKeyDown={onGridKeyDown}
+        className="min-h-0 flex-1 overflow-auto outline-none focus:outline-none"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead className="sticky top-0 z-10 bg-paper-100">
+            <tr className="border-b border-paper-300/70">
+              <th className="group/sa w-10 border-r border-paper-300/40 align-middle">
+                <div
+                  className={[
+                    'flex items-center justify-center',
+                    anySelected ? '' : 'opacity-0 group-hover/sa:opacity-100'
+                  ].join(' ')}
+                >
+                  <DbCheckbox checked={allSelected} onChange={toggleAll} title="Select all" />
+                </div>
+              </th>
             {columns.map((field) => (
               <th
                 key={field.id}
-                className="group/h min-w-[8rem] border-r border-paper-300/40 px-2 py-1.5 text-left font-medium text-ink-600"
+                className="group/h min-w-32 border-r border-paper-300/40 px-2.5 py-2 text-left text-2xs font-medium uppercase tracking-wide text-ink-500"
               >
                 {renamingField === field.id ? (
                   <input
@@ -130,7 +374,7 @@ export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
                       title={`${field.name} · ${FIELD_TYPE_LABELS[field.type]}`}
                     >
                       {field.name}
-                      <span className="text-ink-400">{sortIndicator(field.id)}</span>
+                      <span className="text-accent">{sortIndicator(field.id)}</span>
                     </button>
                     <IconButton
                       size="sm"
@@ -150,33 +394,116 @@ export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
           </tr>
         </thead>
         <tbody>
-          {rows.map((row) => (
-            <tr key={row.id} className="group/row border-b border-paper-300/30 hover:bg-paper-200/30">
-              <td className="border-r border-paper-300/40 text-center align-middle">
-                <IconButton
-                  size="sm"
-                  variant="ghost"
-                  className="opacity-0 group-hover/row:opacity-100"
-                  title="Delete row"
-                  onClick={() => updateDatabaseRows(csvPath, deleteRow(doc, row.id))}
-                >
-                  <TrashIcon className="h-3.5 w-3.5" />
-                </IconButton>
-              </td>
-              {columns.map((field) => (
-                <td key={field.id} className="border-r border-paper-300/40 p-0 align-top">
-                  <Cell
-                    field={field}
-                    value={row.cells[field.id] ?? ''}
-                    editing={editing?.rowId === row.id && editing?.fieldId === field.id}
-                    onStartEdit={() => setEditing({ rowId: row.id, fieldId: field.id })}
-                    onEndEdit={() => setEditing(null)}
-                    onCommit={(v) => commitCell(row.id, field, v)}
-                  />
+          {rows.map((row, rowIndex) => {
+            const isSel = selected.has(row.id)
+            return (
+              <tr
+                key={row.id}
+                onContextMenu={(e) => {
+                  // Let the native menu through while editing a cell's input.
+                  if ((e.target as HTMLElement).closest('input, textarea')) return
+                  e.preventDefault()
+                  setRowMenu({ rowId: row.id, x: e.clientX, y: e.clientY })
+                }}
+                className={[
+                  'group/row border-b border-paper-300/30',
+                  isSel ? 'bg-accent/8' : 'hover:bg-paper-200/30'
+                ].join(' ')}
+              >
+                <td className="w-10 border-r border-paper-300/40 align-middle">
+                  <div
+                    className={[
+                      'flex items-center justify-center',
+                      isSel || anySelected ? '' : 'opacity-0 group-hover/row:opacity-100'
+                    ].join(' ')}
+                  >
+                    <DbCheckbox checked={isSel} onChange={() => toggleRow(row.id)} title="Select row" />
+                  </div>
                 </td>
-              ))}
-            </tr>
-          ))}
+                {columns.map((field, colIndex) => {
+                  const isActive = active.row === rowIndex && active.col === colIndex
+                  const tdClassName = [
+                    'relative border-r border-paper-300/40 p-0 align-top',
+                    isActive ? 'ring-2 ring-inset ring-accent' : ''
+                  ].join(' ')
+                  // Keep keyboard focus on the grid container (not the inner
+                  // button) so vim motions keep working; sync active to the click.
+                  const onCellMouseDown = (e: ReactMouseEvent): void => {
+                    if ((e.target as HTMLElement).closest('input, textarea')) {
+                      setActive({ row: rowIndex, col: colIndex })
+                      return
+                    }
+                    e.preventDefault()
+                    setActive({ row: rowIndex, col: colIndex })
+                    gridRef.current?.focus({ preventScroll: true })
+                  }
+                  const cell = (
+                    <Cell
+                      field={field}
+                      value={row.cells[field.id] ?? ''}
+                      editing={editing?.rowId === row.id && editing?.fieldId === field.id}
+                      onStartEdit={() => setEditing({ rowId: row.id, fieldId: field.id })}
+                      onEndEdit={() => setEditing(null)}
+                      onCommit={(v) => commitCell(row.id, field, v)}
+                    />
+                  )
+                  if (field.id !== titleFieldId) {
+                    return (
+                      <td
+                        key={field.id}
+                        data-active-cell={isActive}
+                        onMouseDown={onCellMouseDown}
+                        className={tdClassName}
+                      >
+                        {cell}
+                      </td>
+                    )
+                  }
+                  // Title cell: a Notion-style page icon on the left whose glyph
+                  // reflects whether the record's linked note has body content.
+                  const hasContent = !!doc.pageHasContent?.[row.id]
+                  const PageGlyph = hasContent ? DocumentTextIcon : DocumentIcon
+                  return (
+                    <td
+                      key={field.id}
+                      data-active-cell={isActive}
+                      onMouseDown={onCellMouseDown}
+                      className={tdClassName}
+                    >
+                      <div className="flex items-start">
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            openPage(row.id)
+                          }}
+                          title={hasContent ? 'Open page' : 'Open page (empty)'}
+                          className={[
+                            'flex shrink-0 items-center pl-2 pr-1 pt-2 transition-colors hover:text-accent',
+                            hasContent ? 'text-ink-500' : 'text-ink-400'
+                          ].join(' ')}
+                        >
+                          <PageGlyph className="h-4 w-4" />
+                        </button>
+                        <div className="min-w-0 flex-1">{cell}</div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          openPage(row.id)
+                        }}
+                        title="Open page"
+                        className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-1 rounded-md border border-paper-300 bg-paper-100 px-2 py-1 text-2xs font-medium text-ink-600 opacity-0 shadow-sm transition hover:border-paper-400 hover:text-ink-900 group-hover/row:opacity-100"
+                      >
+                        <ArrowUpRightIcon className="h-3 w-3" /> Open
+                      </button>
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
           <tr>
             <td colSpan={columns.length + 1} className="px-2 py-1.5">
               <button
@@ -190,6 +517,7 @@ export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
           </tr>
         </tbody>
       </table>
+      </div>
 
       {fieldMenu && (
         <ContextMenu
@@ -199,11 +527,63 @@ export function DatabaseTableView({ csvPath, doc, view }: Props): JSX.Element {
           onClose={() => setFieldMenu(null)}
         />
       )}
+
+      {rowMenu && (
+        <ContextMenu
+          x={rowMenu.x}
+          y={rowMenu.y}
+          items={rowMenuItems(rowMenu.rowId)}
+          onClose={() => setRowMenu(null)}
+        />
+      )}
     </div>
   )
 }
 
 // ---------------------------------------------------------------------------
+
+function DbCheckbox({
+  checked,
+  onChange,
+  title
+}: {
+  checked: boolean
+  onChange: () => void
+  title?: string
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      title={title}
+      onClick={(e) => {
+        e.stopPropagation()
+        onChange()
+      }}
+      className={[
+        'flex h-4 w-4 items-center justify-center rounded border transition-colors',
+        checked
+          ? 'border-accent bg-accent text-white'
+          : 'border-paper-400 text-transparent hover:border-ink-500'
+      ].join(' ')}
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M5 12l5 5L20 7" />
+      </svg>
+    </button>
+  )
+}
 
 interface CellProps {
   field: DbField
@@ -270,16 +650,26 @@ function Cell({ field, value, editing, onStartEdit, onEndEdit, onCommit }: CellP
   )
 }
 
+const SELECT_PANEL_WIDTH = 224
+
 function SelectCell({ field, value, editing, onStartEdit, onEndEdit, onCommit }: CellProps): JSX.Element {
   const multi = field.type === 'multiSelect'
   const selected = multi ? splitMultiSelect(value) : value ? [value] : []
-  const ref = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
+  const [rect, setRect] = useState<DOMRect | null>(null)
   const [draft, setDraft] = useState('')
+
+  useEffect(() => {
+    setRect(editing && triggerRef.current ? triggerRef.current.getBoundingClientRect() : null)
+  }, [editing])
 
   useEffect(() => {
     if (!editing) return
     const onDown = (e: MouseEvent): void => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onEndEdit()
+      const t = e.target as Node
+      if (triggerRef.current?.contains(t) || panelRef.current?.contains(t)) return
+      onEndEdit()
     }
     window.addEventListener('mousedown', onDown, true)
     return () => window.removeEventListener('mousedown', onDown, true)
@@ -303,7 +693,10 @@ function SelectCell({ field, value, editing, onStartEdit, onEndEdit, onCommit }:
         <span className="text-ink-400">—</span>
       ) : (
         selected.map((v) => (
-          <span key={v} className="rounded-full bg-accent/15 px-2 py-0.5 text-2xs font-medium text-accent ring-1 ring-accent/30">
+          <span
+            key={v}
+            className="rounded-full bg-accent/15 px-2 py-0.5 text-2xs font-medium text-accent ring-1 ring-accent/30"
+          >
             {optionLabel(field, v)}
           </span>
         ))
@@ -311,49 +704,76 @@ function SelectCell({ field, value, editing, onStartEdit, onEndEdit, onCommit }:
     </div>
   )
 
-  if (!editing) {
-    return (
-      <button type="button" onClick={onStartEdit} className="block h-full w-full px-2 py-1.5 text-left">
-        {chips}
-      </button>
-    )
-  }
+  // Portal the option list to the body so the table's overflow doesn't clip it;
+  // flip above the cell when there isn't room below.
+  const placeAbove = !!rect && rect.bottom > window.innerHeight - 280
+  const panelStyle: CSSProperties = rect
+    ? {
+        position: 'fixed',
+        left: Math.max(8, Math.min(rect.left, window.innerWidth - SELECT_PANEL_WIDTH - 8)),
+        width: Math.max(rect.width, SELECT_PANEL_WIDTH),
+        ...(placeAbove ? { bottom: window.innerHeight - rect.top + 4 } : { top: rect.bottom + 4 })
+      }
+    : {}
 
   return (
-    <div ref={ref} className="relative">
-      <div className="px-2 py-1.5 ring-1 ring-inset ring-accent">{chips}</div>
-      <div className="absolute left-0 top-full z-50 mt-1 w-56 overflow-hidden rounded-lg border border-paper-300 bg-paper-100 py-1 shadow-float">
-        <div className="max-h-56 overflow-y-auto">
-          {(field.options ?? []).map((opt) => (
-            <button
-              key={opt.id}
-              type="button"
-              onClick={() => toggle(opt.value)}
-              className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm hover:bg-paper-200"
-            >
-              <span className="truncate text-ink-900">{opt.label ?? opt.value}</span>
-              {selected.includes(opt.value) && <span className="text-accent">✓</span>}
-            </button>
-          ))}
-        </div>
-        <div className="border-t border-paper-300/60 p-1.5">
-          <input
-            value={draft}
-            placeholder="Add option…"
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              e.stopPropagation()
-              if (e.key === 'Enter' && draft.trim()) {
-                toggle(draft.trim().replace(/,/g, ' '))
-                setDraft('')
-              } else if (e.key === 'Escape') {
-                onEndEdit()
-              }
-            }}
-            className="w-full rounded border border-paper-300 bg-paper-50 px-2 py-1 text-sm text-ink-900 outline-none focus:border-accent"
-          />
-        </div>
-      </div>
-    </div>
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={onStartEdit}
+        className={[
+          'block h-full w-full px-2 py-1.5 text-left',
+          editing ? 'ring-1 ring-inset ring-accent' : ''
+        ].join(' ')}
+      >
+        {chips}
+      </button>
+      {editing &&
+        rect &&
+        createPortal(
+          <div
+            ref={panelRef}
+            style={panelStyle}
+            className="z-popover overflow-hidden rounded-lg border border-paper-300 bg-paper-100 py-1 shadow-float"
+          >
+            <div className="max-h-60 overflow-y-auto">
+              {(field.options ?? []).map((opt) => (
+                <button
+                  key={opt.id}
+                  type="button"
+                  onClick={() => toggle(opt.value)}
+                  className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm hover:bg-paper-200"
+                >
+                  <span className="truncate text-ink-900">{opt.label ?? opt.value}</span>
+                  {selected.includes(opt.value) && <span className="text-accent">✓</span>}
+                </button>
+              ))}
+              {(field.options ?? []).length === 0 && (
+                <div className="px-3 py-2 text-xs text-ink-500">No options yet — add one below.</div>
+              )}
+            </div>
+            <div className="border-t border-paper-300/60 p-1.5">
+              <input
+                autoFocus
+                value={draft}
+                placeholder="Add option…"
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  e.stopPropagation()
+                  if (e.key === 'Enter' && draft.trim()) {
+                    toggle(draft.trim().replace(/,/g, ' '))
+                    setDraft('')
+                  } else if (e.key === 'Escape') {
+                    onEndEdit()
+                  }
+                }}
+                className="w-full rounded border border-paper-300 bg-paper-50 px-2 py-1 text-sm text-ink-900 outline-none focus:border-accent"
+              />
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
   )
 }

--- a/packages/app-core/src/components/DatabaseView.tsx
+++ b/packages/app-core/src/components/DatabaseView.tsx
@@ -1,0 +1,97 @@
+import { useEffect } from 'react'
+import { csvPathFromDatabaseTab } from '@shared/databases'
+import { useStore } from '../store'
+import { addField, addRow, addView, setActiveView } from '../lib/database-cells'
+import { DatabaseTableView } from './DatabaseTableView'
+import { DatabaseBoardView } from './DatabaseBoardView'
+import { Button, IconButton } from './ui/Button'
+import { DatabaseIcon, TableIcon, KanbanIcon, PlusIcon } from './icons'
+
+/**
+ * Host for a CSV database tab: loads the database, renders the header
+ * (title + view switcher + add controls) and the active view.
+ */
+export function DatabaseView({ tabPath }: { tabPath: string }): JSX.Element {
+  const csvPath = csvPathFromDatabaseTab(tabPath)
+  const doc = useStore((s) => (csvPath ? s.databases[csvPath] : undefined))
+  const loading = useStore((s) => (csvPath ? !!s.databasesLoading[csvPath] : false))
+  const loadDatabase = useStore((s) => s.loadDatabase)
+  const updateDatabaseRows = useStore((s) => s.updateDatabaseRows)
+  const updateDatabaseSchema = useStore((s) => s.updateDatabaseSchema)
+
+  useEffect(() => {
+    if (csvPath && !doc && !loading) void loadDatabase(csvPath)
+  }, [csvPath, doc, loading, loadDatabase])
+
+  if (!csvPath) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-ink-500">
+        Invalid database.
+      </div>
+    )
+  }
+  if (!doc) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-ink-500">
+        {loading ? 'Loading database…' : 'Opening…'}
+      </div>
+    )
+  }
+
+  const activeView = doc.views.find((v) => v.id === doc.activeViewId) ?? doc.views[0]
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-paper-100 text-ink-900">
+      <header className="glass-header flex h-12 shrink-0 items-center gap-2 px-4">
+        <DatabaseIcon className="h-4 w-4 shrink-0 text-ink-500" />
+        <h2 className="truncate text-sm font-semibold text-ink-900">{doc.title}</h2>
+        <span className="shrink-0 text-xs text-ink-500">{doc.rows.length}</span>
+
+        <div className="ml-2 flex items-center gap-0.5 rounded-md bg-paper-200/60 p-0.5">
+          {doc.views.map((v) => {
+            const active = v.id === activeView.id
+            const Icon = v.type === 'board' ? KanbanIcon : TableIcon
+            return (
+              <button
+                key={v.id}
+                type="button"
+                onClick={() => updateDatabaseSchema(csvPath, setActiveView(doc, v.id))}
+                className={[
+                  'flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors',
+                  active ? 'bg-paper-50 text-ink-900 shadow-sm' : 'text-ink-500 hover:text-ink-900'
+                ].join(' ')}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {v.name}
+              </button>
+            )
+          })}
+          <IconButton
+            size="sm"
+            title="Add board view"
+            onClick={() => updateDatabaseSchema(csvPath, addView(doc, 'board'))}
+          >
+            <PlusIcon className="h-3.5 w-3.5" />
+          </IconButton>
+        </div>
+
+        <div className="ml-auto flex items-center gap-1.5">
+          <Button variant="ghost" size="sm" onClick={() => updateDatabaseSchema(csvPath, addField(doc))}>
+            <PlusIcon className="h-3.5 w-3.5" /> Field
+          </Button>
+          <Button variant="secondary" size="sm" onClick={() => updateDatabaseRows(csvPath, addRow(doc))}>
+            <PlusIcon className="h-3.5 w-3.5" /> Row
+          </Button>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {activeView.type === 'table' ? (
+          <DatabaseTableView csvPath={csvPath} doc={doc} view={activeView} />
+        ) : (
+          <DatabaseBoardView csvPath={csvPath} doc={doc} view={activeView} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/app-core/src/components/DatabaseView.tsx
+++ b/packages/app-core/src/components/DatabaseView.tsx
@@ -1,9 +1,18 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { csvPathFromDatabaseTab } from '@shared/databases'
+import { serializeRows } from '@shared/database-csv'
 import { useStore } from '../store'
-import { addField, addRow, addView, setActiveView } from '../lib/database-cells'
+import {
+  addField,
+  addRow,
+  addView,
+  setActiveView,
+  removeView,
+  renameView
+} from '../lib/database-cells'
 import { DatabaseTableView } from './DatabaseTableView'
 import { DatabaseBoardView } from './DatabaseBoardView'
+import { ContextMenu, type ContextMenuItem } from './ContextMenu'
 import { Button, IconButton } from './ui/Button'
 import { DatabaseIcon, TableIcon, KanbanIcon, PlusIcon } from './icons'
 
@@ -18,6 +27,9 @@ export function DatabaseView({ tabPath }: { tabPath: string }): JSX.Element {
   const loadDatabase = useStore((s) => s.loadDatabase)
   const updateDatabaseRows = useStore((s) => s.updateDatabaseRows)
   const updateDatabaseSchema = useStore((s) => s.updateDatabaseSchema)
+  const [viewMenu, setViewMenu] = useState<{ viewId: string; x: number; y: number } | null>(null)
+  const [renamingView, setRenamingView] = useState<string | null>(null)
+  const [rawMode, setRawMode] = useState(false)
 
   useEffect(() => {
     if (csvPath && !doc && !loading) void loadDatabase(csvPath)
@@ -40,6 +52,16 @@ export function DatabaseView({ tabPath }: { tabPath: string }): JSX.Element {
 
   const activeView = doc.views.find((v) => v.id === doc.activeViewId) ?? doc.views[0]
 
+  const viewMenuItems = (viewId: string): ContextMenuItem[] => [
+    { label: 'Rename view', onSelect: () => setRenamingView(viewId) },
+    {
+      label: 'Delete view',
+      danger: true,
+      disabled: doc.views.length <= 1,
+      onSelect: () => updateDatabaseSchema(csvPath, removeView(doc, viewId))
+    }
+  ]
+
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-paper-100 text-ink-900">
       <header className="glass-header flex h-12 shrink-0 items-center gap-2 px-4">
@@ -51,11 +73,36 @@ export function DatabaseView({ tabPath }: { tabPath: string }): JSX.Element {
           {doc.views.map((v) => {
             const active = v.id === activeView.id
             const Icon = v.type === 'board' ? KanbanIcon : TableIcon
+            if (renamingView === v.id) {
+              return (
+                <input
+                  key={v.id}
+                  autoFocus
+                  defaultValue={v.name}
+                  onFocus={(e) => e.currentTarget.select()}
+                  onBlur={(e) => {
+                    updateDatabaseSchema(csvPath, renameView(doc, v.id, e.currentTarget.value))
+                    setRenamingView(null)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') e.currentTarget.blur()
+                    else if (e.key === 'Escape') setRenamingView(null)
+                  }}
+                  className="w-24 rounded border border-accent bg-paper-50 px-1.5 py-1 text-xs text-ink-900 outline-none"
+                />
+              )
+            }
             return (
               <button
                 key={v.id}
                 type="button"
                 onClick={() => updateDatabaseSchema(csvPath, setActiveView(doc, v.id))}
+                onDoubleClick={() => setRenamingView(v.id)}
+                onContextMenu={(e) => {
+                  e.preventDefault()
+                  setViewMenu({ viewId: v.id, x: e.clientX, y: e.clientY })
+                }}
+                title="Click to switch · double-click to rename · right-click for options"
                 className={[
                   'flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors',
                   active ? 'bg-paper-50 text-ink-900 shadow-sm' : 'text-ink-500 hover:text-ink-900'
@@ -76,22 +123,55 @@ export function DatabaseView({ tabPath }: { tabPath: string }): JSX.Element {
         </div>
 
         <div className="ml-auto flex items-center gap-1.5">
-          <Button variant="ghost" size="sm" onClick={() => updateDatabaseSchema(csvPath, addField(doc))}>
-            <PlusIcon className="h-3.5 w-3.5" /> Field
+          <Button
+            variant={rawMode ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setRawMode((r) => !r)}
+            title="Toggle the underlying CSV text"
+          >
+            {rawMode ? 'Grid' : 'Raw CSV'}
           </Button>
-          <Button variant="secondary" size="sm" onClick={() => updateDatabaseRows(csvPath, addRow(doc))}>
-            <PlusIcon className="h-3.5 w-3.5" /> Row
-          </Button>
+          {!rawMode && (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => updateDatabaseSchema(csvPath, addField(doc))}
+              >
+                <PlusIcon className="h-3.5 w-3.5" /> Field
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => updateDatabaseRows(csvPath, addRow(doc))}
+              >
+                <PlusIcon className="h-3.5 w-3.5" /> Row
+              </Button>
+            </>
+          )}
         </div>
       </header>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        {activeView.type === 'table' ? (
+        {rawMode ? (
+          <pre className="h-full select-text overflow-auto whitespace-pre p-4 font-mono text-xs leading-relaxed text-ink-700">
+            {serializeRows(doc.rows, doc.fields)}
+          </pre>
+        ) : activeView.type === 'table' ? (
           <DatabaseTableView csvPath={csvPath} doc={doc} view={activeView} />
         ) : (
           <DatabaseBoardView csvPath={csvPath} doc={doc} view={activeView} />
         )}
       </div>
+
+      {viewMenu && (
+        <ContextMenu
+          x={viewMenu.x}
+          y={viewMenu.y}
+          items={viewMenuItems(viewMenu.viewId)}
+          onClose={() => setViewMenu(null)}
+        />
+      )}
     </div>
   )
 }

--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -75,12 +75,14 @@ import { CalendarPanel } from './CalendarPanel'
 import { CommentsPanel, type CommentDraft } from './CommentsPanel'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu'
 import { TasksView } from './TasksView'
+import { DatabaseView } from './DatabaseView'
 import { TagView } from './TagView'
 import { HelpView } from './HelpView'
 import { ArchiveView } from './ArchiveView'
 import { TrashView } from './TrashView'
 import { QuickNotesView } from './QuickNotesView'
 import { isTasksTabPath } from '@shared/tasks'
+import { isDatabaseTabPath, databaseTitleFromTab } from '@shared/databases'
 import { isTagsTabPath } from '@shared/tags'
 import { isHelpTabPath } from '@shared/help'
 import { isArchiveTabPath } from '@shared/archive'
@@ -2092,7 +2094,8 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
           isArchive: false,
           isTrash: false,
           isAsset: false,
-          isDiagram: false
+          isDiagram: false,
+          isDatabase: false
         }
         if (isTasksTabPath(path)) {
           return {
@@ -2149,6 +2152,13 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
             ...base,
             title: diagramTitleFromTabPath(path),
             isDiagram: true
+          }
+        }
+        if (isDatabaseTabPath(path)) {
+          return {
+            ...base,
+            title: databaseTitleFromTab(path),
+            isDatabase: true
           }
         }
         const meta = path === content?.path ? content : notes.find((n) => n.path === path)
@@ -2226,7 +2236,8 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
       isArchiveTabPath(path) ||
       isTrashTabPath(path) ||
       isAssetTabPath(path) ||
-      isDiagramTabPath(path)
+      isDiagramTabPath(path) ||
+      isDatabaseTabPath(path)
     ) {
       return [
         { label: 'Close', onSelect: async () => closeTabInPane(paneId, path) },
@@ -2921,6 +2932,8 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
             <AssetTabView tabPath={activeTab} vaultRoot={vault?.root ?? null} />
           ) : activeTab && isDiagramTabPath(activeTab) ? (
             <LazyDiagramTabView diagram={diagramFromTabPath(activeTab)} />
+          ) : activeTab && isDatabaseTabPath(activeTab) ? (
+            <DatabaseView tabPath={activeTab} />
           ) : content ? (
             <div
               className={[

--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -50,6 +50,7 @@ import {
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { resolveCodeLanguage } from '../lib/cm-code-languages'
 import { markdownListIndentPlugin } from '../lib/cm-markdown-list-indent'
+import { frontmatterStyle } from '../lib/cm-frontmatter'
 import { codeBlockFontPlugin } from '../lib/cm-code-block-font'
 import {
   orderedListRenumber,
@@ -82,7 +83,7 @@ import { ArchiveView } from './ArchiveView'
 import { TrashView } from './TrashView'
 import { QuickNotesView } from './QuickNotesView'
 import { isTasksTabPath } from '@shared/tasks'
-import { isDatabaseTabPath, databaseTitleFromTab } from '@shared/databases'
+import { isDatabaseTabPath, databaseTitleFromTab, databaseTabPath, isDatabaseCsvPath } from '@shared/databases'
 import { isTagsTabPath } from '@shared/tags'
 import { isHelpTabPath } from '@shared/help'
 import { isArchiveTabPath } from '@shared/archive'
@@ -204,6 +205,7 @@ function markdownEditingExtensions(): Extension[] {
   return [
     markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: true }),
     markdownListIndentPlugin,
+    frontmatterStyle,
     orderedListRenumber,
     headingFolding(),
     codeBlockFontPlugin
@@ -2929,7 +2931,11 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
           ) : isTrashTabPath(activeTab) ? (
             <TrashView />
           ) : activeTab && isAssetTabPath(activeTab) ? (
-            <AssetTabView tabPath={activeTab} vaultRoot={vault?.root ?? null} />
+            isDatabaseCsvPath(assetPathFromTab(activeTab) ?? '') ? (
+              <DatabaseView tabPath={databaseTabPath(assetPathFromTab(activeTab) as string)} />
+            ) : (
+              <AssetTabView tabPath={activeTab} vaultRoot={vault?.root ?? null} />
+            )
           ) : activeTab && isDiagramTabPath(activeTab) ? (
             <LazyDiagramTabView diagram={diagramFromTabPath(activeTab)} />
           ) : activeTab && isDatabaseTabPath(activeTab) ? (

--- a/packages/app-core/src/components/NoteList.tsx
+++ b/packages/app-core/src/components/NoteList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '../store'
 import type { AssetMeta, NoteMeta } from '@shared/ipc'
+import { isDatabaseCsvPath } from '@shared/databases'
 import {
   ArchiveIcon,
   ArrowUpRightIcon,
@@ -82,6 +83,7 @@ export function NoteList(): JSX.Element {
   const moveNote = useStore((s) => s.moveNote)
   const tabsEnabled = useStore((s) => s.tabsEnabled)
   const openNoteInTab = useStore((s) => s.openNoteInTab)
+  const openDatabase = useStore((s) => s.openDatabase)
   const prefetchNotes = useStore((s) => s.prefetchNotes)
   const focusedPanel = useStore((s) => s.focusedPanel)
   const noteListCursorIndex = useStore((s) => s.noteListCursorIndex)
@@ -305,6 +307,10 @@ export function NoteList(): JSX.Element {
     const abs = [root.replace(/[\\/]+$/, ''), ...asset.path.split('/').filter(Boolean)].join(sep)
     const currentDir = asset.path.split('/').slice(0, -1).join('/')
     const openAsset = async (): Promise<void> => {
+      if (isDatabaseCsvPath(asset.path)) {
+        await openDatabase(asset.path)
+        return
+      }
       await openNoteInTab(assetTabPath(asset.path))
     }
 
@@ -793,7 +799,11 @@ export function NoteList(): JSX.Element {
                       key={asset.path}
                       asset={asset}
                       vaultRoot={vault?.root ?? null}
-                      onOpen={() => void openNoteInTab(assetTabPath(asset.path))}
+                      onOpen={() =>
+                        void (isDatabaseCsvPath(asset.path)
+                          ? openDatabase(asset.path)
+                          : openNoteInTab(assetTabPath(asset.path)))
+                      }
                       onContextMenu={(e) => {
                         e.preventDefault()
                         setAssetMenu({ x: e.clientX, y: e.clientY, path: asset.path })

--- a/packages/app-core/src/components/Sidebar.tsx
+++ b/packages/app-core/src/components/Sidebar.tsx
@@ -367,6 +367,7 @@ export function Sidebar(): JSX.Element {
   const tagsViewActive = useStore(isTagsViewActive);
   const setSearchOpen = useStore((s) => s.setSearchOpen);
   const createAndOpen = useStore((s) => s.createAndOpen);
+  const createDatabase = useStore((s) => s.createDatabase);
   const createNoteInChosenFolder = useStore((s) => s.createNoteInChosenFolder);
   const openTemplatePaletteForFolder = useStore((s) => s.openTemplatePaletteForFolder);
   const quickNoteDateTitle = useStore((s) => s.quickNoteDateTitle);
@@ -1574,6 +1575,12 @@ export function Sidebar(): JSX.Element {
           openTemplatePaletteForFolder(folder, subpath);
         },
       },
+      {
+        label: "New database",
+        onSelect: async () => {
+          await createDatabase(folder, subpath);
+        },
+      },
     ];
     if (folder === "quick" && isTop) {
       items.push({
@@ -1747,6 +1754,7 @@ export function Sidebar(): JSX.Element {
     allFolders,
     vault,
     createAndOpen,
+    createDatabase,
     openTemplatePaletteForFolder,
     openArchiveView,
     openQuickNotesView,
@@ -1785,6 +1793,12 @@ export function Sidebar(): JSX.Element {
         },
       },
       {
+        label: "New database",
+        onSelect: async () => {
+          await createDatabase("inbox", "");
+        },
+      },
+      {
         label: "New folder",
         onSelect: async () => {
           const name = await promptApp({
@@ -1803,7 +1817,7 @@ export function Sidebar(): JSX.Element {
         },
       },
     ],
-    [createAndOpen, openTemplatePaletteForFolder, createFolderAction],
+    [createAndOpen, createDatabase, openTemplatePaletteForFolder, createFolderAction],
   );
 
   const noteMenuItems = useMemo<ContextMenuItem[]>(() => {

--- a/packages/app-core/src/components/VimNav.tsx
+++ b/packages/app-core/src/components/VimNav.tsx
@@ -280,6 +280,9 @@ export function VimNav(): JSX.Element | null {
       // Never steal keys from normal text-entry fields such as the
       // inline note title, prompt inputs, or textarea-based controls.
       if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      // The database/table view runs its own vim-style motion grid; yield to it
+      // so sidebar/note-list navigation doesn't steal j/k/h/l etc.
+      if (target?.closest('[data-zen-db-grid]')) return
       // CodeMirror's editor surface is contenteditable; keep global
       // hint/navigation bindings working there. Only skip other
       // unrelated contenteditable widgets.

--- a/packages/app-core/src/components/icons.tsx
+++ b/packages/app-core/src/components/icons.tsx
@@ -303,6 +303,15 @@ export const DocumentIcon = (p: IconProps): JSX.Element => (
   </I>
 )
 
+export const DocumentTextIcon = (p: IconProps): JSX.Element => (
+  <I {...p}>
+    <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8Z" />
+    <path d="M14 3v5h5" />
+    <path d="M9 13h6" />
+    <path d="M9 17h6" />
+  </I>
+)
+
 export const FileDownIcon = (p: IconProps): JSX.Element => (
   <I {...p}>
     <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8Z" />

--- a/packages/app-core/src/components/icons.tsx
+++ b/packages/app-core/src/components/icons.tsx
@@ -29,6 +29,21 @@ export const SearchIcon = (p: IconProps): JSX.Element => (
   </I>
 )
 
+export const TableIcon = (p: IconProps): JSX.Element => (
+  <I {...p}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M3 9h18M3 15h18M9 3v18" />
+  </I>
+)
+
+export const DatabaseIcon = (p: IconProps): JSX.Element => (
+  <I {...p}>
+    <ellipse cx="12" cy="5" rx="8" ry="3" />
+    <path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5" />
+    <path d="M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3" />
+  </I>
+)
+
 export const InboxIcon = (p: IconProps): JSX.Element => (
   <I {...p}>
     <path d="M4 13v5a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5" />

--- a/packages/app-core/src/lib/cm-frontmatter.ts
+++ b/packages/app-core/src/lib/cm-frontmatter.ts
@@ -1,0 +1,51 @@
+/**
+ * Render a note's leading YAML frontmatter block (the `---` … `---` at the very
+ * top) as compact, muted "properties" instead of full-size body text. This is
+ * the in-editor counterpart to how the preview hides frontmatter — and it makes
+ * database "record page" notes (whose properties live in frontmatter) read like
+ * a property list rather than a wall of big text.
+ */
+import { RangeSetBuilder } from '@codemirror/state'
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate
+} from '@codemirror/view'
+
+const FRONTMATTER_LINE = Decoration.line({ class: 'cm-frontmatter-line' })
+const FRONTMATTER_FENCE = Decoration.line({ class: 'cm-frontmatter-line cm-frontmatter-fence' })
+
+function buildFrontmatterDeco(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>()
+  const doc = view.state.doc
+  // Frontmatter must start on line 1 with an exact `---` fence.
+  if (doc.lines < 2 || doc.line(1).text.trim() !== '---') return builder.finish()
+  let endLine = -1
+  for (let i = 2; i <= doc.lines; i++) {
+    if (doc.line(i).text.trim() === '---') {
+      endLine = i
+      break
+    }
+  }
+  if (endLine === -1) return builder.finish()
+  for (let i = 1; i <= endLine; i++) {
+    const line = doc.line(i)
+    builder.add(line.from, line.from, i === 1 || i === endLine ? FRONTMATTER_FENCE : FRONTMATTER_LINE)
+  }
+  return builder.finish()
+}
+
+export const frontmatterStyle = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet
+    constructor(view: EditorView) {
+      this.decorations = buildFrontmatterDeco(view)
+    }
+    update(update: ViewUpdate): void {
+      if (update.docChanged) this.decorations = buildFrontmatterDeco(update.view)
+    }
+  },
+  { decorations: (v) => v.decorations }
+)

--- a/packages/app-core/src/lib/commands.ts
+++ b/packages/app-core/src/lib/commands.ts
@@ -103,6 +103,13 @@ export function buildCommands(options?: { includeUnavailable?: boolean }): Comma
       run: () => getState().createAndOpen('inbox', '', { focusTitle: true })
     },
     {
+      id: 'database.new',
+      title: 'New Database',
+      category: 'Note',
+      keywords: 'database table csv records spreadsheet board kanban base',
+      run: () => getState().createDatabase('inbox')
+    },
+    {
       id: 'note.daily.today',
       title: "Open Today's Daily Note",
       category: 'Note',

--- a/packages/app-core/src/lib/commands.ts
+++ b/packages/app-core/src/lib/commands.ts
@@ -107,7 +107,7 @@ export function buildCommands(options?: { includeUnavailable?: boolean }): Comma
       title: 'New Database',
       category: 'Note',
       keywords: 'database table csv records spreadsheet board kanban base',
-      run: () => getState().createDatabase('inbox')
+      run: () => getState().createDatabase('inbox', '')
     },
     {
       id: 'note.daily.today',

--- a/packages/app-core/src/lib/database-cells.ts
+++ b/packages/app-core/src/lib/database-cells.ts
@@ -39,6 +39,38 @@ export function fieldsById(doc: DatabaseDoc): Map<string, DbField> {
   return new Map(doc.fields.map((f) => [f.id, f]))
 }
 
+/** A record's display title: the first non-id field's value (fallback "Untitled"). */
+export function recordTitle(doc: DatabaseDoc, row: DbRow): string {
+  const titleField = doc.fields.find((f) => f.id !== doc.idFieldId)
+  const v = titleField ? (row.cells[titleField.id] ?? '').trim() : ''
+  return v || 'Untitled'
+}
+
+function yamlScalar(value: string): string {
+  if (value === '') return '""'
+  if (/[:#"'\n]|^\s|\s$/.test(value)) return JSON.stringify(value)
+  return value
+}
+
+/**
+ * Compose a record "page" note: the record's properties as flat YAML
+ * frontmatter followed by `body` (the freeform page). The id field and the
+ * title field are omitted — the title is the page's `# heading`, so repeating
+ * it as a `Name:` property would be redundant. Empty values render as a blank
+ * `key:` rather than `key: ""`.
+ */
+export function composePageBody(doc: DatabaseDoc, row: DbRow, body: string): string {
+  const titleFieldId = doc.fields.find((f) => f.id !== doc.idFieldId)?.id
+  const lines = ['---']
+  for (const f of doc.fields) {
+    if (f.id === doc.idFieldId || f.id === titleFieldId) continue
+    const v = row.cells[f.id] ?? ''
+    lines.push(v ? `${f.name}: ${yamlScalar(v)}` : `${f.name}:`)
+  }
+  lines.push('---')
+  return `${lines.join('\n')}\n${body.replace(/^\n+/, '')}`
+}
+
 // --- row mutations (→ updateDatabaseRows) -------------------------------
 
 export function setCell(doc: DatabaseDoc, rowId: string, fieldId: string, value: string): DatabaseDoc {
@@ -155,6 +187,19 @@ export function updateView(doc: DatabaseDoc, viewId: string, patch: Partial<DbVi
     ...doc,
     views: doc.views.map((v) => (v.id === viewId ? ({ ...v, ...patch } as DbView) : v))
   }
+}
+
+export function renameView(doc: DatabaseDoc, viewId: string, name: string): DatabaseDoc {
+  const trimmed = name.trim()
+  if (!trimmed) return doc
+  return updateView(doc, viewId, { name: trimmed })
+}
+
+export function removeView(doc: DatabaseDoc, viewId: string): DatabaseDoc {
+  if (doc.views.length <= 1) return doc // keep at least one view
+  const views = doc.views.filter((v) => v.id !== viewId)
+  const activeViewId = doc.activeViewId === viewId ? views[0].id : doc.activeViewId
+  return { ...doc, views, activeViewId }
 }
 
 export function addView(doc: DatabaseDoc, type: 'table' | 'board'): DatabaseDoc {

--- a/packages/app-core/src/lib/database-cells.ts
+++ b/packages/app-core/src/lib/database-cells.ts
@@ -1,0 +1,178 @@
+/**
+ * Renderer-side helpers for CSV databases: per-type cell display, and pure
+ * `DatabaseDoc` → `DatabaseDoc` mutations the views dispatch through the store.
+ * Rows changes go through `updateDatabaseRows`; schema/field/view changes go
+ * through `updateDatabaseSchema`. All cell values are raw CSV strings.
+ */
+import { defaultGenId } from '@shared/database-csv'
+import {
+  splitMultiSelect,
+  joinMultiSelect,
+  isCheckboxTrue
+} from '@shared/database-transforms'
+import type {
+  DatabaseDoc,
+  DbField,
+  DbRow,
+  DbView,
+  FieldType,
+  SelectOption
+} from '@shared/databases'
+
+export { splitMultiSelect, joinMultiSelect, isCheckboxTrue }
+
+const genId = defaultGenId
+
+export function formatDate(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(`${iso}T00:00:00`)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+export function optionLabel(field: DbField, value: string): string {
+  const opt = field.options?.find((o) => o.value === value)
+  return opt?.label ?? opt?.value ?? value
+}
+
+export function fieldsById(doc: DatabaseDoc): Map<string, DbField> {
+  return new Map(doc.fields.map((f) => [f.id, f]))
+}
+
+// --- row mutations (→ updateDatabaseRows) -------------------------------
+
+export function setCell(doc: DatabaseDoc, rowId: string, fieldId: string, value: string): DatabaseDoc {
+  return {
+    ...doc,
+    rows: doc.rows.map((r) => (r.id === rowId ? { ...r, cells: { ...r.cells, [fieldId]: value } } : r))
+  }
+}
+
+export function addRow(doc: DatabaseDoc): DatabaseDoc {
+  const id = genId()
+  const cells: Record<string, string> = {}
+  for (const f of doc.fields) cells[f.id] = ''
+  cells[doc.idFieldId] = id
+  const row: DbRow = { id, cells }
+  return { ...doc, rows: [...doc.rows, row] }
+}
+
+export function deleteRow(doc: DatabaseDoc, rowId: string): DatabaseDoc {
+  return { ...doc, rows: doc.rows.filter((r) => r.id !== rowId) }
+}
+
+// --- schema / view mutations (→ updateDatabaseSchema) -------------------
+
+function uniqueFieldName(doc: DatabaseDoc, base: string): string {
+  const taken = new Set(doc.fields.map((f) => f.name))
+  if (!taken.has(base)) return base
+  let n = 2
+  while (taken.has(`${base} ${n}`)) n++
+  return `${base} ${n}`
+}
+
+export function addField(doc: DatabaseDoc, type: FieldType = 'text', name = 'New field'): DatabaseDoc {
+  const field: DbField = {
+    id: genId(),
+    name: uniqueFieldName(doc, name),
+    type,
+    ...(type === 'select' || type === 'multiSelect' ? { options: [] } : {})
+  }
+  return {
+    ...doc,
+    fields: [...doc.fields, field],
+    views: doc.views.map((v) =>
+      v.type === 'table' ? { ...v, columnOrder: [...(v.columnOrder ?? doc.fields.map((f) => f.id)), field.id] } : v
+    )
+  }
+}
+
+export function renameField(doc: DatabaseDoc, fieldId: string, name: string): DatabaseDoc {
+  const trimmed = name.trim()
+  if (!trimmed) return doc
+  return {
+    ...doc,
+    fields: doc.fields.map((f) =>
+      f.id === fieldId ? { ...f, name: uniqueFieldName({ ...doc, fields: doc.fields.filter((x) => x.id !== fieldId) }, trimmed) } : f
+    )
+  }
+}
+
+export function retypeField(doc: DatabaseDoc, fieldId: string, type: FieldType): DatabaseDoc {
+  return {
+    ...doc,
+    fields: doc.fields.map((f) => {
+      if (f.id !== fieldId) return f
+      const next: DbField = { ...f, type }
+      if ((type === 'select' || type === 'multiSelect') && !next.options) next.options = []
+      return next
+    })
+  }
+}
+
+export function deleteField(doc: DatabaseDoc, fieldId: string): DatabaseDoc {
+  if (fieldId === doc.idFieldId) return doc // never delete the id field
+  return {
+    ...doc,
+    fields: doc.fields.filter((f) => f.id !== fieldId),
+    rows: doc.rows.map((r) => {
+      const { [fieldId]: _drop, ...cells } = r.cells
+      void _drop
+      return { ...r, cells }
+    }),
+    views: doc.views.map((v) => ({
+      ...v,
+      columnOrder: v.columnOrder?.filter((id) => id !== fieldId),
+      hiddenFieldIds: v.hiddenFieldIds?.filter((id) => id !== fieldId),
+      sorts: v.sorts.filter((s) => s.fieldId !== fieldId),
+      filters: v.filters.filter((f) => f.fieldId !== fieldId),
+      groupByFieldId: v.groupByFieldId === fieldId ? undefined : v.groupByFieldId
+    }))
+  }
+}
+
+export function ensureSelectOption(doc: DatabaseDoc, fieldId: string, rawValue: string): DatabaseDoc {
+  const value = rawValue.trim().replace(/,/g, ' ') // option values may not contain commas
+  if (!value) return doc
+  return {
+    ...doc,
+    fields: doc.fields.map((f) => {
+      if (f.id !== fieldId) return f
+      const options = f.options ?? []
+      if (options.some((o) => o.value === value)) return f
+      const opt: SelectOption = { id: genId(), value }
+      return { ...f, options: [...options, opt] }
+    })
+  }
+}
+
+export function setActiveView(doc: DatabaseDoc, viewId: string): DatabaseDoc {
+  return doc.views.some((v) => v.id === viewId) ? { ...doc, activeViewId: viewId } : doc
+}
+
+export function updateView(doc: DatabaseDoc, viewId: string, patch: Partial<DbView>): DatabaseDoc {
+  return {
+    ...doc,
+    views: doc.views.map((v) => (v.id === viewId ? ({ ...v, ...patch } as DbView) : v))
+  }
+}
+
+export function addView(doc: DatabaseDoc, type: 'table' | 'board'): DatabaseDoc {
+  const id = genId()
+  const base = { id, name: type === 'board' ? 'Board' : 'Table', filters: [], sorts: [] }
+  const view: DbView =
+    type === 'board'
+      ? {
+          ...base,
+          type: 'board',
+          groupByFieldId: doc.fields.find((f) => f.type === 'select')?.id,
+          cardFieldIds: doc.fields.filter((f) => f.id !== doc.idFieldId).map((f) => f.id)
+        }
+      : {
+          ...base,
+          type: 'table',
+          columnOrder: doc.fields.map((f) => f.id),
+          hiddenFieldIds: doc.fields.filter((f) => f.hidden).map((f) => f.id)
+        }
+  return { ...doc, views: [...doc.views, view], activeViewId: id }
+}

--- a/packages/app-core/src/lib/workspace-tabs.ts
+++ b/packages/app-core/src/lib/workspace-tabs.ts
@@ -4,6 +4,7 @@ import { isQuickNotesTabPath } from '@shared/quick-notes'
 import { isTagsTabPath } from '@shared/tags'
 import { isTasksTabPath } from '@shared/tasks'
 import { isTrashTabPath } from '@shared/trash'
+import { isDatabaseTabPath } from '@shared/databases'
 import { isAssetTabPath } from './asset-tabs'
 import { isDiagramTabPath } from './diagram-tabs'
 import { allLeaves, type PaneLayout } from './pane-layout'
@@ -17,7 +18,8 @@ export function isWorkspaceVirtualTabPath(path: string): boolean {
     isArchiveTabPath(path) ||
     isTrashTabPath(path) ||
     isAssetTabPath(path) ||
-    isDiagramTabPath(path)
+    isDiagramTabPath(path) ||
+    isDatabaseTabPath(path)
   )
 }
 

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -23,6 +23,8 @@ import type {
 } from '@shared/ipc'
 import type { VaultTask } from '@shared/tasks'
 import { TASKS_TAB_PATH, isTasksTabPath } from '@shared/tasks'
+import type { DatabaseDoc, DatabaseSidecar } from '@shared/databases'
+import { databaseTabPath } from '@shared/databases'
 import { TAGS_TAB_PATH, isTagsTabPath } from '@shared/tags'
 import { HELP_TAB_PATH, isHelpTabPath } from '@shared/help'
 import { ARCHIVE_TAB_PATH, isArchiveTabPath } from '@shared/archive'
@@ -1533,6 +1535,11 @@ interface Store {
   /** First-of-month anchor (ISO YYYY-MM-01) for the Calendar view's grid. */
   tasksCalendarMonthAnchor: string | null
 
+  /** Hydrated CSV databases keyed by their vault-relative `.csv` path. */
+  databases: Record<string, DatabaseDoc>
+  /** In-flight load flags keyed by `.csv` path. */
+  databasesLoading: Record<string, boolean>
+
   /** Tags currently selected in the Tags view. The view shows every non-
    *  trash note carrying *any* of these (union), so toggling more tags
    *  widens the result set. Cleared when the Tags tab closes. */
@@ -1587,6 +1594,18 @@ interface Store {
   openArchiveView: () => Promise<void>
   /** Open the built-in Trash tab in the active pane. */
   openTrashView: () => Promise<void>
+  /** Read a CSV database (CSV + sidecar) into `databases` if not already loaded. */
+  loadDatabase: (csvPath: string) => Promise<void>
+  /** Load a database and open it as a tab in the active pane. */
+  openDatabase: (csvPath: string) => Promise<void>
+  /** Create a new empty database and open it. */
+  createDatabase: (folder: NoteFolder, title?: string) => Promise<void>
+  /** Optimistically replace a database's rows and debounce-persist the CSV. */
+  updateDatabaseRows: (csvPath: string, next: DatabaseDoc) => void
+  /** Optimistically replace a database's schema/views and debounce-persist sidecar + CSV. */
+  updateDatabaseSchema: (csvPath: string, next: DatabaseDoc) => void
+  /** Re-read a database from disk after an external change (skips our own write echoes). */
+  syncDatabaseFromDisk: (csvPath: string) => Promise<void>
   /** Add or remove a tag from the Tags view selection without touching
    *  pane layout. No-op if the selection is already in that state. */
   toggleTagSelection: (tag: string) => void
@@ -1890,6 +1909,53 @@ const PATH_SAVE_DEBOUNCE_MS = 350
  * completion and echo arrival get rolled back to the older disk body.
  */
 const lastWrittenByPath = new Map<string, string>()
+
+// --- CSV database debounced persistence + echo suppression ---
+const DATABASE_SAVE_DEBOUNCE_MS = 400
+const databaseSaveTimers = new Map<string, ReturnType<typeof setTimeout>>()
+/** A pending write that touched the schema must persist the sidecar too. */
+const databaseWriteKind = new Map<string, 'rows' | 'schema'>()
+/** When we last wrote a database; used to ignore the watcher echo of our own write. */
+const lastDatabaseWriteAt = new Map<string, number>()
+
+function databaseToSidecar(doc: DatabaseDoc): DatabaseSidecar {
+  return {
+    version: 1,
+    idFieldId: doc.idFieldId,
+    fields: doc.fields,
+    views: doc.views,
+    activeViewId: doc.activeViewId
+  }
+}
+
+function scheduleDatabaseWrite(
+  csvPath: string,
+  kind: 'rows' | 'schema',
+  getDoc: () => DatabaseDoc | undefined
+): void {
+  const prev = databaseWriteKind.get(csvPath)
+  databaseWriteKind.set(csvPath, kind === 'schema' || prev === 'schema' ? 'schema' : 'rows')
+  const existing = databaseSaveTimers.get(csvPath)
+  if (existing) clearTimeout(existing)
+  databaseSaveTimers.set(
+    csvPath,
+    setTimeout(() => {
+      databaseSaveTimers.delete(csvPath)
+      const writeKind = databaseWriteKind.get(csvPath) ?? 'rows'
+      databaseWriteKind.delete(csvPath)
+      const doc = getDoc()
+      if (!doc) return
+      const done = (): void => {
+        lastDatabaseWriteAt.set(csvPath, Date.now())
+      }
+      const write =
+        writeKind === 'schema'
+          ? window.zen.writeDatabaseSchema(csvPath, databaseToSidecar(doc), doc.rows)
+          : window.zen.writeDatabaseRows(csvPath, doc.rows)
+      void write.catch((err) => console.error('database write failed', err)).finally(done)
+    }, DATABASE_SAVE_DEBOUNCE_MS)
+  )
+}
 
 function normalizeServerBaseUrl(value: string): string {
   const trimmed = value.trim()
@@ -2617,6 +2683,8 @@ export const useStore = create<Store>((set, get) => {
   taskCursorIndex: 0,
   tasksCalendarSelectedDate: null,
   tasksCalendarMonthAnchor: null,
+  databases: {},
+  databasesLoading: {},
   selectedTags: [],
   focusedPanel: null,
   sidebarCursorIndex: 0,
@@ -2753,6 +2821,56 @@ export const useStore = create<Store>((set, get) => {
     await get().openNoteInPane(state.activePaneId, TRASH_TAB_PATH)
     ;(document.activeElement as HTMLElement | null)?.blur?.()
     set({ focusedPanel: 'editor' })
+  },
+  loadDatabase: async (csvPath) => {
+    if (get().databasesLoading[csvPath]) return
+    set((s) => ({ databasesLoading: { ...s.databasesLoading, [csvPath]: true } }))
+    try {
+      const doc = await window.zen.openDatabase(csvPath)
+      set((s) => ({ databases: { ...s.databases, [csvPath]: doc } }))
+    } catch (err) {
+      console.error('loadDatabase failed', err)
+    } finally {
+      set((s) => ({ databasesLoading: { ...s.databasesLoading, [csvPath]: false } }))
+    }
+  },
+  openDatabase: async (csvPath) => {
+    await get().loadDatabase(csvPath)
+    await get().openNoteInPane(get().activePaneId, databaseTabPath(csvPath))
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+    set({ focusedPanel: 'editor' })
+  },
+  createDatabase: async (folder, title) => {
+    try {
+      const doc = await window.zen.createDatabase(folder, title)
+      set((s) => ({ databases: { ...s.databases, [doc.path]: doc } }))
+      await get().openNoteInPane(get().activePaneId, databaseTabPath(doc.path))
+      ;(document.activeElement as HTMLElement | null)?.blur?.()
+      set({ focusedPanel: 'editor' })
+    } catch (err) {
+      console.error('createDatabase failed', err)
+    }
+  },
+  updateDatabaseRows: (csvPath, next) => {
+    set((s) => ({ databases: { ...s.databases, [csvPath]: next } }))
+    scheduleDatabaseWrite(csvPath, 'rows', () => get().databases[csvPath])
+  },
+  updateDatabaseSchema: (csvPath, next) => {
+    set((s) => ({ databases: { ...s.databases, [csvPath]: next } }))
+    scheduleDatabaseWrite(csvPath, 'schema', () => get().databases[csvPath])
+  },
+  syncDatabaseFromDisk: async (csvPath) => {
+    if (!get().databases[csvPath]) return
+    // Ignore the watcher echo of a write we just made.
+    if (Date.now() - (lastDatabaseWriteAt.get(csvPath) ?? 0) < 1500) return
+    // Don't clobber edits that are still mid-debounce.
+    if (databaseSaveTimers.has(csvPath)) return
+    try {
+      const doc = await window.zen.openDatabase(csvPath)
+      set((s) => (s.databases[csvPath] ? { databases: { ...s.databases, [csvPath]: doc } } : {}))
+    } catch (err) {
+      console.error('syncDatabaseFromDisk failed', err)
+    }
   },
 
   toggleTagSelection: (tag) => {
@@ -3213,6 +3331,10 @@ export const useStore = create<Store>((set, get) => {
   applyChange: async (ev) => {
     if (ev.scope === 'comments') {
       await get().loadNoteComments(ev.path)
+      return
+    }
+    if (ev.scope === 'database') {
+      await get().syncDatabaseFromDisk(ev.path)
       return
     }
     const pathIsMarkdown = ev.path.toLowerCase().endsWith('.md')

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -24,7 +24,9 @@ import type {
 import type { VaultTask } from '@shared/tasks'
 import { TASKS_TAB_PATH, isTasksTabPath } from '@shared/tasks'
 import type { DatabaseDoc, DatabaseSidecar } from '@shared/databases'
-import { databaseTabPath } from '@shared/databases'
+import { databaseTabPath, isDatabaseInternalPath } from '@shared/databases'
+import { parseFrontmatter } from '@shared/template-files'
+import { recordTitle, composePageBody } from './lib/database-cells'
 import { TAGS_TAB_PATH, isTagsTabPath } from '@shared/tags'
 import { HELP_TAB_PATH, isHelpTabPath } from '@shared/help'
 import { ARCHIVE_TAB_PATH, isArchiveTabPath } from '@shared/archive'
@@ -1598,14 +1600,18 @@ interface Store {
   loadDatabase: (csvPath: string) => Promise<void>
   /** Load a database and open it as a tab in the active pane. */
   openDatabase: (csvPath: string) => Promise<void>
-  /** Create a new empty database and open it. */
-  createDatabase: (folder: NoteFolder, title?: string) => Promise<void>
+  /** Create a new empty database under `folder`/`subpath` and open it. */
+  createDatabase: (folder: NoteFolder, subpath?: string, title?: string) => Promise<void>
   /** Optimistically replace a database's rows and debounce-persist the CSV. */
   updateDatabaseRows: (csvPath: string, next: DatabaseDoc) => void
   /** Optimistically replace a database's schema/views and debounce-persist sidecar + CSV. */
   updateDatabaseSchema: (csvPath: string, next: DatabaseDoc) => void
   /** Re-read a database from disk after an external change (skips our own write echoes). */
   syncDatabaseFromDisk: (csvPath: string) => Promise<void>
+  /** Open a record as a markdown "page" note (creating + linking it on first open). */
+  openRecordPage: (csvPath: string, rowId: string) => Promise<void>
+  /** Rename a record's linked page note to match its title (no-op if unlinked). */
+  renameRecordPage: (csvPath: string, rowId: string) => Promise<void>
   /** Add or remove a tag from the Tags view selection without touching
    *  pane layout. No-op if the selection is already in that state. */
   toggleTagSelection: (tag: string) => void
@@ -1924,7 +1930,8 @@ function databaseToSidecar(doc: DatabaseDoc): DatabaseSidecar {
     idFieldId: doc.idFieldId,
     fields: doc.fields,
     views: doc.views,
-    activeViewId: doc.activeViewId
+    activeViewId: doc.activeViewId,
+    ...(doc.pages ? { pages: doc.pages } : {})
   }
 }
 
@@ -2840,9 +2847,9 @@ export const useStore = create<Store>((set, get) => {
     ;(document.activeElement as HTMLElement | null)?.blur?.()
     set({ focusedPanel: 'editor' })
   },
-  createDatabase: async (folder, title) => {
+  createDatabase: async (folder, subpath = '', title) => {
     try {
-      const doc = await window.zen.createDatabase(folder, title)
+      const doc = await window.zen.createDatabase(folder, subpath, title)
       set((s) => ({ databases: { ...s.databases, [doc.path]: doc } }))
       await get().openNoteInPane(get().activePaneId, databaseTabPath(doc.path))
       ;(document.activeElement as HTMLElement | null)?.blur?.()
@@ -2870,6 +2877,63 @@ export const useStore = create<Store>((set, get) => {
       set((s) => (s.databases[csvPath] ? { databases: { ...s.databases, [csvPath]: doc } } : {}))
     } catch (err) {
       console.error('syncDatabaseFromDisk failed', err)
+    }
+  },
+  openRecordPage: async (csvPath, rowId) => {
+    const doc = get().databases[csvPath]
+    if (!doc) return
+    const row = doc.rows.find((r) => r.id === rowId)
+    if (!row) return
+    let pagePath = doc.pages?.[rowId]
+    if (pagePath) {
+      // Confirm the linked note still exists; otherwise recreate-and-relink.
+      try {
+        await window.zen.readNote(pagePath)
+      } catch {
+        pagePath = undefined
+      }
+    }
+    if (!pagePath) {
+      try {
+        const body = composePageBody(doc, row, `# ${recordTitle(doc, row)}\n\n`)
+        pagePath = await window.zen.createRecordPage(csvPath, recordTitle(doc, row), body)
+        get().updateDatabaseSchema(csvPath, {
+          ...doc,
+          pages: { ...(doc.pages ?? {}), [rowId]: pagePath },
+          pageHasContent: { ...(doc.pageHasContent ?? {}), [rowId]: false }
+        })
+      } catch (err) {
+        console.error('createRecordPage failed', err)
+        return
+      }
+    } else {
+      // Re-mirror current properties into the note's frontmatter, keep the body.
+      try {
+        const note = await window.zen.readNote(pagePath)
+        const { body } = parseFrontmatter(note.body)
+        await window.zen.writeNote(pagePath, composePageBody(doc, row, body))
+      } catch (err) {
+        console.error('refresh record page failed', err)
+      }
+    }
+    await get().selectNote(pagePath)
+  },
+  renameRecordPage: async (csvPath, rowId) => {
+    const doc = get().databases[csvPath]
+    const pagePath = doc?.pages?.[rowId]
+    if (!doc || !pagePath) return
+    const row = doc.rows.find((r) => r.id === rowId)
+    if (!row) return
+    try {
+      const meta = await window.zen.renameNote(pagePath, recordTitle(doc, row))
+      if (meta.path !== pagePath) {
+        get().updateDatabaseSchema(csvPath, {
+          ...get().databases[csvPath]!,
+          pages: { ...(get().databases[csvPath]!.pages ?? {}), [rowId]: meta.path }
+        })
+      }
+    } catch (err) {
+      console.error('renameRecordPage failed', err)
     }
   },
 
@@ -3268,10 +3332,13 @@ export const useStore = create<Store>((set, get) => {
   refreshAssets: async () => {
     try {
       const startedAt = performance.now()
-      const [assetFiles, hasAssetsDirOnDisk] = await Promise.all([
+      const [rawAssets, hasAssetsDirOnDisk] = await Promise.all([
         window.zen.listAssets(),
         window.zen.hasAssetsDir()
       ])
+      // Hide database internals (sidecar + .bak backups) — they're not
+      // standalone files the user manages.
+      const assetFiles = rawAssets.filter((a) => !isDatabaseInternalPath(a.path))
       set({
         assetFiles,
         hasAssetsDir: hasAssetsDirOnDisk || assetFiles.length > 0
@@ -3335,6 +3402,8 @@ export const useStore = create<Store>((set, get) => {
     }
     if (ev.scope === 'database') {
       await get().syncDatabaseFromDisk(ev.path)
+      // Surface a newly-created (or removed) .csv in the note list.
+      if (ev.kind !== 'change') await get().refreshAssets()
       return
     }
     const pathIsMarkdown = ev.path.toLowerCase().endsWith('.md')
@@ -3358,6 +3427,15 @@ export const useStore = create<Store>((set, get) => {
     const state = get()
 
     if (ev.scope === 'vault-settings') return
+
+    // A record "page" note changed on disk — re-sync any open database that
+    // links to it so the Table's page icon (empty vs has-content) updates. The
+    // page note needn't be open in a pane; the database tab is what shows it.
+    for (const [csvPath, dbDoc] of Object.entries(state.databases)) {
+      if (dbDoc.pages && Object.values(dbDoc.pages).includes(ev.path)) {
+        void get().syncDatabaseFromDisk(csvPath)
+      }
+    }
 
     // Keep an open Tasks tab in sync as files change externally or via our own
     // writes — cheap per-path rescans instead of walking the whole vault. This

--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -1656,6 +1656,21 @@ textarea,
 .cm-editor .tok-meta {
   color: rgb(var(--z-fg));
 }
+
+/* Leading YAML frontmatter — render as compact, muted "properties" (see
+ * cm-frontmatter.ts) instead of full-size body text. */
+.cm-editor .cm-frontmatter-line {
+  font-size: 0.8em;
+  line-height: 1.55;
+  color: rgb(var(--z-grey-1));
+  background: rgb(var(--z-bg-1) / 0.35);
+}
+.cm-editor .cm-frontmatter-line :is(.tok-meta, .tok-string, .tok-keyword, .tok-atom) {
+  color: inherit;
+}
+.cm-editor .cm-frontmatter-fence {
+  color: rgb(var(--z-grey-0) / 0.5);
+}
 .cm-editor .tok-heading,
 .cm-editor .tok-heading1,
 .cm-editor .tok-heading2,

--- a/packages/bridge-contract/src/bridge.ts
+++ b/packages/bridge-contract/src/bridge.ts
@@ -36,6 +36,12 @@ import type {
 import type { CustomTemplateFile, WriteTemplateInput } from './templates'
 import type { VaultTask } from '@zennotes/shared-domain/tasks'
 import type {
+  DatabaseDoc,
+  DatabaseSidecar,
+  DatabaseSummary,
+  DbRow
+} from '@zennotes/shared-domain/databases'
+import type {
   McpClientId,
   McpClientStatus,
   McpInstructionsPayload,
@@ -129,6 +135,11 @@ export interface ZenBridge {
   writeNoteComments(relPath: string, comments: NoteCommentInput[]): Promise<NoteComment[]>
   scanTasks(): Promise<VaultTask[]>
   scanTasksForPath(relPath: string): Promise<VaultTask[]>
+  openDatabase(relPath: string): Promise<DatabaseDoc>
+  writeDatabaseRows(relPath: string, rows: DbRow[]): Promise<DatabaseDoc>
+  writeDatabaseSchema(relPath: string, sidecar: DatabaseSidecar, rows: DbRow[]): Promise<DatabaseDoc>
+  createDatabase(folder: string, title?: string): Promise<DatabaseDoc>
+  listDatabases(): Promise<DatabaseSummary[]>
   writeNote(relPath: string, body: string): Promise<NoteMeta>
   appendToNote(relPath: string, body: string, position: 'start' | 'end'): Promise<NoteMeta>
   createNote(folder: NoteFolder, title?: string, subpath?: string): Promise<NoteMeta>

--- a/packages/bridge-contract/src/bridge.ts
+++ b/packages/bridge-contract/src/bridge.ts
@@ -138,7 +138,9 @@ export interface ZenBridge {
   openDatabase(relPath: string): Promise<DatabaseDoc>
   writeDatabaseRows(relPath: string, rows: DbRow[]): Promise<DatabaseDoc>
   writeDatabaseSchema(relPath: string, sidecar: DatabaseSidecar, rows: DbRow[]): Promise<DatabaseDoc>
-  createDatabase(folder: string, title?: string): Promise<DatabaseDoc>
+  createDatabase(folder: NoteFolder, subpath: string, title?: string): Promise<DatabaseDoc>
+  /** Create a record's "page" note (returns its vault-relative path). */
+  createRecordPage(csvPath: string, title: string, body: string): Promise<string>
   listDatabases(): Promise<DatabaseSummary[]>
   writeNote(relPath: string, body: string): Promise<NoteMeta>
   appendToNote(relPath: string, body: string, position: 'start' | 'end'): Promise<NoteMeta>

--- a/packages/bridge-contract/src/ipc.ts
+++ b/packages/bridge-contract/src/ipc.ts
@@ -65,6 +65,11 @@ export const IPC = {
   VAULT_REVEAL_ASSETS_DIR: 'vault:reveal-assets-dir',
   VAULT_SCAN_TASKS: 'vault:scan-tasks',
   VAULT_SCAN_TASKS_FOR: 'vault:scan-tasks-for',
+  VAULT_OPEN_DATABASE: 'vault:open-database',
+  VAULT_WRITE_DATABASE_ROWS: 'vault:write-database-rows',
+  VAULT_WRITE_DATABASE_SCHEMA: 'vault:write-database-schema',
+  VAULT_CREATE_DATABASE: 'vault:create-database',
+  VAULT_LIST_DATABASES: 'vault:list-databases',
   APP_LIST_FONTS: 'app:list-fonts',
   APP_ICON_DATA_URL: 'app:icon-data-url',
   APP_OPEN_SETTINGS: 'app:open-settings',
@@ -522,7 +527,7 @@ export interface FolderEntry {
 }
 
 export type VaultChangeKind = 'add' | 'change' | 'unlink'
-export type VaultChangeScope = 'content' | 'vault-settings' | 'comments'
+export type VaultChangeScope = 'content' | 'vault-settings' | 'comments' | 'database'
 
 export interface VaultChangeEvent {
   kind: VaultChangeKind

--- a/packages/bridge-contract/src/ipc.ts
+++ b/packages/bridge-contract/src/ipc.ts
@@ -69,6 +69,7 @@ export const IPC = {
   VAULT_WRITE_DATABASE_ROWS: 'vault:write-database-rows',
   VAULT_WRITE_DATABASE_SCHEMA: 'vault:write-database-schema',
   VAULT_CREATE_DATABASE: 'vault:create-database',
+  VAULT_CREATE_RECORD_PAGE: 'vault:create-record-page',
   VAULT_LIST_DATABASES: 'vault:list-databases',
   APP_LIST_FONTS: 'app:list-fonts',
   APP_ICON_DATA_URL: 'app:icon-data-url',

--- a/packages/shared-domain/src/database-csv.ts
+++ b/packages/shared-domain/src/database-csv.ts
@@ -1,0 +1,248 @@
+/**
+ * Pure CSV (de)serialization + schema inference for the Databases feature.
+ *
+ * Hand-rolled RFC-4180 parser/serializer (no dependency) so `shared-domain`
+ * stays dependency-free. Round-trip fidelity (embedded commas, double-quotes,
+ * newlines, CRLF) is covered by unit tests. `multiSelect` uses a second layer
+ * of encoding inside a single cell ("a, b") — option values therefore may not
+ * contain commas (enforced when options are created).
+ */
+import type { DbField, DbRow, DbView, FieldType } from './databases'
+import { DEFAULT_ID_FIELD_NAME } from './databases'
+
+/** Injectable id factory (main passes node's randomUUID; tests pass a counter). */
+export type GenId = () => string
+
+export const defaultGenId: GenId = () => {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto
+  if (c?.randomUUID) return c.randomUUID()
+  return `r-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`
+}
+
+// ---------------------------------------------------------------------------
+// Low-level RFC-4180 CSV
+// ---------------------------------------------------------------------------
+
+/** Parse CSV text into a grid of string cells. Blank lines are dropped. */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+  let i = text.charCodeAt(0) === 0xfeff ? 1 : 0 // strip BOM
+  const n = text.length
+
+  const endField = (): void => {
+    row.push(field)
+    field = ''
+  }
+  const endRow = (): void => {
+    endField()
+    // Drop blank lines (a single empty field).
+    if (!(row.length === 1 && row[0] === '')) rows.push(row)
+    row = []
+  }
+
+  while (i < n) {
+    const ch = text[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"'
+          i += 2
+          continue
+        }
+        inQuotes = false
+        i++
+        continue
+      }
+      field += ch
+      i++
+      continue
+    }
+    if (ch === '"') {
+      inQuotes = true
+      i++
+    } else if (ch === ',') {
+      endField()
+      i++
+    } else if (ch === '\r') {
+      endRow()
+      i += text[i + 1] === '\n' ? 2 : 1
+    } else if (ch === '\n') {
+      endRow()
+      i++
+    } else {
+      field += ch
+      i++
+    }
+  }
+  // Flush trailing field/row unless the text ended exactly on a row boundary.
+  if (field !== '' || row.length > 0) endRow()
+  return rows
+}
+
+function serializeCell(value: string): string {
+  if (value === '') return ''
+  if (/[",\r\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`
+  return value
+}
+
+/** Serialize a grid to RFC-4180 CSV text (LF newlines, trailing newline). */
+export function serializeCsv(rows: string[][]): string {
+  if (rows.length === 0) return ''
+  return `${rows.map((r) => r.map(serializeCell).join(',')).join('\n')}\n`
+}
+
+// ---------------------------------------------------------------------------
+// Schema-aware rows
+// ---------------------------------------------------------------------------
+
+/**
+ * Hydrate rows from CSV text given the known fields. Columns are matched to
+ * fields by header NAME (robust to external column reordering). Rows missing an
+ * id cell get a fresh UUID. Returns rows keyed by field.id.
+ */
+export function parseRows(
+  csvText: string,
+  fields: DbField[],
+  idFieldId: string,
+  genId: GenId = defaultGenId
+): DbRow[] {
+  const grid = parseCsv(csvText)
+  if (grid.length === 0) return []
+  const headers = grid[0]
+  // header name -> column index
+  const colByName = new Map<string, number>()
+  headers.forEach((h, idx) => {
+    if (!colByName.has(h)) colByName.set(h, idx)
+  })
+  const idField = fields.find((f) => f.id === idFieldId)
+
+  const out: DbRow[] = []
+  for (let r = 1; r < grid.length; r++) {
+    const raw = grid[r]
+    const cells: Record<string, string> = {}
+    for (const field of fields) {
+      const col = colByName.get(field.name)
+      cells[field.id] = col === undefined ? '' : (raw[col] ?? '')
+    }
+    let id = idField ? cells[idField.id] : ''
+    if (!id) {
+      id = genId()
+      if (idField) cells[idField.id] = id
+    }
+    out.push({ id, cells })
+  }
+  return out
+}
+
+/** Serialize rows back to CSV text (header from field.name in field order). */
+export function serializeRows(rows: DbRow[], fields: DbField[]): string {
+  const header = fields.map((f) => f.name)
+  const body = rows.map((row) => fields.map((f) => row.cells[f.id] ?? ''))
+  return serializeCsv([header, ...body])
+}
+
+// ---------------------------------------------------------------------------
+// Inference (opening a CSV that has no sidecar yet)
+// ---------------------------------------------------------------------------
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const BOOL_TRUE = new Set(['true', 'x', '1', 'yes', 'checked'])
+const BOOL_FALSE = new Set(['false', '', '0', 'no', 'unchecked'])
+
+function isValidIsoDate(s: string): boolean {
+  if (!ISO_DATE_RE.test(s)) return false
+  const d = new Date(`${s}T00:00:00Z`)
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s
+}
+
+function inferColumnType(samples: string[]): FieldType {
+  const nonEmpty = samples.map((s) => s.trim()).filter((s) => s.length > 0)
+  if (nonEmpty.length === 0) return 'text'
+  if (nonEmpty.every((s) => BOOL_TRUE.has(s.toLowerCase()) || BOOL_FALSE.has(s.toLowerCase())))
+    return 'checkbox'
+  if (nonEmpty.every((s) => s !== '' && Number.isFinite(Number(s)))) return 'number'
+  if (nonEmpty.every((s) => isValidIsoDate(s))) return 'date'
+  return 'text'
+  // select/multiSelect are never auto-inferred — they require user intent
+  // (promote a low-cardinality text column to select in the UI).
+}
+
+function dedupeHeader(name: string, used: Set<string>, index: number): string {
+  let base = name.trim() || `Column ${index + 1}`
+  let candidate = base
+  let n = 2
+  while (used.has(candidate)) candidate = `${base} (${n++})`
+  used.add(candidate)
+  return candidate
+}
+
+export interface InferredSchema {
+  idFieldId: string
+  fields: DbField[]
+}
+
+/**
+ * Infer fields + the id field from a header row and sample data rows. If a
+ * usable `id` column exists (all-unique, non-empty) it becomes the id field;
+ * otherwise a leading `id` field is synthesized.
+ */
+export function inferFields(
+  headers: string[],
+  sampleRows: string[][],
+  genId: GenId = defaultGenId
+): InferredSchema {
+  const usedNames = new Set<string>()
+  const normalizedHeaders = headers.map((h, i) => dedupeHeader(h, usedNames, i))
+
+  // Detect a usable id column.
+  let idColIndex = -1
+  const idHeaderIdx = normalizedHeaders.findIndex((h) => h.toLowerCase() === DEFAULT_ID_FIELD_NAME)
+  if (idHeaderIdx >= 0) {
+    const values = sampleRows.map((r) => r[idHeaderIdx] ?? '')
+    const allPresent = values.length > 0 && values.every((v) => v.trim().length > 0)
+    const unique = new Set(values).size === values.length
+    if (sampleRows.length === 0 || (allPresent && unique)) idColIndex = idHeaderIdx
+  }
+
+  const fields: DbField[] = normalizedHeaders.map((name, i) => ({
+    id: genId(),
+    name,
+    type:
+      i === idColIndex
+        ? 'text'
+        : inferColumnType(sampleRows.map((r) => r[i] ?? ''))
+  }))
+
+  let idFieldId: string
+  if (idColIndex >= 0) {
+    idFieldId = fields[idColIndex].id
+    fields[idColIndex].hidden = true
+  } else {
+    // Synthesize a leading id field.
+    const idField: DbField = { id: genId(), name: DEFAULT_ID_FIELD_NAME, type: 'text', hidden: true }
+    fields.unshift(idField)
+    idFieldId = idField.id
+  }
+  return { idFieldId, fields }
+}
+
+/** A single default Table view (id hidden) covering all fields in order. */
+export function buildDefaultViews(
+  fields: DbField[],
+  genId: GenId = defaultGenId
+): { views: DbView[]; activeViewId: string } {
+  const id = genId()
+  const view: DbView = {
+    id,
+    name: 'Table',
+    type: 'table',
+    filters: [],
+    sorts: [],
+    columnOrder: fields.map((f) => f.id),
+    hiddenFieldIds: fields.filter((f) => f.hidden).map((f) => f.id)
+  }
+  return { views: [view], activeViewId: id }
+}

--- a/packages/shared-domain/src/database-transforms.ts
+++ b/packages/shared-domain/src/database-transforms.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure, type-aware filter / sort / group transforms over database rows.
+ * Reused by both the Table view (filter + sort) and the Board view (group-by).
+ */
+import type { DbField, DbRow, FilterRule, SortRule } from './databases'
+import { EMPTY_GROUP } from './databases'
+
+const MULTISELECT_SEP = ', '
+
+/** Split a multiSelect cell ("a, b") into values. Option values never contain commas. */
+export function splitMultiSelect(cell: string): string[] {
+  return cell
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+export function joinMultiSelect(values: string[]): string {
+  return values.join(MULTISELECT_SEP)
+}
+
+const TRUE_VALUES = new Set(['true', 'x', '1', 'yes', 'checked'])
+export function isCheckboxTrue(cell: string): boolean {
+  return TRUE_VALUES.has(cell.trim().toLowerCase())
+}
+
+function cell(row: DbRow, fieldId: string): string {
+  return row.cells[fieldId] ?? ''
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+function matchesRule(row: DbRow, rule: FilterRule, field: DbField | undefined): boolean {
+  if (!field) return true
+  const raw = cell(row, field.id)
+  const v = raw.trim()
+  const target = (rule.value ?? '').trim()
+  switch (rule.op) {
+    case 'is':
+      if (field.type === 'multiSelect') return splitMultiSelect(raw).includes(target)
+      return v.toLowerCase() === target.toLowerCase()
+    case 'isNot':
+      if (field.type === 'multiSelect') return !splitMultiSelect(raw).includes(target)
+      return v.toLowerCase() !== target.toLowerCase()
+    case 'contains':
+      return v.toLowerCase().includes(target.toLowerCase())
+    case 'notContains':
+      return !v.toLowerCase().includes(target.toLowerCase())
+    case 'isEmpty':
+      return v.length === 0
+    case 'isNotEmpty':
+      return v.length > 0
+    case 'gt':
+      return Number(v) > Number(target)
+    case 'lt':
+      return Number(v) < Number(target)
+    case 'before':
+      return v.length > 0 && v < target
+    case 'after':
+      return v.length > 0 && v > target
+    case 'checked':
+      return isCheckboxTrue(raw)
+    case 'unchecked':
+      return !isCheckboxTrue(raw)
+    default:
+      return true
+  }
+}
+
+export function filterRows(
+  rows: DbRow[],
+  filters: FilterRule[] | undefined,
+  fieldsById: Map<string, DbField>
+): DbRow[] {
+  if (!filters || filters.length === 0) return rows
+  // All rules AND together (MVP).
+  return rows.filter((row) => filters.every((rule) => matchesRule(row, rule, fieldsById.get(rule.fieldId))))
+}
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+function compareByField(a: DbRow, b: DbRow, field: DbField): number {
+  const av = cell(a, field.id).trim()
+  const bv = cell(b, field.id).trim()
+  // Empty values always sort last (regardless of direction is applied by caller).
+  if (av === '' && bv === '') return 0
+  if (av === '') return 1
+  if (bv === '') return -1
+  switch (field.type) {
+    case 'number': {
+      const na = Number(av)
+      const nb = Number(bv)
+      if (Number.isNaN(na) || Number.isNaN(nb)) return av.localeCompare(bv)
+      return na - nb
+    }
+    case 'checkbox':
+      return Number(isCheckboxTrue(av)) - Number(isCheckboxTrue(bv))
+    case 'date':
+      // ISO YYYY-MM-DD sorts correctly lexically.
+      return av < bv ? -1 : av > bv ? 1 : 0
+    default:
+      return av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' })
+  }
+}
+
+export function sortRows(
+  rows: DbRow[],
+  sorts: SortRule[] | undefined,
+  fieldsById: Map<string, DbField>
+): DbRow[] {
+  if (!sorts || sorts.length === 0) return rows
+  const decorated = rows.map((row, index) => ({ row, index }))
+  decorated.sort((a, b) => {
+    for (const sort of sorts) {
+      const field = fieldsById.get(sort.fieldId)
+      if (!field) continue
+      const cmp = compareByField(a.row, b.row, field)
+      if (cmp !== 0) return sort.direction === 'desc' ? -cmp : cmp
+    }
+    return a.index - b.index // stable tie-break
+  })
+  return decorated.map((d) => d.row)
+}
+
+// ---------------------------------------------------------------------------
+// Grouping (Board view)
+// ---------------------------------------------------------------------------
+
+export interface BoardColumn {
+  /** Option value, or EMPTY_GROUP for unset/unmatched rows. */
+  key: string
+  rows: DbRow[]
+}
+
+/**
+ * Group rows by a `select` field's value. Columns follow `optionOrder` (option
+ * values), with an EMPTY_GROUP column appended for rows whose cell is empty or
+ * references a removed option.
+ */
+export function boardColumns(
+  rows: DbRow[],
+  groupField: DbField,
+  optionOrder: string[]
+): BoardColumn[] {
+  const buckets = new Map<string, DbRow[]>()
+  const known = new Set(optionOrder)
+  for (const value of optionOrder) buckets.set(value, [])
+  buckets.set(EMPTY_GROUP, [])
+  for (const row of rows) {
+    const v = cell(row, groupField.id).trim()
+    const key = v.length > 0 && known.has(v) ? v : EMPTY_GROUP
+    buckets.get(key)!.push(row)
+  }
+  const columns = optionOrder.map((value) => ({ key: value, rows: buckets.get(value)! }))
+  columns.push({ key: EMPTY_GROUP, rows: buckets.get(EMPTY_GROUP)! })
+  return columns
+}

--- a/packages/shared-domain/src/databases.ts
+++ b/packages/shared-domain/src/databases.ts
@@ -1,0 +1,180 @@
+/**
+ * CSV-backed "Databases" — a general data primitive (à la Notion / Obsidian
+ * Bases). A `.csv` file in the vault is a database: rows are records, columns
+ * are typed fields. The same data is shown through multiple VIEWS (an editable
+ * Table and a Board grouped by a field).
+ *
+ * On disk a database is a pair:
+ *   <folder>/<Name>.csv            — the data (an `id` UUID column gives rows a
+ *                                    stable identity across external edits)
+ *   <folder>/<Name>.csv.base.json  — the sidecar: field types, select options,
+ *                                    and view definitions (a CSV can't hold these)
+ *
+ * This module is PURE (no node/DOM imports) so it is shared by the main process
+ * and the renderer. Cell values are stored as raw CSV strings; the field type
+ * drives parse/format/compare at the edges (lossless round-trips, no coercion
+ * on load).
+ */
+
+export const DATABASE_SIDECAR_SUFFIX = '.base.json'
+export const DEFAULT_ID_FIELD_NAME = 'id'
+/** Board column key for rows whose group-by cell is empty/unmatched. */
+export const EMPTY_GROUP = '__empty__'
+
+export type FieldType = 'text' | 'number' | 'checkbox' | 'date' | 'select' | 'multiSelect'
+
+export interface SelectOption {
+  id: string
+  /** The literal stored in the CSV cell. */
+  value: string
+  /** Display override; defaults to `value`. */
+  label?: string
+  /** Palette token name (not a raw hex), mapped to a chip color by the UI. */
+  color?: string
+}
+
+export interface DbField {
+  /** Stable uuid referenced by rows/views — NOT the CSV header. */
+  id: string
+  /** The CSV column header (display + the header text written to disk). */
+  name: string
+  type: FieldType
+  /** For `select` / `multiSelect`. */
+  options?: SelectOption[]
+  /** Table column width in px. */
+  width?: number
+  /** Hidden in the Table view by default (e.g. the id field). */
+  hidden?: boolean
+}
+
+export type FilterOp =
+  | 'is'
+  | 'isNot'
+  | 'contains'
+  | 'notContains'
+  | 'isEmpty'
+  | 'isNotEmpty'
+  | 'gt'
+  | 'lt'
+  | 'before'
+  | 'after'
+  | 'checked'
+  | 'unchecked'
+
+export interface FilterRule {
+  fieldId: string
+  op: FilterOp
+  value?: string
+}
+
+export interface SortRule {
+  fieldId: string
+  direction: 'asc' | 'desc'
+}
+
+export type DbViewType = 'table' | 'board'
+
+export interface DbView {
+  id: string
+  name: string
+  type: DbViewType
+  filters: FilterRule[]
+  sorts: SortRule[]
+  // --- table ---
+  /** Ordered fieldIds (display order). */
+  columnOrder?: string[]
+  hiddenFieldIds?: string[]
+  columnWidths?: Record<string, number>
+  // --- board ---
+  /** Must reference a `select` field. */
+  groupByFieldId?: string
+  /** Order of board columns; values are SelectOption.value (+ EMPTY_GROUP). */
+  boardColumnOrder?: string[]
+  /** Per-card visible fields. */
+  cardFieldIds?: string[]
+}
+
+/** The sidecar JSON written to `<name>.csv.base.json`. */
+export interface DatabaseSidecar {
+  version: 1
+  /** Field whose cells hold the row UUID (its `name` is the CSV header). */
+  idFieldId: string
+  /** Order == on-disk CSV column order. */
+  fields: DbField[]
+  views: DbView[]
+  activeViewId: string
+}
+
+/** Cells are raw CSV strings keyed by DbField.id. */
+export interface DbRow {
+  /** == cells[idFieldId]. */
+  id: string
+  cells: Record<string, string>
+}
+
+/** Fully-hydrated database handed to the renderer (sidecar + rows + identity). */
+export interface DatabaseDoc extends DatabaseSidecar {
+  /** Vault-relative POSIX path of the `.csv` — identity / cache key. */
+  path: string
+  /** Basename without `.csv`. */
+  title: string
+  rows: DbRow[]
+}
+
+/** Lightweight listing entry for database discovery (sidebar / quick-open). */
+export interface DatabaseSummary {
+  path: string
+  title: string
+}
+
+// ---------------------------------------------------------------------------
+// Virtual tab-path helpers (mirror lib/asset-tabs.ts). A database opens as a
+// virtual tab keyed by the real CSV path, so it never hits the markdown
+// pipeline but the path stays recoverable for IPC.
+// ---------------------------------------------------------------------------
+
+const DATABASE_TAB_PREFIX = 'zen://database/'
+
+export function databaseTabPath(csvPath: string): string {
+  return `${DATABASE_TAB_PREFIX}${encodeURIComponent(csvPath.replace(/^\/+/, ''))}`
+}
+
+export function isDatabaseTabPath(path: string | null | undefined): boolean {
+  return typeof path === 'string' && path.startsWith(DATABASE_TAB_PREFIX)
+}
+
+export function csvPathFromDatabaseTab(path: string | null | undefined): string | null {
+  if (!path || !isDatabaseTabPath(path)) return null
+  const encoded = path.slice(DATABASE_TAB_PREFIX.length)
+  if (!encoded) return null
+  try {
+    return decodeURIComponent(encoded)
+  } catch {
+    return encoded
+  }
+}
+
+export function databaseTitleFromTab(path: string | null | undefined): string {
+  const csv = csvPathFromDatabaseTab(path)
+  if (!csv) return 'Database'
+  const base = csv.split('/').filter(Boolean).pop() ?? csv
+  return base.replace(/\.csv$/i, '')
+}
+
+/** True for the sidecar file path (`*.csv.base.json`). */
+export function isDatabaseSidecarPath(relPath: string): boolean {
+  return relPath.toLowerCase().endsWith(`.csv${DATABASE_SIDECAR_SUFFIX}`)
+}
+
+/** True for a database data file (`*.csv`, but not the sidecar). */
+export function isDatabaseCsvPath(relPath: string): boolean {
+  const lower = relPath.toLowerCase()
+  return lower.endsWith('.csv') && !lower.endsWith(`.csv${DATABASE_SIDECAR_SUFFIX}`)
+}
+
+/** Given a `.csv` or its `.base.json` sidecar, return the canonical `.csv` path. */
+export function databaseCsvPathFor(relPath: string): string | null {
+  if (isDatabaseSidecarPath(relPath)) return relPath.slice(0, -DATABASE_SIDECAR_SUFFIX.length)
+  if (isDatabaseCsvPath(relPath)) return relPath
+  return null
+}

--- a/packages/shared-domain/src/databases.ts
+++ b/packages/shared-domain/src/databases.ts
@@ -103,6 +103,8 @@ export interface DatabaseSidecar {
   fields: DbField[]
   views: DbView[]
   activeViewId: string
+  /** Row id → vault path of that record's "page" note (created on demand). */
+  pages?: Record<string, string>
 }
 
 /** Cells are raw CSV strings keyed by DbField.id. */
@@ -119,6 +121,11 @@ export interface DatabaseDoc extends DatabaseSidecar {
   /** Basename without `.csv`. */
   title: string
   rows: DbRow[]
+  /**
+   * Row id → whether that record's linked page note has body content (beyond
+   * frontmatter + the title heading). Derived on read; not persisted.
+   */
+  pageHasContent?: Record<string, boolean>
 }
 
 /** Lightweight listing entry for database discovery (sidebar / quick-open). */
@@ -164,6 +171,19 @@ export function databaseTitleFromTab(path: string | null | undefined): string {
 /** True for the sidecar file path (`*.csv.base.json`). */
 export function isDatabaseSidecarPath(relPath: string): boolean {
   return relPath.toLowerCase().endsWith(`.csv${DATABASE_SIDECAR_SUFFIX}`)
+}
+
+/**
+ * True for files that belong to a database but aren't the user-facing `.csv` —
+ * the sidecar and any `.bak` backups. These are hidden from the note list.
+ */
+export function isDatabaseInternalPath(relPath: string): boolean {
+  const l = relPath.toLowerCase()
+  return (
+    l.endsWith(`.csv${DATABASE_SIDECAR_SUFFIX}`) ||
+    l.endsWith('.csv.bak') ||
+    l.endsWith(`.csv${DATABASE_SIDECAR_SUFFIX}.bak`)
+  )
 }
 
 /** True for a database data file (`*.csv`, but not the sidecar). */


### PR DESCRIPTION
A `.csv` in the vault becomes a full database (à la Notion / Obsidian Bases): typed fields, multiple views, and per-record pages — zero new dependencies (hand-rolled RFC-4180).

### Highlights
- **Table + Board views** over a `.csv` + co-located `.csv.base.json` sidecar (schema/views/pages). Rows get a stable `id` UUID column so external edits round-trip.
- **Editable grid**: inline cell editing, typed fields (text/number/checkbox/date/select/multiSelect), add/rename/retype/delete fields, sort, filter, raw-CSV toggle, row-selection checkboxes with bulk delete.
- **Records as pages**: each row links to a real markdown note in a per-db folder; properties mirror into frontmatter, the body is the freeform page. The title cell shows a page icon reflecting whether the note has content, plus a hover **Open** button; opening focuses the editor.
- **Vim grid**: the Table view is a focusable grid — `h/j/k/l`, `gg`/`G`, `0`/`$`, `i`/`Enter` to edit, `Space`/`x` to select, `o` to open, `a` to add, `dd` to delete. `VimNav` yields to it via `data-zen-db-grid`.
- **Create from the sidebar**: right-click a folder → New database (location-aware).
- Right-click a row → Open / Delete. Frontmatter rendered compact + muted in the editor.

### Verification
`npm run typecheck` (7/7), `npm run test:run` (140 passed / 1 skipped), `npm run build` (6/6) — all green locally.