### PR TITLE
fix(keymaps): comments shortcuts + always-on pane focus

### DIFF
--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -9,6 +9,7 @@ import { ConfirmHost } from './components/ConfirmHost'
 import { ServerDirectoryPickerHost } from './components/ServerDirectoryPickerHost'
 import { resolveQuickNoteTitle } from './lib/quick-note-title'
 import { matchesShortcut, matchesSequenceToken } from './lib/keymaps'
+import { focusPaneOrEdgePanel } from './lib/pane-nav'
 import { requestPaneMode } from './lib/pane-mode'
 import { recordRendererPerf } from './lib/perf'
 import { focusEditorNormalMode } from './lib/editor-focus'
@@ -596,6 +597,36 @@ function App(): JSX.Element {
         e.preventDefault()
         window.dispatchEvent(new Event('zen:toggle-outline'))
         return
+      }
+      // ⇧⌘C — toggle the comments panel in the active pane
+      if (matchesShortcut(e, overrides, 'global.toggleCommentsPanel')) {
+        e.preventDefault()
+        window.dispatchEvent(new Event('zen:toggle-comments'))
+        return
+      }
+      // ⌥⌘M — comment the current selection (or line) without the mouse
+      if (matchesShortcut(e, overrides, 'global.addComment')) {
+        e.preventDefault()
+        window.dispatchEvent(new Event('zen:add-comment'))
+        return
+      }
+      // ⌥h/j/k/l — focus the neighbouring pane/panel. Works regardless of vim
+      // mode (unlike <C-w>hjkl) and never needs the command palette.
+      {
+        const paneDir = matchesShortcut(e, overrides, 'global.focusPaneLeft')
+          ? 'h'
+          : matchesShortcut(e, overrides, 'global.focusPaneDown')
+            ? 'j'
+            : matchesShortcut(e, overrides, 'global.focusPaneUp')
+              ? 'k'
+              : matchesShortcut(e, overrides, 'global.focusPaneRight')
+                ? 'l'
+                : null
+        if (paneDir) {
+          e.preventDefault()
+          focusPaneOrEdgePanel(paneDir)
+          return
+        }
       }
       if (matchesShortcut(e, overrides, 'global.modeEdit')) {
         e.preventDefault()

--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -1031,6 +1031,17 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
     return draft
   }, [content, paneId, setActiveCommentId, setActivePane, setFocusedPanel])
 
+  // `zen:add-comment` — keyboard shortcut (⌥⌘M) / palette command to start a
+  // comment on the current selection (or line) in the active pane, no mouse.
+  useEffect(() => {
+    if (!isActive) return
+    const handler = (): void => {
+      captureCommentDraft()
+    }
+    window.addEventListener('zen:add-comment', handler)
+    return () => window.removeEventListener('zen:add-comment', handler)
+  }, [isActive, captureCommentDraft])
+
   const jumpToComment = useCallback((comment: NoteComment) => {
     const view = viewRef.current
     setActivePane(paneId)

--- a/packages/app-core/src/lib/commands.ts
+++ b/packages/app-core/src/lib/commands.ts
@@ -494,10 +494,22 @@ export function buildCommands(options?: { includeUnavailable?: boolean }): Comma
       id: 'view.comments-panel',
       title: 'Toggle Comments Panel',
       category: 'View',
+      shortcut: shortcut('global.toggleCommentsPanel'),
       keywords: 'comments annotations discussion margin review',
       when: () => !!getState().activeNote,
       run: () => {
         window.dispatchEvent(new Event('zen:toggle-comments'))
+      }
+    },
+    {
+      id: 'editor.add-comment',
+      title: 'Add Comment to Selection',
+      category: 'Editor',
+      shortcut: shortcut('global.addComment'),
+      keywords: 'comment annotate selection note review',
+      when: () => !!getState().activeNote,
+      run: () => {
+        window.dispatchEvent(new Event('zen:add-comment'))
       }
     },
     {

--- a/packages/app-core/src/lib/keymaps.ts
+++ b/packages/app-core/src/lib/keymaps.ts
@@ -18,6 +18,12 @@ export type KeymapId =
   | "global.toggleSidebar"
   | "global.toggleConnections"
   | "global.toggleOutlinePanel"
+  | "global.toggleCommentsPanel"
+  | "global.addComment"
+  | "global.focusPaneLeft"
+  | "global.focusPaneRight"
+  | "global.focusPaneUp"
+  | "global.focusPaneDown"
   | "global.modeEdit"
   | "global.modeSplit"
   | "global.modePreview"
@@ -178,6 +184,60 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: "Toggle outline panel",
     description: "Toggle the outline panel in the active pane.",
     defaultBinding: "Mod+3",
+  },
+  {
+    id: "global.toggleCommentsPanel",
+    kind: "shortcut",
+    scope: "app",
+    group: "global",
+    title: "Toggle comments panel",
+    description: "Toggle the comments panel in the active pane.",
+    defaultBinding: "Mod+Shift+C",
+  },
+  {
+    id: "global.addComment",
+    kind: "shortcut",
+    scope: "app",
+    group: "global",
+    title: "Add comment to selection",
+    description: "Start a comment on the selected text (or current line).",
+    defaultBinding: "Mod+Alt+M",
+  },
+  {
+    id: "global.focusPaneLeft",
+    kind: "shortcut",
+    scope: "app",
+    group: "global",
+    title: "Focus pane left",
+    description: "Move focus to the pane/panel on the left. Works without vim mode.",
+    defaultBinding: "Alt+H",
+  },
+  {
+    id: "global.focusPaneDown",
+    kind: "shortcut",
+    scope: "app",
+    group: "global",
+    title: "Focus pane down",
+    description: "Move focus to the pane/panel below. Works without vim mode.",
+    defaultBinding: "Alt+J",
+  },
+  {
+    id: "global.focusPaneUp",
+    kind: "shortcut",
+    scope: "app",
+    group: "global",
+    title: "Focus pane up",
+    description: "Move focus to the pane/panel above. Works without vim mode.",
+    defaultBinding: "Alt+K",
+  },
+  {
+    id: "global.focusPaneRight",
+    kind: "shortcut",
+    scope: "app",
+    group: "global",
+    title: "Focus pane right",
+    description: "Move focus to the pane/panel on the right. Works without vim mode.",
+    defaultBinding: "Alt+L",
   },
   {
     id: "global.modeEdit",


### PR DESCRIPTION
Addresses keyboard-shortcut gaps reported by a community member (Kelv).

### Changes
- **Toggle Comments panel** — new `⌘⇧C` / `Ctrl+Shift+C`. The command existed but had no shortcut, unlike Sidebar/Connections/Outline (`⌘1/2/3`). Also surfaced in the command palette.
- **Comment a selection from the keyboard** — new `⌥⌘M` / `Ctrl+Alt+M` (the Google-Docs "add comment" convention), plus an **Add Comment to Selection** palette command. Comments the selection, or the current line when nothing is selected; opens + focuses the panel.
- **Focus panes without `Ctrl+W`** — new always-on `⌥h/j/k/l` (Alt+hjkl) pane/panel focus. The existing `<C-w>hjkl` is vim-mode-gated, so it does nothing when vim mode is off while the palette command still works (the reporter's exact symptom). `Alt+hjkl` closes that gap and sidesteps `Ctrl+W` being intercepted on some Linux setups. `<C-w>hjkl` still works in vim mode.

### Notes
- All new bindings are user-rebindable via the keymap settings; checked there are no collisions with existing bindings.
- `Alt+hjkl` chosen to avoid known Ubuntu OS shortcuts (Ctrl+Alt+Arrow = workspaces, Ctrl+Alt+L = lock).

### Verification
`npm run typecheck` (7/7), `npm run test:run` (140 passed / 1 skipped), `npm run build` (6/6) — all green locally.