### PR TITLE
fix(preview): render JSXGraph diagrams against the live DOM (#68)

### DIFF
--- a/packages/app-core/src/components/Preview.tsx
+++ b/packages/app-core/src/components/Preview.tsx
@@ -700,9 +700,15 @@ export const Preview = memo(function Preview({
       } catch {
         /* render errors are surfaced inline per block */
       }
-      await renderDiagrams(stage, { themeKey: effectiveMode, expanded: false });
       if (cancelled) return;
+      // Attach to the live document BEFORE rendering diagrams. JSXGraph binds to
+      // a real element via document.getElementById and sizes the board from the
+      // laid-out container, so a detached buffer yields "HTML container element
+      // not found" and zero-size boards (#68). Mermaid renders to inline SVG, so
+      // it is safe to render in the detached buffer above.
       root.replaceChildren(...Array.from(stage.childNodes));
+      await renderDiagrams(root, { themeKey: effectiveMode, expanded: false });
+      if (cancelled) return;
       requestAnimationFrame(() => {
         if (!cancelled) onRenderedRef.current?.();
       });


### PR DESCRIPTION
Fixes #68 — JSXGraph diagrams failed to render in the preview with *"JSXGraph: HTML container element 'zen-jxg-…' not found."*

### Cause
The preview renders a note into a **detached** `<article>` buffer, runs every diagram renderer on it, then swaps it into the live DOM. JSXGraph's `initBoard(id)` resolves its container via `document.getElementById` (the live document) and sizes the board from the laid-out element — so against a detached buffer it can't find the container and would get a zero-size board. Mermaid (inline SVG) and function-plot (handed the element directly) were unaffected, which is why only JSXGraph broke.

### Fix
Attach the rendered content to the live document **before** running the diagram renderers (`Preview.tsx`). Mermaid still renders in the buffer (inline SVG). Side benefit: note text now paints immediately instead of waiting for every diagram library to load. The PDF export window reuses `<Preview>`, so it's fixed there too.

### Verification
- Traced to the detached-buffer swap in `Preview.tsx`.
- Reproduced via the demo tour note **`05b — Math Diagrams`** (3 JSXGraph blocks); confirmed they now render and are draggable, no console errors.
- `npm run typecheck` passes.