### PR TITLE
fix(preview): make footnote & heading anchor links navigate (#69)

### DIFF
--- a/packages/app-core/src/components/Preview.tsx
+++ b/packages/app-core/src/components/Preview.tsx
@@ -563,6 +563,29 @@ export const Preview = memo(function Preview({
         window.open(href, "_blank");
         return;
       }
+      // In-page anchors — footnote refs / back-refs and heading links. The
+      // browser's default hash navigation doesn't scroll an element that lives
+      // inside the preview's own overflow:auto container, so resolve the target
+      // and scroll it ourselves. This is what made footnotes feel dead in the
+      // (split) preview, and it works both ways: ref → definition and the ↩
+      // back-ref → reference (#69).
+      if (href.startsWith("#") && href.length > 1) {
+        e.preventDefault();
+        const id = decodeURIComponent(href.slice(1));
+        const dest =
+          root.querySelector<HTMLElement>(`#${CSS.escape(id)}`) ??
+          root.querySelector<HTMLElement>(`[name="${CSS.escape(id)}"]`);
+        if (dest) {
+          dest.scrollIntoView({ behavior: "smooth", block: "center" });
+          // Brief highlight so the jump is obvious in a long note.
+          dest.style.transition = "background-color 700ms ease";
+          dest.style.backgroundColor = "rgb(var(--z-accent) / 0.22)";
+          window.setTimeout(() => {
+            dest.style.backgroundColor = "";
+          }, 900);
+        }
+        return;
+      }
       e.preventDefault();
     };
     const onMouseOver = (e: MouseEvent): void => {


### PR DESCRIPTION
Fixes #69 — footnotes did nothing in the (split) preview, and should link both ways.

### Cause
Footnote refs/back-refs render as in-page anchors (`#…fn-1` ⇄ `#…fnref-1`). The preview's click handler ended in a catch-all `e.preventDefault()` that swallowed those clicks — and the browser's native hash navigation doesn't scroll a target that lives inside the preview's own `overflow:auto` container anyway. (The sanitizer keeps the `href`/`id`, so the markup was fine — purely a navigation gap.)

### Fix
When a clicked anchor's `href` is a `#`-fragment, resolve the target by id within the preview container and `scrollIntoView` it, with a brief accent highlight so the jump is visible. Works **both ways** — ref → definition and the `↩` back-ref → reference — and also fixes heading/TOC anchor links.

### Verification
- Reproduced + fixed against the demo tour note **`06 — Callouts and Footnotes`** in Split/Preview (clicking a footnote jumps to its definition and back).
- `npm run typecheck` passes.

One-spot change in `Preview.tsx`; independent of #88 (different region of the same file).