### PR TITLE
Fix: set world-readable permissions on /opt/zennotes-bin after extraction. 

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -41,6 +41,7 @@ package() {
   # Install the unpacked app under /opt.
   install -dm755 "${pkgdir}/opt/${pkgname}"
   cp -a squashfs-root/. "${pkgdir}/opt/${pkgname}/"
+  chmod -R a+rX "${pkgdir}/opt/${pkgname}/"
 
   # `cp -a` re-applies the extracted squashfs root's mode (often 0700) onto
   # /opt/zennotes-bin, leaving the tree untraversable for non-root users — so


### PR DESCRIPTION
the `cp -a` call preserves the permissions of the extracted squashfs-root
directory, which comes out as `drwx------` (root-only). This means non-root
users cannot enter /opt/zennotes-bin/ at all, causing `zennotes: permission
denied` on launch even after the symlink in /usr/bin is correctly set.

Fix: add `chmod -R a+rX` after the cp to ensure directories are traversable
and files are readable by all users. The `X` (capital) flag only sets execute
on directories and already-executable files, so regular data files are not
made executable.

