### PR TITLE
feat: add tar.gz Linux target and simplify AUR PKGBUILD

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: adibhanna

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ On macOS, the first-party `zen` CLI also powers launcher workflows such as the R
 
 Grab the latest build from [GitHub Releases](https://github.com/ZenNotes/zennotes/releases/latest) — see [Install](#install) below.  
 Website: [zennotes.org](https://zennotes.org)
+Support development: [GitHub Sponsors](https://github.com/sponsors/adibhanna)
 
 Detailed in-repo documentation lives under [docs/README.md](docs/README.md).
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -152,20 +152,6 @@
           "!coverage/**",
           "!*.log"
         ]
-      },
-      {
-        "from": "../../packaging/aur/arch-extras/zennotes.desktop",
-        "to": "arch-extras/zennotes.desktop"
-      },
-      {
-        "from": "build/icons",
-        "to": "arch-extras/icons"
-      }
-    ],
-    "extraFiles": [
-      {
-        "from": "../../LICENSE",
-        "to": "LICENSE"
       }
     ],
     "afterSign": "scripts/notarize.cjs",
@@ -246,7 +232,23 @@
       ],
       "icon": "build/icons",
       "maintainer": "Adib Hanna <adibhanna@gmail.com>",
-      "category": "Office"
+      "category": "Office",
+      "extraResources": [
+        {
+          "from": "../../packaging/aur/arch-extras/zennotes.desktop",
+          "to": "arch-extras/zennotes.desktop"
+        },
+        {
+          "from": "build/icons",
+          "to": "arch-extras/icons"
+        }
+      ],
+      "extraFiles": [
+        {
+          "from": "../../LICENSE",
+          "to": "LICENSE"
+        }
+      ]
     },
     "deb": {
       "afterInstall": "build/after-install.sh"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -152,6 +152,20 @@
           "!coverage/**",
           "!*.log"
         ]
+      },
+      {
+        "from": "../../packaging/aur/arch-extras/zennotes.desktop",
+        "to": "arch-extras/zennotes.desktop"
+      },
+      {
+        "from": "build/icons",
+        "to": "arch-extras/icons"
+      }
+    ],
+    "extraFiles": [
+      {
+        "from": "../../LICENSE",
+        "to": "LICENSE"
       }
     ],
     "afterSign": "scripts/notarize.cjs",
@@ -227,7 +241,8 @@
       "target": [
         "AppImage",
         "deb",
-        "pacman"
+        "pacman",
+        "tar.gz"
       ],
       "icon": "build/icons",
       "maintainer": "Adib Hanna <adibhanna@gmail.com>",

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zennotes-bin
 	pkgdesc = Keyboard-first, local-first Markdown notes with vim motions and live preview
-	pkgver = 2.3.0
+	pkgver = 2.4.0
 	pkgrel = 1
 	url = https://github.com/ZenNotes/zennotes
 	arch = x86_64
@@ -12,7 +12,7 @@ pkgbase = zennotes-bin
 	provides = zennotes
 	conflicts = zennotes
 	options = !strip
-	source = ZenNotes-2.3.0-linux-x64.tar.gz::https://github.com/ZenNotes/zennotes/releases/download/v2.3.0/ZenNotes-2.3.0-linux-x64.tar.gz
+	source = ZenNotes-2.4.0-linux-x64.tar.gz::https://github.com/ZenNotes/zennotes/releases/download/v2.4.0/ZenNotes-2.4.0-linux-x64.tar.gz
 	sha256sums = f7f6a67b193dad9961b3844a9ddb213ba866467999574b7f7bbaaff465895722
 
 pkgname = zennotes-bin

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zennotes-bin
 	pkgdesc = Keyboard-first, local-first Markdown notes with vim motions and live preview
-	pkgver = 2.2.0
+	pkgver = 2.3.0
 	pkgrel = 1
 	url = https://github.com/ZenNotes/zennotes
 	arch = x86_64
@@ -12,7 +12,7 @@ pkgbase = zennotes-bin
 	provides = zennotes
 	conflicts = zennotes
 	options = !strip
-	source = ZenNotes-2.2.0.AppImage::https://github.com/ZenNotes/zennotes/releases/download/v2.2.0/ZenNotes-2.2.0-linux-x86_64.AppImage
+	source = ZenNotes-2.3.0-linux-x64.tar.gz::https://github.com/ZenNotes/zennotes/releases/download/v2.3.0/ZenNotes-2.3.0-linux-x64.tar.gz
 	sha256sums = f7f6a67b193dad9961b3844a9ddb213ba866467999574b7f7bbaaff465895722
 
 pkgname = zennotes-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -10,7 +10,7 @@
 
 pkgname=zennotes-bin
 _appname=ZenNotes
-pkgver=2.3.0
+pkgver=2.4.0
 pkgrel=1
 pkgdesc="Keyboard-first, local-first Markdown notes with vim motions and live preview"
 arch=('x86_64')
@@ -35,6 +35,8 @@ package() {
 
   # Install application
   install -dm755 "${pkgdir}/opt/${pkgname}"
+  # tar.gz preserves permissions (unlike squashfs extraction), so the
+  # chmod workarounds from #70/#74/#92 are no longer needed.
   cp -a "${_extracted}/." "${pkgdir}/opt/${pkgname}/"
 
   # Chromium sandbox

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,12 +2,6 @@
 #
 # AUR package for ZenNotes (yay -S zennotes-bin).
 #
-# This is a -bin package: it downloads the official AppImage from the GitHub
-# release and *extracts* it at build time (--appimage-extract), then installs the
-# unpacked app to /opt. Extraction does not need FUSE, so the resulting install
-# runs on CachyOS / Arch without libfuse2 — sidestepping the AppImage-won't-start
-# problem entirely.
-#
 # Before publishing a new version:
 #   1. bump pkgver to match the GitHub release tag (without the leading "v"),
 #   2. run `updpkgsums` to fill in sha256sums (or `makepkg -g`),
@@ -16,80 +10,61 @@
 
 pkgname=zennotes-bin
 _appname=ZenNotes
-pkgver=2.2.0
+pkgver=2.3.0
 pkgrel=1
 pkgdesc="Keyboard-first, local-first Markdown notes with vim motions and live preview"
 arch=('x86_64')
 url="https://github.com/ZenNotes/zennotes"
 license=('MIT')
-# Electron bundles its own runtime; these are the shared libs it links against.
 depends=('gtk3' 'nss' 'alsa-lib' 'libxss')
 provides=('zennotes')
 conflicts=('zennotes')
 options=('!strip')
-source=("${_appname}-${pkgver}.AppImage::${url}/releases/download/v${pkgver}/${_appname}-${pkgver}-linux-x86_64.AppImage")
-# sha256 of the v2.2.0 x86_64 AppImage. Regenerate with `updpkgsums` on each bump.
+
+source=(
+  "${_appname}-${pkgver}-linux-x64.tar.gz::${url}/releases/download/v${pkgver}/${_appname}-${pkgver}-linux-x64.tar.gz"
+)
+
 sha256sums=('f7f6a67b193dad9961b3844a9ddb213ba866467999574b7f7bbaaff465895722')
 
 package() {
   cd "${srcdir}"
 
-  chmod +x "${_appname}-${pkgver}.AppImage"
-  # FUSE-free extraction — no libfuse2 required on the build host.
-  ./"${_appname}-${pkgver}.AppImage" --appimage-extract >/dev/null
+  local _extracted="${_appname}-${pkgver}-linux-x64"
+  local _extras="${_extracted}/resources/arch-extras"
 
-  # Install the unpacked app under /opt.
+  # Install application
   install -dm755 "${pkgdir}/opt/${pkgname}"
-  cp -a squashfs-root/. "${pkgdir}/opt/${pkgname}/"
+  cp -a "${_extracted}/." "${pkgdir}/opt/${pkgname}/"
 
-  # `cp -a` re-applies the extracted squashfs root's mode (often 0700) onto
-  # /opt/zennotes-bin, leaving the tree untraversable for non-root users — so
-  # launching the desktop entry or `zennotes` fails with "command not found"
-  # or "not executable" (issues #70, #74). Force every directory and
-  # already-executable file world-traversable and everything world-readable.
-  # (chmod -R skips symlinks during recursion, so AppRun's real target is
-  # fixed via the regular file it points to.)
-  chmod -R a+rX "${pkgdir}/opt/${pkgname}"
-
-  # `a+rX` only PRESERVES an existing execute bit — it won't restore one the
-  # source mode dropped during extraction/cp, so on some build hosts the
-  # Electron launcher lands non-executable and `/usr/bin/zennotes` reports
-  # "exists but is not an executable file" (#92). Force it on the launcher
-  # entry points; chmod follows the AppRun symlink to its real target.
-  for _exe in "${_appname}" AppRun chrome_crashpad_handler; do
-    if [ -e "${pkgdir}/opt/${pkgname}/${_exe}" ]; then
-      chmod a+x "${pkgdir}/opt/${pkgname}/${_exe}"
-    fi
-  done
-
-  # The Chromium sandbox helper must be setuid-root to work without
-  # --no-sandbox. Keep this AFTER the chmod -R above so the setuid bit stands.
-  if [ -f "${pkgdir}/opt/${pkgname}/chrome-sandbox" ]; then
+  # Chromium sandbox
+  if [[ -f "${pkgdir}/opt/${pkgname}/chrome-sandbox" ]]; then
     chmod 4755 "${pkgdir}/opt/${pkgname}/chrome-sandbox"
   fi
 
-  # CLI launcher.
+  # CLI launcher
   install -dm755 "${pkgdir}/usr/bin"
-  ln -s "/opt/${pkgname}/AppRun" "${pkgdir}/usr/bin/zennotes"
+  ln -s "/opt/${pkgname}/${_appname}" "${pkgdir}/usr/bin/zennotes"
 
-  # Desktop entry — repoint Exec/Icon at the installed paths.
-  local desktop
-  desktop=$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -n1)
-  if [ -n "${desktop}" ]; then
-    install -Dm644 "${desktop}" "${pkgdir}/usr/share/applications/zennotes.desktop"
-    sed -i \
-      -e 's|^Exec=.*|Exec=zennotes %U|' \
-      -e 's|^Icon=.*|Icon=zennotes|' \
+  # Desktop entry
+  if [[ -f "${_extras}/zennotes.desktop" ]]; then
+    install -Dm644 \
+      "${_extras}/zennotes.desktop" \
       "${pkgdir}/usr/share/applications/zennotes.desktop"
   fi
 
-  # Icons shipped inside the AppImage.
-  local size icon
-  for size in 16 32 48 64 128 256 512; do
-    icon="squashfs-root/usr/share/icons/hicolor/${size}x${size}/apps/${_appname}.png"
-    if [ -f "${icon}" ]; then
-      install -Dm644 "${icon}" \
+  # Icons
+  local size
+  for size in 16 24 32 48 64 128 256 512; do
+    if [[ -f "${_extras}/icons/${size}x${size}.png" ]]; then
+      install -Dm644 \
+        "${_extras}/icons/${size}x${size}.png" \
         "${pkgdir}/usr/share/icons/hicolor/${size}x${size}/apps/zennotes.png"
     fi
   done
+
+  # LICENSE
+  install -Dm644 \
+    "${_extracted}/LICENSE" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -35,7 +35,7 @@ package() {
 
   # Install application
   install -dm755 "${pkgdir}/opt/${pkgname}"
-  # tar.gz preserves permissions (unlike squashfs extraction), so the
+  # tar.gz preserves permissions (unlike squashfs extraction)
   # chmod workarounds from #70/#74/#92 are no longer needed.
   cp -a "${_extracted}/." "${pkgdir}/opt/${pkgname}/"
 

--- a/packaging/aur/arch-extras/zennotes.desktop
+++ b/packaging/aur/arch-extras/zennotes.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=ZenNotes
+Comment=ZenNotes desktop shell
+Exec=zennotes %U
+Icon=zennotes
+Terminal=false
+Type=Application
+Categories=Office;
+MimeType=text/markdown;x-scheme-handler/zennotes;
+StartupWMClass=ZenNotes


### PR DESCRIPTION
- Add tar.gz to electron-builder Linux targets
- Include desktop file (copy of the appimage), icons via arch-extras in extraResources
- Include LICENSE via extraFiles
- Rewrite PKGBUILD to use tar.gz instead of AppImage extraction
- Fixes #103

## Verified

Tarball produced by `npm run dist:linux` (`ZenNotes-2.3.0-linux-x64.tar.gz`):

### Confirmed resources/arch-extras exists with desktop file + icons
```sh
tar -tzf ZenNotes-2.3.0-linux-x64.tar.gz | grep -i arch-extras
```

### LICENSE present at tarball root
```sh
tar -tzf ZenNotes-2.3.0-linux-x64.tar.gz | grep -i license
```

### chrome_crashpad_handler ships with correct execute permissions (-rwxr-xr-x) 
```sh
tar -tvzf ZenNotes-2.3.0-linux-x64.tar.gz | grep crashpad
```

**Note:** sha256sums in `.SRCINFO` / `PKGBUILD` still reference the old AppImage hash.