### PR TITLE
feat(ui): add middle-click to close tabs

### DIFF
--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -2453,6 +2453,17 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
             e.preventDefault()
             setTabMenu({ x: e.clientX, y: e.clientY, path: tab.path })
           }}
+          onMouseDown={(e) => {
+            if (e.button === 1) {
+              e.preventDefault()
+            }
+          }}
+          onAuxClick={(e) => {
+            if (e.button === 1) {
+              e.preventDefault()
+              void closeTabInPane(paneId, tab.path)
+            }
+          }}
         >
           {tabDropIndicator?.path === tab.path && (
             <div


### PR DESCRIPTION
This PR introduces a small UX improvement by adding the ability to close tabs using the middle mouse button.

Since this is the standard behavior for tabs in most modern web browsers, it makes navigating the editor pane feel much more natural even for me as a heavy vim motion user. Users can now quickly close tabs without needing to aim exactly at the small close icon.

It's a very straightforward and isolated change, so I decided to open a PR directly for it.

I'm in love with the app! Thank you.