### PR TITLE
Add Flatpak packaging

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: adibhanna

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ On macOS, the first-party `zen` CLI also powers launcher workflows such as the R
 
 Grab the latest build from [GitHub Releases](https://github.com/ZenNotes/zennotes/releases/latest) — see [Install](#install) below.  
 Website: [zennotes.org](https://zennotes.org)
+Support development: [GitHub Sponsors](https://github.com/sponsors/adibhanna)
 
 Detailed in-repo documentation lives under [docs/README.md](docs/README.md).
 

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,73 @@
+# Linux packaging (Flatpak)
+
+This directory holds the Flatpak packaging for ZenNotes.
+
+## Why this exists
+
+The same class of problem reported in
+[#65](https://github.com/ZenNotes/zennotes/issues/65) — the AppImage failing to
+start on some distros — also hits other setups. AppImages rely on the host's
+`libfuse2` and system libraries; on Fedora Atomic/Silverblue, some Arch
+variants, and minimal installs the image simply won't launch.
+
+Flatpak sidesteps all of that: the app ships against a self-contained
+[org.freedesktop.Platform](https://docs.flatpak.org/) runtime plus the
+[Electron base app](https://github.com/flathub/org.electronjs.Electron2.BaseApp),
+so it does not depend on host FUSE or system libraries, and it runs sandboxed.
+
+## How it works
+
+Like the AUR `PKGBUILD`, this manifest downloads the official AppImage from the
+GitHub release and **extracts** it at build time (`--appimage-extract`, which
+does not need FUSE). No source rebuild is required. The unpacked Electron app is
+installed into `/app` and launched through
+[`zypak`](https://github.com/refi64/zypak) (provided by the Electron base app),
+which makes Chromium's sandbox work inside the Flatpak sandbox without the SUID
+`chrome-sandbox` helper.
+
+Files:
+
+- `com.adibhanna.zennotes.yml` — flatpak-builder manifest
+- `zennotes.sh` — launcher that wraps the binary with `zypak-wrapper`
+- `com.adibhanna.zennotes.desktop` — desktop entry (Markdown + `zennotes://` handler)
+- `com.adibhanna.zennotes.metainfo.xml` — AppStream metadata
+
+## Build & install locally
+
+Requires `flatpak` and `flatpak-builder`.
+
+```sh
+cd packaging/flatpak
+
+# one-time: runtime, SDK and Electron base app (from Flathub)
+flatpak install -y flathub org.freedesktop.Platform//25.08 \
+  org.freedesktop.Sdk//25.08 org.electronjs.Electron2.BaseApp//25.08
+
+flatpak-builder --user --install --force-clean build-dir com.adibhanna.zennotes.yml
+
+flatpak run com.adibhanna.zennotes
+```
+
+## Updating to a new release
+
+```sh
+cd packaging/flatpak
+# 1. bump the `url` in com.adibhanna.zennotes.yml to the new release tag
+# 2. update the `sha256`:
+curl -L -o /tmp/ZenNotes.AppImage \
+  https://github.com/ZenNotes/zennotes/releases/download/v<version>/ZenNotes-<version>-linux-x86_64.AppImage
+sha256sum /tmp/ZenNotes.AppImage
+# 3. bump the <release> entry in com.adibhanna.zennotes.metainfo.xml
+# 4. rebuild and smoke-test (see above)
+```
+
+## Notes & limitations
+
+- **Sandbox permissions:** `--filesystem=home` is granted so notes (plain
+  Markdown files) are reachable. Tighten it to a specific path (e.g.
+  `--filesystem=~/Notes`) if you prefer.
+- **Auto-update is disabled** inside Flatpak (`electron-updater` cannot replace a
+  read-only `/app`). Update via `flatpak update` once published, or rebuild with
+  a new `url`/`sha256` for a local install.
+- **Publishing to Flathub** would be a follow-up: it needs the `com.adibhanna.*`
+  app-id owner's sign-off plus screenshots in the AppStream metadata.

--- a/packaging/flatpak/com.adibhanna.zennotes.desktop
+++ b/packaging/flatpak/com.adibhanna.zennotes.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=ZenNotes
+Comment=Keyboard-first Markdown notes app
+Exec=zennotes %U
+Terminal=false
+Type=Application
+Icon=com.adibhanna.zennotes
+StartupWMClass=ZenNotes
+MimeType=text/markdown;x-scheme-handler/zennotes;
+Categories=Office;Utility;TextEditor;

--- a/packaging/flatpak/com.adibhanna.zennotes.metainfo.xml
+++ b/packaging/flatpak/com.adibhanna.zennotes.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.adibhanna.zennotes</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>ZenNotes</name>
+  <summary>Keyboard-first Markdown notes app</summary>
+  <description>
+    <p>
+      ZenNotes is a keyboard-first Markdown notes app that keeps your notes as
+      ordinary Markdown files on disk. It adds Vim-friendly editing, split and
+      preview workflows, tasks, tags, archive/trash, diagrams, search, daily
+      notes and CSV databases (Notion-style Table and Board views over plain
+      .csv files) on top of the files you already own.
+    </p>
+  </description>
+  <launchable type="desktop-id">com.adibhanna.zennotes.desktop</launchable>
+  <url type="homepage">https://zennotes.org</url>
+  <url type="bugtracker">https://github.com/ZenNotes/zennotes/issues</url>
+  <url type="vcs-browser">https://github.com/ZenNotes/zennotes</url>
+  <developer id="com.adibhanna">
+    <name>Adib Hanna</name>
+  </developer>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="2.3.0" date="2026-06-13"/>
+  </releases>
+</component>

--- a/packaging/flatpak/com.adibhanna.zennotes.yml
+++ b/packaging/flatpak/com.adibhanna.zennotes.yml
@@ -1,0 +1,59 @@
+app-id: com.adibhanna.zennotes
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+command: zennotes
+separate-locales: false
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --socket=pulseaudio
+  # Notes are plain Markdown files on disk — allow access to the home dir.
+  - --filesystem=home
+  - --talk-name=org.freedesktop.Notifications
+
+modules:
+  - name: zennotes
+    buildsystem: simple
+    build-commands:
+      # Unpack the official AppImage. `--appimage-extract` uses the embedded
+      # squashfs extractor and needs no FUSE, so it runs inside the build sandbox.
+      - chmod +x ZenNotes.AppImage
+      - ./ZenNotes.AppImage --appimage-extract
+      # Install icons from the AppImage's hicolor tree, renamed to the app-id.
+      - |
+        for s in 16 24 32 48 64 128 256 512; do
+          install -Dm644 "squashfs-root/usr/share/icons/hicolor/${s}x${s}/apps/ZenNotes.png" \
+            "/app/share/icons/hicolor/${s}x${s}/apps/com.adibhanna.zennotes.png"
+        done
+      # Copy the unpacked Electron app into /app, dropping AppImage-only bits.
+      - mkdir -p /app/zennotes
+      - cp -a squashfs-root/. /app/zennotes/
+      - rm -rf /app/zennotes/usr /app/zennotes/AppRun /app/zennotes/.DirIcon
+          /app/zennotes/ZenNotes.png /app/zennotes/ZenNotes.desktop
+      # The SUID chrome-sandbox is unusable in Flatpak; zypak handles sandboxing.
+      - rm -f /app/zennotes/chrome-sandbox
+      - chmod -R a+rX /app/zennotes
+      - install -Dm755 zennotes.sh /app/bin/zennotes
+      - install -Dm644 com.adibhanna.zennotes.desktop
+          /app/share/applications/com.adibhanna.zennotes.desktop
+      - install -Dm644 com.adibhanna.zennotes.metainfo.xml
+          /app/share/metainfo/com.adibhanna.zennotes.metainfo.xml
+    sources:
+      # Bump `url` + `sha256` on each release (see README.md).
+      - type: file
+        url: https://github.com/ZenNotes/zennotes/releases/download/v2.3.0/ZenNotes-2.3.0-linux-x86_64.AppImage
+        sha256: 22f1462bb9f72905461139adea1414cbe6d935338291fbb01fc89f978293c71c
+        dest-filename: ZenNotes.AppImage
+      - type: file
+        path: zennotes.sh
+      - type: file
+        path: com.adibhanna.zennotes.desktop
+      - type: file
+        path: com.adibhanna.zennotes.metainfo.xml

--- a/packaging/flatpak/zennotes.sh
+++ b/packaging/flatpak/zennotes.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrap the Electron binary with zypak so Chromium's sandbox works inside the
+# Flatpak sandbox (the SUID chrome-sandbox is unavailable here).
+exec zypak-wrapper /app/zennotes/ZenNotes "$@"


### PR DESCRIPTION
Adds `packaging/flatpak/`, mirroring the existing `packaging/aur/` setup.

Like the AUR `PKGBUILD`, the manifest downloads the official AppImage from the GitHub release and extracts it at build time (`--appimage-extract`, no FUSE required), then installs the unpacked Electron app against the Flathub Electron base app (`org.electronjs.Electron2.BaseApp`) and launches it via [zypak](https://github.com/refi64/zypak).

Flatpak ships a self-contained runtime, so it sidesteps the host FUSE / system-library issues that keep the AppImage from starting on Fedora Atomic/Silverblue, minimal installs and some Arch variants — the same class of problem as #65.

Includes the flatpak-builder manifest, zypak launcher, desktop entry, AppStream metainfo and a README with build + release-bump steps. Built from a clean checkout and smoke-tested locally on Fedora:

```
flatpak-builder --user --install --force-clean build-dir com.adibhanna.zennotes.yml
flatpak run com.adibhanna.zennotes
```

Publishing to Flathub could be a follow-up; it needs the `com.adibhanna.*` app-id owner's sign-off plus screenshots in the AppStream metadata.