### PR TITLE
feature(vimscript-mappings): add support to extend base keymaps with vimscript

### DIFF
--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -44,6 +44,7 @@ import { applyVimInsertEscape } from '../lib/vim-insert-escape'
 
 let vimCommandsRegistered = false
 let syncedVimBindings: Partial<Record<KeymapId, string[]>> = {}
+let appliedVimMappingLhs: string[] = []
 
 const DEFAULT_VIM_MAPPINGS_TO_CLEAR = [
   'gd',
@@ -164,6 +165,36 @@ function editorHalfPage(view: EditorView | undefined, forward: boolean): void {
   const nextTop = Math.max(0, Math.min(maxTop, scroller.scrollTop + (forward ? half : -half)))
   view.dispatch({ selection: { anchor: range.head } })
   scroller.scrollTop = nextTop
+}
+
+function applyVimMappings(raw: string): void {
+  for (const lhs of appliedVimMappingLhs) {
+    try {
+      Vim.unmap(lhs, 'normal')
+    } catch { 
+      /* ignore */ 
+    }
+  }
+  appliedVimMappingLhs = []
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('"')) continue
+    const [cmd, lhs, rhs] = trimmed.split(/\s+/)
+    if (!lhs) continue
+    try {
+      if ((cmd === 'noremap' || cmd === 'nnoremap') && rhs) {
+        Vim.noremap(lhs, rhs, 'normal')
+        appliedVimMappingLhs.push(lhs)
+      } else if ((cmd === 'map' || cmd === 'nmap') && rhs) {
+        Vim.map(lhs, rhs, 'normal')
+        appliedVimMappingLhs.push(lhs)
+      } else if (cmd === 'unmap' || cmd === 'nunmap') {
+        Vim.unmap(lhs, 'normal')
+      }
+    } catch { 
+      /* ignore bad mappings */ 
+    }
+  }
 }
 
 function syncVimKeymaps(overrides: KeymapOverrides): void {
@@ -1261,6 +1292,8 @@ export function Editor(): JSX.Element {
   const keymapOverrides = useStore((s) => s.keymapOverrides)
   const vimInsertEscape = useStore((s) => s.vimInsertEscape)
   const zenMode = useStore((s) => s.zenMode)
+  const vimMappings = useStore((s) => s.vimMappings)
+  const vimMode = useStore((s)=> s.vimMode)
 
   useEffect(() => {
     registerVimCommands()
@@ -1274,6 +1307,11 @@ export function Editor(): JSX.Element {
   useEffect(() => {
     applyVimInsertEscape(vimInsertEscape)
   }, [vimInsertEscape])
+
+  useEffect(() => {
+    if (!vimMode) return
+    applyVimMappings(vimMappings)
+  }, [vimMappings, vimMode])
 
   return (
     <section className="flex min-w-0 flex-1 flex-col">

--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -20,13 +20,16 @@ import type { PaneLayout, PaneSplit } from '../lib/pane-layout'
 import {
   parseCreateNotePath,
   resolveWikilinkTarget,
-  suggestCreateNotePath
+  suggestCreateNotePath,
 } from '../lib/wikilinks'
-import { classifyLocalAssetHref, resolveAssetVaultRelativePath } from '../lib/local-assets'
+import {
+  classifyLocalAssetHref,
+  resolveAssetVaultRelativePath,
+} from '../lib/local-assets'
 import {
   buildMoveNotePrompt,
   parseMoveNoteTarget,
-  validateMoveNoteTarget
+  validateMoveNoteTarget,
 } from '../lib/move-note'
 import { promptApp } from '../lib/prompt-requests'
 import { StatusBar } from './StatusBar'
@@ -35,12 +38,13 @@ import { focusPaneInDirection, focusPaneOrEdgePanel } from '../lib/pane-nav'
 import { requestPaneMode } from '../lib/pane-mode'
 import {
   getKeymapBinding,
+  getKeymapDefinitions,
   getSequenceTokens,
   type KeymapId,
   type KeymapOverrides,
-} from '../lib/keymaps';
-import { navigateActiveBuffer } from '../lib/buffer-navigation';
-import { applyVimInsertEscape } from '../lib/vim-insert-escape';
+} from '../lib/keymaps'
+import { navigateActiveBuffer } from '../lib/buffer-navigation'
+import { applyVimInsertEscape } from '../lib/vim-insert-escape'
 import {
   type AppliedVimMapping,
   type VimMapCmd,
@@ -49,6 +53,7 @@ import {
   VIM_NOREMAP_CMDS,
   VIM_UNMAP_CMD_MODES,
   VIM_UNMAP_CMDS,
+  toVimSequence,
 } from '../lib/vim-mappings'
 
 let vimCommandsRegistered = false
@@ -68,7 +73,7 @@ const DEFAULT_VIM_MAPPINGS_TO_CLEAR = [
   'zc',
   'zo',
   'zM',
-  'zR'
+  'zR',
 ]
 
 function clearKnownVimMappings(): void {
@@ -81,56 +86,13 @@ function clearKnownVimMappings(): void {
   }
 }
 
-function toVimKeyName(base: string): string {
-  if (base === 'Space') return 'Space'
-  if (base === 'Enter') return 'CR'
-  if (base === 'Esc' || base === 'Escape') return 'Esc'
-  if (base === 'Tab') return 'Tab'
-  if (base === 'ArrowUp') return 'Up'
-  if (base === 'ArrowDown') return 'Down'
-  if (base === 'ArrowLeft') return 'Left'
-  if (base === 'ArrowRight') return 'Right'
-  return base
-}
-
-function toVimSequenceToken(token: string): string | null {
-  const parts = token
-    .split('+')
-    .map((part) => part.trim())
-    .filter(Boolean)
-  if (parts.length === 0) return null
-  const base = parts.pop()
-  if (!base) return null
-  const keyName = toVimKeyName(base)
-  if (parts.length === 0) {
-    if (base.length === 1) return base
-    return `<${keyName}>`
-  }
-  const modifiers = parts
-    .map((part) => {
-      if (part === 'Ctrl') return 'C'
-      if (part === 'Alt') return 'A'
-      if (part === 'Shift') return 'S'
-      if (part === 'Meta' || part === 'Mod') return 'D'
-      return null
-    })
-    .filter(Boolean) as string[]
-  const normalizedKey = base.length === 1 ? base.toLowerCase() : keyName
-  return `<${[...modifiers, normalizedKey].join('-')}>`
-}
-
-function toVimSequence(binding: string): string | null {
-  const tokens = binding
-    .split(/\s+/)
-    .map((token) => token.trim())
-    .filter(Boolean)
-    .map((token) => toVimSequenceToken(token))
-  if (tokens.length === 0 || tokens.some((token) => !token)) return null
-  return tokens.join('')
-}
-
-function paneMapBindings(overrides: KeymapOverrides, actionId: KeymapId): string[] {
-  const prefixBinding = toVimSequence(getKeymapBinding(overrides, 'vim.panePrefix'))
+function paneMapBindings(
+  overrides: KeymapOverrides,
+  actionId: KeymapId,
+): string[] {
+  const prefixBinding = toVimSequence(
+    getKeymapBinding(overrides, 'vim.panePrefix'),
+  )
   const actionBinding = toVimSequence(getKeymapBinding(overrides, actionId))
   if (!prefixBinding || !actionBinding) return []
   const bindings = [`${prefixBinding}${actionBinding}`]
@@ -171,7 +133,10 @@ function editorHalfPage(view: EditorView | undefined, forward: boolean): void {
     range = next
   }
   const maxTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
-  const nextTop = Math.max(0, Math.min(maxTop, scroller.scrollTop + (forward ? half : -half)))
+  const nextTop = Math.max(
+    0,
+    Math.min(maxTop, scroller.scrollTop + (forward ? half : -half)),
+  )
   view.dispatch({ selection: { anchor: range.head } })
   scroller.scrollTop = nextTop
 }
@@ -219,105 +184,106 @@ function applyVimMappings(raw: string, overrides: KeymapOverrides): void {
 }
 
 function syncVimKeymaps(overrides: KeymapOverrides): void {
-  const mappings: Array<{ id: KeymapId; action: string; bindings: string[] }> = [
-    {
-      id: 'vim.goToDefinition',
-      action: 'goToDefinition',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.goToDefinition'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.paneFocusLeft',
-      action: 'focusPaneLeft',
-      bindings: paneMapBindings(overrides, 'vim.paneFocusLeft')
-    },
-    {
-      id: 'vim.paneFocusDown',
-      action: 'focusPaneDown',
-      bindings: paneMapBindings(overrides, 'vim.paneFocusDown')
-    },
-    {
-      id: 'vim.paneFocusUp',
-      action: 'focusPaneUp',
-      bindings: paneMapBindings(overrides, 'vim.paneFocusUp')
-    },
-    {
-      id: 'vim.paneFocusRight',
-      action: 'focusPaneRight',
-      bindings: paneMapBindings(overrides, 'vim.paneFocusRight')
-    },
-    {
-      id: 'vim.bufferPrevious',
-      action: 'previousBuffer',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.bufferPrevious'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.bufferNext',
-      action: 'nextBuffer',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.bufferNext'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.tabPrevious',
-      action: 'previousBuffer',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.tabPrevious'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.tabNext',
-      action: 'nextBuffer',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.tabNext'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.foldCurrent',
-      action: 'foldHeadingAtCursor',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.foldCurrent'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.unfoldCurrent',
-      action: 'unfoldHeadingAtCursor',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.unfoldCurrent'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.foldAll',
-      action: 'foldAllHeadings',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.foldAll'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.unfoldAll',
-      action: 'unfoldAllHeadings',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.unfoldAll'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'nav.halfPageDown',
-      action: 'zenHalfPageDown',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'nav.halfPageUp',
-      action: 'zenHalfPageUp',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'nav.halfPageUp'))].filter(
-        (binding): binding is string => !!binding
-      )
-    }
-  ]
+  const mappings: Array<{ id: KeymapId; action: string; bindings: string[] }> =
+    [
+      {
+        id: 'vim.goToDefinition',
+        action: 'goToDefinition',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.goToDefinition')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'vim.paneFocusLeft',
+        action: 'focusPaneLeft',
+        bindings: paneMapBindings(overrides, 'vim.paneFocusLeft'),
+      },
+      {
+        id: 'vim.paneFocusDown',
+        action: 'focusPaneDown',
+        bindings: paneMapBindings(overrides, 'vim.paneFocusDown'),
+      },
+      {
+        id: 'vim.paneFocusUp',
+        action: 'focusPaneUp',
+        bindings: paneMapBindings(overrides, 'vim.paneFocusUp'),
+      },
+      {
+        id: 'vim.paneFocusRight',
+        action: 'focusPaneRight',
+        bindings: paneMapBindings(overrides, 'vim.paneFocusRight'),
+      },
+      {
+        id: 'vim.bufferPrevious',
+        action: 'previousBuffer',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.bufferPrevious')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'vim.bufferNext',
+        action: 'nextBuffer',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.bufferNext')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'vim.tabPrevious',
+        action: 'previousBuffer',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.tabPrevious')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'vim.tabNext',
+        action: 'nextBuffer',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.tabNext')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'vim.foldCurrent',
+        action: 'foldHeadingAtCursor',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.foldCurrent')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'vim.unfoldCurrent',
+        action: 'unfoldHeadingAtCursor',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldCurrent')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'vim.foldAll',
+        action: 'foldAllHeadings',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.foldAll')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'vim.unfoldAll',
+        action: 'unfoldAllHeadings',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldAll')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'nav.halfPageDown',
+        action: 'zenHalfPageDown',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown')),
+        ].filter((binding): binding is string => !!binding),
+      },
+      {
+        id: 'nav.halfPageUp',
+        action: 'zenHalfPageUp',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageUp')),
+        ].filter((binding): binding is string => !!binding),
+      },
+    ]
 
   for (const mapping of mappings) {
     for (const binding of syncedVimBindings[mapping.id] ?? []) {
@@ -328,7 +294,13 @@ function syncVimKeymaps(overrides: KeymapOverrides): void {
       }
     }
     for (const binding of mapping.bindings) {
-      Vim.mapCommand(binding, 'action', mapping.action, {}, { context: 'normal' })
+      Vim.mapCommand(
+        binding,
+        'action',
+        mapping.action,
+        {},
+        { context: 'normal' },
+      )
     }
     syncedVimBindings[mapping.id] = mapping.bindings
   }
@@ -337,7 +309,8 @@ function syncVimKeymaps(overrides: KeymapOverrides): void {
 function unwrapMdUrl(url: string): string {
   // Markdown wraps URLs with spaces in angle brackets: `[x](<a b.pdf>)`.
   const trimmed = url.trim()
-  if (trimmed.startsWith('<') && trimmed.endsWith('>')) return trimmed.slice(1, -1)
+  if (trimmed.startsWith('<') && trimmed.endsWith('>'))
+    return trimmed.slice(1, -1)
   return trimmed
 }
 
@@ -425,7 +398,7 @@ function registerVimCommands(): void {
   // prefix of `template`) is registered as its own command sharing the handler.
   const runTemplateEx = (
     _cm: unknown,
-    params: { argString?: string } | undefined
+    params: { argString?: string } | undefined,
   ): void => {
     const state = useStore.getState()
     const arg = (params?.argString ?? '').trim()
@@ -435,7 +408,7 @@ function registerVimCommands(): void {
     }
     const all = mergeTemplates(
       state.hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES,
-      state.customTemplates
+      state.customTemplates,
     )
     const lower = arg.toLowerCase()
     const match =
@@ -475,7 +448,7 @@ function registerVimCommands(): void {
       }
       state.setSelectedTags(args)
       void state.openTagView()
-    }
+    },
   )
 
   // Vim-style window splits. `:split` clones the current tab into a
@@ -488,7 +461,7 @@ function registerVimCommands(): void {
     void state.splitPaneWithTab({
       targetPaneId: state.activePaneId,
       edge: 'bottom',
-      path
+      path,
     })
   })
   Vim.defineEx('vsplit', 'vs', () => {
@@ -498,7 +471,7 @@ function registerVimCommands(): void {
     void state.splitPaneWithTab({
       targetPaneId: state.activePaneId,
       edge: 'right',
-      path
+      path,
     })
   })
 
@@ -509,10 +482,15 @@ function registerVimCommands(): void {
   const focusDir = (dir: 'h' | 'j' | 'k' | 'l'): void => {
     focusPaneInDirection(dir)
   }
-  Vim.defineEx('wincmd', 'winc', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const dir = (params?.argString ?? '').trim().toLowerCase()[0]
-    if (dir === 'h' || dir === 'j' || dir === 'k' || dir === 'l') focusDir(dir)
-  })
+  Vim.defineEx(
+    'wincmd',
+    'winc',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const dir = (params?.argString ?? '').trim().toLowerCase()[0]
+      if (dir === 'h' || dir === 'j' || dir === 'k' || dir === 'l')
+        focusDir(dir)
+    },
+  )
   Vim.defineEx('pane_focus_left', 'pane_focus_left', () => focusDir('h'))
   Vim.defineEx('pane_focus_down', 'pane_focus_down', () => focusDir('j'))
   Vim.defineEx('pane_focus_up', 'pane_focus_up', () => focusDir('k'))
@@ -571,21 +549,27 @@ function registerVimCommands(): void {
         } catch (err) {
           return (err as Error).message
         }
-      }
+      },
     }).then(async (value) => {
       if (!value) return
       try {
         const parsed = parseCreateNotePath(value)
         const existing = state.notes.find(
-          (note) => note.folder !== 'trash' && note.path.toLowerCase() === parsed.relPath.toLowerCase()
+          (note) =>
+            note.folder !== 'trash' &&
+            note.path.toLowerCase() === parsed.relPath.toLowerCase(),
         )
         if (existing) {
           await state.selectNote(existing.path)
           state.setFocusedPanel('editor')
-          requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
+          requestAnimationFrame(() =>
+            useStore.getState().editorViewRef?.focus(),
+          )
           return
         }
-        await state.createAndOpen(parsed.folder, parsed.subpath, { title: parsed.title })
+        await state.createAndOpen(parsed.folder, parsed.subpath, {
+          title: parsed.title,
+        })
         state.setFocusedPanel('editor')
         requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
       } catch (err) {
@@ -641,7 +625,11 @@ function registerVimCommands(): void {
  * - `:h[elp]`            open the built-in Help manual
  */
 function registerVimNoteCommands(): void {
-  const getActiveLeaf = (): { id: string; tabs: string[]; activeTab: string | null } | null => {
+  const getActiveLeaf = (): {
+    id: string
+    tabs: string[]
+    activeTab: string | null
+  } | null => {
     const s = useStore.getState()
     const leaves = allLeavesFlat(s.paneLayout)
     return leaves.find((l) => l.id === s.activePaneId) ?? null
@@ -663,7 +651,7 @@ function registerVimNoteCommands(): void {
     const existing = state.notes.find(
       (n) =>
         n.folder !== 'trash' &&
-        n.path.toLowerCase() === parsed.relPath.toLowerCase()
+        n.path.toLowerCase() === parsed.relPath.toLowerCase(),
     )
     if (existing) {
       await state.selectNote(existing.path)
@@ -672,7 +660,7 @@ function registerVimNoteCommands(): void {
       return
     }
     await state.createAndOpen(parsed.folder, parsed.subpath, {
-      title: parsed.title
+      title: parsed.title,
     })
     state.setFocusedPanel('editor')
     requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
@@ -683,7 +671,7 @@ function registerVimNoteCommands(): void {
     'e',
     (_cm: unknown, params: { argString?: string } | undefined) => {
       void openOrCreateByPath(params?.argString ?? '')
-    }
+    },
   )
 
   // `:new` shadows vim's "horizontal split empty buffer" — for a notes
@@ -694,11 +682,13 @@ function registerVimNoteCommands(): void {
     (_cm: unknown, params: { argString?: string } | undefined) => {
       const arg = (params?.argString ?? '').trim()
       if (!arg) {
-        void useStore.getState().createAndOpen('inbox', '', { focusTitle: true })
+        void useStore
+          .getState()
+          .createAndOpen('inbox', '', { focusTitle: true })
         return
       }
       void openOrCreateByPath(arg)
-    }
+    },
   )
 
   const moveActiveNote = async (raw: string): Promise<void> => {
@@ -709,7 +699,8 @@ function registerVimNoteCommands(): void {
     const value = raw.trim()
     let target = value
     if (!target) {
-      target = (await promptApp(buildMoveNotePrompt(active, state.folders))) ?? ''
+      target =
+        (await promptApp(buildMoveNotePrompt(active, state.folders))) ?? ''
       if (!target) return
     }
 
@@ -722,18 +713,29 @@ function registerVimNoteCommands(): void {
     await state.moveNote(active.path, dest.folder, dest.subpath)
   }
 
-  const runMoveEx = (_cm: unknown, params: { argString?: string } | undefined): void => {
+  const runMoveEx = (
+    _cm: unknown,
+    params: { argString?: string } | undefined,
+  ): void => {
     void moveActiveNote(params?.argString ?? '')
   }
 
   Vim.defineEx('move', 'move', runMoveEx)
   Vim.defineEx('mv', 'mv', runMoveEx)
 
-  Vim.defineEx('bnext', 'bn', () => navigateActiveBuffer(useStore.getState(), 1))
-  Vim.defineEx('bprev', 'bp', () => navigateActiveBuffer(useStore.getState(), -1))
+  Vim.defineEx('bnext', 'bn', () =>
+    navigateActiveBuffer(useStore.getState(), 1),
+  )
+  Vim.defineEx('bprev', 'bp', () =>
+    navigateActiveBuffer(useStore.getState(), -1),
+  )
   // Vim tab aliases over the same active-pane tab navigation.
-  Vim.defineEx('tabnext', 'tabn', () => navigateActiveBuffer(useStore.getState(), 1))
-  Vim.defineEx('tabprevious', 'tabp', () => navigateActiveBuffer(useStore.getState(), -1))
+  Vim.defineEx('tabnext', 'tabn', () =>
+    navigateActiveBuffer(useStore.getState(), 1),
+  )
+  Vim.defineEx('tabprevious', 'tabp', () =>
+    navigateActiveBuffer(useStore.getState(), -1),
+  )
   // Vim aliases: :bNext and :bfirst/:blast — rare, skipped.
 
   const closeActiveTabLikeQuit = (): void => {
@@ -787,22 +789,34 @@ function registerVimNoteCommands(): void {
       requestPaneMode(mode)
     })
   }
-  Vim.defineEx('view', 'view', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const nextMode = (params?.argString ?? '').trim().toLowerCase()
-    if (nextMode === 'edit' || nextMode === 'split' || nextMode === 'preview') {
-      setPaneMode(nextMode)
-    }
-  })
-  Vim.defineEx('zen', 'zen', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const nextMode = (params?.argString ?? '').trim().toLowerCase()
-    if (!nextMode || nextMode === 'toggle') {
-      setZenMode('toggle')
-      return
-    }
-    if (nextMode === 'on' || nextMode === 'off') {
-      setZenMode(nextMode)
-    }
-  })
+  Vim.defineEx(
+    'view',
+    'view',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const nextMode = (params?.argString ?? '').trim().toLowerCase()
+      if (
+        nextMode === 'edit' ||
+        nextMode === 'split' ||
+        nextMode === 'preview'
+      ) {
+        setPaneMode(nextMode)
+      }
+    },
+  )
+  Vim.defineEx(
+    'zen',
+    'zen',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const nextMode = (params?.argString ?? '').trim().toLowerCase()
+      if (!nextMode || nextMode === 'toggle') {
+        setZenMode('toggle')
+        return
+      }
+      if (nextMode === 'on' || nextMode === 'off') {
+        setZenMode(nextMode)
+      }
+    },
+  )
   Vim.defineEx('zenmode', 'zenmode', () => setZenMode('toggle'))
   Vim.defineEx('editmode', 'editmode', () => setPaneMode('edit'))
   Vim.defineEx('splitmode', 'splitmode', () => setPaneMode('split'))
@@ -844,7 +858,9 @@ function registerVimNoteCommands(): void {
   // on the current heading; `:foldall` / `:unfoldall` cover the whole
   // note. We map vim's `zc` / `zo` / `zM` / `zR` keys explicitly so the
   // advertised fold chords work regardless of what CM-Vim ships by default.
-  const runFold = (cmd: (view: { state: unknown; dispatch: unknown }) => boolean): void => {
+  const runFold = (
+    cmd: (view: { state: unknown; dispatch: unknown }) => boolean,
+  ): void => {
     const view = useStore.getState().editorViewRef
     if (!view) return
     cmd(view as unknown as Parameters<typeof foldCode>[0])
@@ -855,10 +871,10 @@ function registerVimNoteCommands(): void {
   Vim.defineAction('foldAllHeadings', () => runFold(foldAll as never))
   Vim.defineAction('unfoldAllHeadings', () => runFold(unfoldAll as never))
   Vim.defineAction('zenHalfPageDown', (cm: ReturnType<typeof getCM>) =>
-    editorHalfPage((cm as unknown as { cm6?: EditorView }).cm6, true)
+    editorHalfPage((cm as unknown as { cm6?: EditorView }).cm6, true),
   )
   Vim.defineAction('zenHalfPageUp', (cm: ReturnType<typeof getCM>) =>
-    editorHalfPage((cm as unknown as { cm6?: EditorView }).cm6, false)
+    editorHalfPage((cm as unknown as { cm6?: EditorView }).cm6, false),
   )
   Vim.defineEx('fold', 'fold', () => runFold(foldCode as never))
   Vim.defineEx('unfold', 'unfold', () => runFold(unfoldCode as never))
@@ -870,12 +886,13 @@ function registerVimNoteCommands(): void {
  *  `allLeaves` helper (which lives in `lib/pane-layout`). Duplicated
  *  locally to avoid a new import chain. */
 function allLeavesFlat(
-  node: PaneLayout
+  node: PaneLayout,
 ): Array<{ id: string; tabs: string[]; activeTab: string | null }> {
   if (node.kind === 'leaf') {
     return [{ id: node.id, tabs: node.tabs, activeTab: node.activeTab }]
   }
-  const out: Array<{ id: string; tabs: string[]; activeTab: string | null }> = []
+  const out: Array<{ id: string; tabs: string[]; activeTab: string | null }> =
+    []
   for (const child of node.children) out.push(...allLeavesFlat(child))
   return out
 }
@@ -941,7 +958,7 @@ const MANUAL_EX_NAMES = new Set([
   'wall',
   'wa',
   'help',
-  'h'
+  'h',
 ])
 
 function commandIdToExName(id: string): string {
@@ -999,11 +1016,11 @@ function registerCommandPaletteEx(): void {
       const ranked = rankItems(commands, query, [
         { get: (c) => c.title, weight: 1 },
         { get: (c) => c.keywords ?? '', weight: 0.6 },
-        { get: (c) => c.category, weight: 0.4 }
+        { get: (c) => c.category, weight: 0.4 },
       ])
       const first = ranked.find((c) => !c.when || c.when())
       if (first) runCommand(first)
-    }
+    },
   )
   names.add('cmd')
 
@@ -1053,7 +1070,7 @@ function ensureWildmenu(): Wildmenu {
     'box-shadow: 0 10px 30px rgba(0,0,0,0.35)',
     'font: 12px/1.4 var(--z-mono-font, ui-monospace, Menlo, monospace)',
     'color: rgb(var(--z-fg))',
-    'backdrop-filter: blur(6px)'
+    'backdrop-filter: blur(6px)',
   ].join(';')
 
   const list = document.createElement('div')
@@ -1088,7 +1105,11 @@ interface ExCompletionMatch {
   apply: string
 }
 
-function renderWildmenu(matches: ExCompletionMatch[], cycleIdx: number, anchor: HTMLElement): void {
+function renderWildmenu(
+  matches: ExCompletionMatch[],
+  cycleIdx: number,
+  anchor: HTMLElement,
+): void {
   const menu = ensureWildmenu()
   if (matches.length === 0) {
     menu.root.style.display = 'none'
@@ -1111,7 +1132,7 @@ function renderWildmenu(matches: ExCompletionMatch[], cycleIdx: number, anchor: 
       'white-space: nowrap',
       isActive
         ? 'background: rgb(var(--z-accent) / 0.85); color: white'
-        : 'color: rgb(var(--z-fg))'
+        : 'color: rgb(var(--z-fg))',
     ].join(';')
     menu.list.appendChild(row)
   })
@@ -1128,7 +1149,7 @@ function renderWildmenu(matches: ExCompletionMatch[], cycleIdx: number, anchor: 
   positionWildmenu(anchor)
 
   const activeRow = menu.list.querySelector<HTMLDivElement>(
-    `[data-idx="${cycleIdx}"]`
+    `[data-idx="${cycleIdx}"]`,
   )
   if (activeRow) activeRow.scrollIntoView({ block: 'nearest' })
 }
@@ -1155,7 +1176,7 @@ let exCycle: ExTabCycle | null = null
 function completeCommandArgs(
   input: string,
   command: string,
-  options: string[]
+  options: string[],
 ): ExCompletionMatch[] | null {
   const match = input.match(/^([A-Za-z0-9_]+)(\s+)([^ ]*)$/)
   if (!match) return null
@@ -1166,7 +1187,7 @@ function completeCommandArgs(
     : options
   return filtered.map((option) => ({
     label: option,
-    apply: `${commandName}${whitespace}${option}`
+    apply: `${commandName}${whitespace}${option}`,
   }))
 }
 
@@ -1214,7 +1235,12 @@ function installExTabCompletion(): void {
         // the app shouldn't clobber our state (modifier keys fire even
         // when the input is focused too, so we ignore those explicitly
         // instead of resetting on them).
-        if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Alt' || e.key === 'Meta') {
+        if (
+          e.key === 'Shift' ||
+          e.key === 'Control' ||
+          e.key === 'Alt' ||
+          e.key === 'Meta'
+        ) {
           return
         }
         const target = e.target as HTMLElement | null
@@ -1244,7 +1270,8 @@ function installExTabCompletion(): void {
       e.stopImmediatePropagation()
 
       const step = e.shiftKey ? -1 : 1
-      const fresh = !exCycle || exCycle.input !== target || exCycle.basePrefix === null
+      const fresh =
+        !exCycle || exCycle.input !== target || exCycle.basePrefix === null
 
       if (fresh) {
         exCycle = {
@@ -1254,7 +1281,7 @@ function installExTabCompletion(): void {
           // exactly the prefix we want to filter by.
           basePrefix: target.value,
           matches: computeExMatches(target.value),
-          cycleIdx: step === 1 ? 0 : -1 // sentinel; normalized below
+          cycleIdx: step === 1 ? 0 : -1, // sentinel; normalized below
         }
       } else if (exCycle) {
         exCycle.cycleIdx += step
@@ -1282,7 +1309,7 @@ function installExTabCompletion(): void {
       // Render / refresh the wildmenu with the highlighted match.
       renderWildmenu(cycle.matches, idx, target)
     },
-    true
+    true,
   )
 
   // Hide the wildmenu when the ex prompt's own input is detached from
@@ -1373,7 +1400,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
         index: handleIndex,
         startClient: isRow ? e.clientX : e.clientY,
         startSizes: split.sizes.slice(),
-        totalPx
+        totalPx,
       }
       const onMove = (ev: MouseEvent): void => {
         const st = dragState.current
@@ -1411,7 +1438,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
       document.body.style.cursor = isRow ? 'col-resize' : 'row-resize'
       document.body.style.userSelect = 'none'
     },
-    [isRow, resizeSplit, split.id, split.sizes]
+    [isRow, resizeSplit, split.id, split.sizes],
   )
 
   const nodes = useMemo(() => {
@@ -1421,11 +1448,13 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
       out.push(
         <div
           key={child.id}
-          className={['flex min-h-0 min-w-0', isRow ? '' : 'flex-col'].join(' ')}
+          className={['flex min-h-0 min-w-0', isRow ? '' : 'flex-col'].join(
+            ' ',
+          )}
           style={{ flex: `${basis} 1 0`, minWidth: 0, minHeight: 0 }}
         >
           <PaneTreeView node={child} />
-        </div>
+        </div>,
       )
       if (i < split.children.length - 1) {
         out.push(
@@ -1433,7 +1462,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
             key={`handle-${child.id}`}
             orientation={isRow ? 'vertical' : 'horizontal'}
             onMouseDown={onHandleMouseDown(i)}
-          />
+          />,
         )
       }
     })
@@ -1443,7 +1472,10 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
   return (
     <div
       ref={containerRef}
-      className={['flex min-h-0 min-w-0 flex-1', isRow ? 'flex-row' : 'flex-col'].join(' ')}
+      className={[
+        'flex min-h-0 min-w-0 flex-1',
+        isRow ? 'flex-row' : 'flex-col',
+      ].join(' ')}
     >
       {nodes}
     </div>
@@ -1457,7 +1489,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
  */
 function ResizeDivider({
   orientation,
-  onMouseDown
+  onMouseDown,
 }: {
   orientation: 'vertical' | 'horizontal'
   onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void
@@ -1470,9 +1502,7 @@ function ResizeDivider({
       onMouseDown={onMouseDown}
       className={[
         'group relative z-10 shrink-0 select-none bg-paper-300/70 transition-colors hover:bg-accent/60 active:bg-accent',
-        isVertical
-          ? 'w-px cursor-col-resize'
-          : 'h-px cursor-row-resize'
+        isVertical ? 'w-px cursor-col-resize' : 'h-px cursor-row-resize',
       ].join(' ')}
     >
       {/* Wider hit zone centered on the divider line. */}
@@ -1481,7 +1511,7 @@ function ResizeDivider({
           'absolute',
           isVertical
             ? 'top-0 bottom-0 -left-1 w-[9px]'
-            : 'left-0 right-0 -top-1 h-[9px]'
+            : 'left-0 right-0 -top-1 h-[9px]',
         ].join(' ')}
       />
     </div>

--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -20,16 +20,16 @@ import type { PaneLayout, PaneSplit } from '../lib/pane-layout'
 import {
   parseCreateNotePath,
   resolveWikilinkTarget,
-  suggestCreateNotePath,
+  suggestCreateNotePath
 } from '../lib/wikilinks'
 import {
   classifyLocalAssetHref,
-  resolveAssetVaultRelativePath,
+  resolveAssetVaultRelativePath
 } from '../lib/local-assets'
 import {
   buildMoveNotePrompt,
   parseMoveNoteTarget,
-  validateMoveNoteTarget,
+  validateMoveNoteTarget
 } from '../lib/move-note'
 import { promptApp } from '../lib/prompt-requests'
 import { StatusBar } from './StatusBar'
@@ -41,7 +41,7 @@ import {
   getKeymapDefinitions,
   getSequenceTokens,
   type KeymapId,
-  type KeymapOverrides,
+  type KeymapOverrides
 } from '../lib/keymaps'
 import { navigateActiveBuffer } from '../lib/buffer-navigation'
 import { applyVimInsertEscape } from '../lib/vim-insert-escape'
@@ -53,7 +53,7 @@ import {
   VIM_NOREMAP_CMDS,
   VIM_UNMAP_CMD_MODES,
   VIM_UNMAP_CMDS,
-  toVimSequence,
+  toVimSequence
 } from '../lib/vim-mappings'
 
 let vimCommandsRegistered = false
@@ -73,7 +73,7 @@ const DEFAULT_VIM_MAPPINGS_TO_CLEAR = [
   'zc',
   'zo',
   'zM',
-  'zR',
+  'zR'
 ]
 
 function clearKnownVimMappings(): void {
@@ -88,10 +88,10 @@ function clearKnownVimMappings(): void {
 
 function paneMapBindings(
   overrides: KeymapOverrides,
-  actionId: KeymapId,
+  actionId: KeymapId
 ): string[] {
   const prefixBinding = toVimSequence(
-    getKeymapBinding(overrides, 'vim.panePrefix'),
+    getKeymapBinding(overrides, 'vim.panePrefix')
   )
   const actionBinding = toVimSequence(getKeymapBinding(overrides, actionId))
   if (!prefixBinding || !actionBinding) return []
@@ -135,7 +135,7 @@ function editorHalfPage(view: EditorView | undefined, forward: boolean): void {
   const maxTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
   const nextTop = Math.max(
     0,
-    Math.min(maxTop, scroller.scrollTop + (forward ? half : -half)),
+    Math.min(maxTop, scroller.scrollTop + (forward ? half : -half))
   )
   view.dispatch({ selection: { anchor: range.head } })
   scroller.scrollTop = nextTop
@@ -152,7 +152,7 @@ function applyVimMappings(raw: string, overrides: KeymapOverrides): void {
   appliedVimMappings = []
 
   const leaderKey = toVimSequence(
-    getKeymapBinding(overrides, 'vim.leaderPrefix'),
+    getKeymapBinding(overrides, 'vim.leaderPrefix')
   )!
   const resolve = (token: string): string =>
     token.replace(/<leader>/gi, leaderKey)
@@ -191,99 +191,99 @@ function syncVimKeymaps(overrides: KeymapOverrides): void {
         id: 'vim.goToDefinition',
         action: 'goToDefinition',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.goToDefinition')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.goToDefinition'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'vim.paneFocusLeft',
         action: 'focusPaneLeft',
-        bindings: paneMapBindings(overrides, 'vim.paneFocusLeft'),
+        bindings: paneMapBindings(overrides, 'vim.paneFocusLeft')
       },
       {
         id: 'vim.paneFocusDown',
         action: 'focusPaneDown',
-        bindings: paneMapBindings(overrides, 'vim.paneFocusDown'),
+        bindings: paneMapBindings(overrides, 'vim.paneFocusDown')
       },
       {
         id: 'vim.paneFocusUp',
         action: 'focusPaneUp',
-        bindings: paneMapBindings(overrides, 'vim.paneFocusUp'),
+        bindings: paneMapBindings(overrides, 'vim.paneFocusUp')
       },
       {
         id: 'vim.paneFocusRight',
         action: 'focusPaneRight',
-        bindings: paneMapBindings(overrides, 'vim.paneFocusRight'),
+        bindings: paneMapBindings(overrides, 'vim.paneFocusRight')
       },
       {
         id: 'vim.bufferPrevious',
         action: 'previousBuffer',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.bufferPrevious')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.bufferPrevious'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'vim.bufferNext',
         action: 'nextBuffer',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.bufferNext')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.bufferNext'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'vim.tabPrevious',
         action: 'previousBuffer',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.tabPrevious')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.tabPrevious'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'vim.tabNext',
         action: 'nextBuffer',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.tabNext')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.tabNext'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'vim.foldCurrent',
         action: 'foldHeadingAtCursor',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.foldCurrent')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.foldCurrent'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'vim.unfoldCurrent',
         action: 'unfoldHeadingAtCursor',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldCurrent')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldCurrent'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'vim.foldAll',
         action: 'foldAllHeadings',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.foldAll')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.foldAll'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'vim.unfoldAll',
         action: 'unfoldAllHeadings',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldAll')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldAll'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'nav.halfPageDown',
         action: 'zenHalfPageDown',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown')),
-        ].filter((binding): binding is string => !!binding),
+          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown'))
+        ].filter((binding): binding is string => !!binding)
       },
       {
         id: 'nav.halfPageUp',
         action: 'zenHalfPageUp',
         bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageUp')),
-        ].filter((binding): binding is string => !!binding),
-      },
+          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageUp'))
+        ].filter((binding): binding is string => !!binding)
+      }
     ]
 
   for (const mapping of mappings) {
@@ -300,7 +300,7 @@ function syncVimKeymaps(overrides: KeymapOverrides): void {
         'action',
         mapping.action,
         {},
-        { context: 'normal' },
+        { context: 'normal' }
       )
     }
     syncedVimBindings[mapping.id] = mapping.bindings
@@ -399,7 +399,7 @@ function registerVimCommands(): void {
   // prefix of `template`) is registered as its own command sharing the handler.
   const runTemplateEx = (
     _cm: unknown,
-    params: { argString?: string } | undefined,
+    params: { argString?: string } | undefined
   ): void => {
     const state = useStore.getState()
     const arg = (params?.argString ?? '').trim()
@@ -409,7 +409,7 @@ function registerVimCommands(): void {
     }
     const all = mergeTemplates(
       state.hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES,
-      state.customTemplates,
+      state.customTemplates
     )
     const lower = arg.toLowerCase()
     const match =
@@ -449,7 +449,7 @@ function registerVimCommands(): void {
       }
       state.setSelectedTags(args)
       void state.openTagView()
-    },
+    }
   )
 
   // Vim-style window splits. `:split` clones the current tab into a
@@ -462,7 +462,7 @@ function registerVimCommands(): void {
     void state.splitPaneWithTab({
       targetPaneId: state.activePaneId,
       edge: 'bottom',
-      path,
+      path
     })
   })
   Vim.defineEx('vsplit', 'vs', () => {
@@ -472,7 +472,7 @@ function registerVimCommands(): void {
     void state.splitPaneWithTab({
       targetPaneId: state.activePaneId,
       edge: 'right',
-      path,
+      path
     })
   })
 
@@ -490,7 +490,7 @@ function registerVimCommands(): void {
       const dir = (params?.argString ?? '').trim().toLowerCase()[0]
       if (dir === 'h' || dir === 'j' || dir === 'k' || dir === 'l')
         focusDir(dir)
-    },
+    }
   )
   Vim.defineEx('pane_focus_left', 'pane_focus_left', () => focusDir('h'))
   Vim.defineEx('pane_focus_down', 'pane_focus_down', () => focusDir('j'))
@@ -550,7 +550,7 @@ function registerVimCommands(): void {
         } catch (err) {
           return (err as Error).message
         }
-      },
+      }
     }).then(async (value) => {
       if (!value) return
       try {
@@ -558,18 +558,18 @@ function registerVimCommands(): void {
         const existing = state.notes.find(
           (note) =>
             note.folder !== 'trash' &&
-            note.path.toLowerCase() === parsed.relPath.toLowerCase(),
+            note.path.toLowerCase() === parsed.relPath.toLowerCase()
         )
         if (existing) {
           await state.selectNote(existing.path)
           state.setFocusedPanel('editor')
           requestAnimationFrame(() =>
-            useStore.getState().editorViewRef?.focus(),
+            useStore.getState().editorViewRef?.focus()
           )
           return
         }
         await state.createAndOpen(parsed.folder, parsed.subpath, {
-          title: parsed.title,
+          title: parsed.title
         })
         state.setFocusedPanel('editor')
         requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
@@ -652,7 +652,7 @@ function registerVimNoteCommands(): void {
     const existing = state.notes.find(
       (n) =>
         n.folder !== 'trash' &&
-        n.path.toLowerCase() === parsed.relPath.toLowerCase(),
+        n.path.toLowerCase() === parsed.relPath.toLowerCase()
     )
     if (existing) {
       await state.selectNote(existing.path)
@@ -661,7 +661,7 @@ function registerVimNoteCommands(): void {
       return
     }
     await state.createAndOpen(parsed.folder, parsed.subpath, {
-      title: parsed.title,
+      title: parsed.title
     })
     state.setFocusedPanel('editor')
     requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
@@ -672,7 +672,7 @@ function registerVimNoteCommands(): void {
     'e',
     (_cm: unknown, params: { argString?: string } | undefined) => {
       void openOrCreateByPath(params?.argString ?? '')
-    },
+    }
   )
 
   // `:new` shadows vim's "horizontal split empty buffer" — for a notes
@@ -689,7 +689,7 @@ function registerVimNoteCommands(): void {
         return
       }
       void openOrCreateByPath(arg)
-    },
+    }
   )
 
   const moveActiveNote = async (raw: string): Promise<void> => {
@@ -716,7 +716,7 @@ function registerVimNoteCommands(): void {
 
   const runMoveEx = (
     _cm: unknown,
-    params: { argString?: string } | undefined,
+    params: { argString?: string } | undefined
   ): void => {
     void moveActiveNote(params?.argString ?? '')
   }
@@ -725,17 +725,17 @@ function registerVimNoteCommands(): void {
   Vim.defineEx('mv', 'mv', runMoveEx)
 
   Vim.defineEx('bnext', 'bn', () =>
-    navigateActiveBuffer(useStore.getState(), 1),
+    navigateActiveBuffer(useStore.getState(), 1)
   )
   Vim.defineEx('bprev', 'bp', () =>
-    navigateActiveBuffer(useStore.getState(), -1),
+    navigateActiveBuffer(useStore.getState(), -1)
   )
   // Vim tab aliases over the same active-pane tab navigation.
   Vim.defineEx('tabnext', 'tabn', () =>
-    navigateActiveBuffer(useStore.getState(), 1),
+    navigateActiveBuffer(useStore.getState(), 1)
   )
   Vim.defineEx('tabprevious', 'tabp', () =>
-    navigateActiveBuffer(useStore.getState(), -1),
+    navigateActiveBuffer(useStore.getState(), -1)
   )
   // Vim aliases: :bNext and :bfirst/:blast — rare, skipped.
 
@@ -802,7 +802,7 @@ function registerVimNoteCommands(): void {
       ) {
         setPaneMode(nextMode)
       }
-    },
+    }
   )
   Vim.defineEx(
     'zen',
@@ -816,7 +816,7 @@ function registerVimNoteCommands(): void {
       if (nextMode === 'on' || nextMode === 'off') {
         setZenMode(nextMode)
       }
-    },
+    }
   )
   Vim.defineEx('zenmode', 'zenmode', () => setZenMode('toggle'))
   Vim.defineEx('editmode', 'editmode', () => setPaneMode('edit'))
@@ -860,7 +860,7 @@ function registerVimNoteCommands(): void {
   // note. We map vim's `zc` / `zo` / `zM` / `zR` keys explicitly so the
   // advertised fold chords work regardless of what CM-Vim ships by default.
   const runFold = (
-    cmd: (view: { state: unknown; dispatch: unknown }) => boolean,
+    cmd: (view: { state: unknown; dispatch: unknown }) => boolean
   ): void => {
     const view = useStore.getState().editorViewRef
     if (!view) return
@@ -872,10 +872,10 @@ function registerVimNoteCommands(): void {
   Vim.defineAction('foldAllHeadings', () => runFold(foldAll as never))
   Vim.defineAction('unfoldAllHeadings', () => runFold(unfoldAll as never))
   Vim.defineAction('zenHalfPageDown', (cm: ReturnType<typeof getCM>) =>
-    editorHalfPage((cm as unknown as { cm6?: EditorView }).cm6, true),
+    editorHalfPage((cm as unknown as { cm6?: EditorView }).cm6, true)
   )
   Vim.defineAction('zenHalfPageUp', (cm: ReturnType<typeof getCM>) =>
-    editorHalfPage((cm as unknown as { cm6?: EditorView }).cm6, false),
+    editorHalfPage((cm as unknown as { cm6?: EditorView }).cm6, false)
   )
   Vim.defineEx('fold', 'fold', () => runFold(foldCode as never))
   Vim.defineEx('unfold', 'unfold', () => runFold(unfoldCode as never))
@@ -887,7 +887,7 @@ function registerVimNoteCommands(): void {
  *  `allLeaves` helper (which lives in `lib/pane-layout`). Duplicated
  *  locally to avoid a new import chain. */
 function allLeavesFlat(
-  node: PaneLayout,
+  node: PaneLayout
 ): Array<{ id: string; tabs: string[]; activeTab: string | null }> {
   if (node.kind === 'leaf') {
     return [{ id: node.id, tabs: node.tabs, activeTab: node.activeTab }]
@@ -959,7 +959,7 @@ const MANUAL_EX_NAMES = new Set([
   'wall',
   'wa',
   'help',
-  'h',
+  'h'
 ])
 
 function commandIdToExName(id: string): string {
@@ -1017,11 +1017,11 @@ function registerCommandPaletteEx(): void {
       const ranked = rankItems(commands, query, [
         { get: (c) => c.title, weight: 1 },
         { get: (c) => c.keywords ?? '', weight: 0.6 },
-        { get: (c) => c.category, weight: 0.4 },
+        { get: (c) => c.category, weight: 0.4 }
       ])
       const first = ranked.find((c) => !c.when || c.when())
       if (first) runCommand(first)
-    },
+    }
   )
   names.add('cmd')
 
@@ -1071,7 +1071,7 @@ function ensureWildmenu(): Wildmenu {
     'box-shadow: 0 10px 30px rgba(0,0,0,0.35)',
     'font: 12px/1.4 var(--z-mono-font, ui-monospace, Menlo, monospace)',
     'color: rgb(var(--z-fg))',
-    'backdrop-filter: blur(6px)',
+    'backdrop-filter: blur(6px)'
   ].join(';')
 
   const list = document.createElement('div')
@@ -1109,7 +1109,7 @@ interface ExCompletionMatch {
 function renderWildmenu(
   matches: ExCompletionMatch[],
   cycleIdx: number,
-  anchor: HTMLElement,
+  anchor: HTMLElement
 ): void {
   const menu = ensureWildmenu()
   if (matches.length === 0) {
@@ -1133,7 +1133,7 @@ function renderWildmenu(
       'white-space: nowrap',
       isActive
         ? 'background: rgb(var(--z-accent) / 0.85); color: white'
-        : 'color: rgb(var(--z-fg))',
+        : 'color: rgb(var(--z-fg))'
     ].join(';')
     menu.list.appendChild(row)
   })
@@ -1150,7 +1150,7 @@ function renderWildmenu(
   positionWildmenu(anchor)
 
   const activeRow = menu.list.querySelector<HTMLDivElement>(
-    `[data-idx="${cycleIdx}"]`,
+    `[data-idx="${cycleIdx}"]`
   )
   if (activeRow) activeRow.scrollIntoView({ block: 'nearest' })
 }
@@ -1177,7 +1177,7 @@ let exCycle: ExTabCycle | null = null
 function completeCommandArgs(
   input: string,
   command: string,
-  options: string[],
+  options: string[]
 ): ExCompletionMatch[] | null {
   const match = input.match(/^([A-Za-z0-9_]+)(\s+)([^ ]*)$/)
   if (!match) return null
@@ -1188,7 +1188,7 @@ function completeCommandArgs(
     : options
   return filtered.map((option) => ({
     label: option,
-    apply: `${commandName}${whitespace}${option}`,
+    apply: `${commandName}${whitespace}${option}`
   }))
 }
 
@@ -1282,7 +1282,7 @@ function installExTabCompletion(): void {
           // exactly the prefix we want to filter by.
           basePrefix: target.value,
           matches: computeExMatches(target.value),
-          cycleIdx: step === 1 ? 0 : -1, // sentinel; normalized below
+          cycleIdx: step === 1 ? 0 : -1 // sentinel; normalized below
         }
       } else if (exCycle) {
         exCycle.cycleIdx += step
@@ -1310,7 +1310,7 @@ function installExTabCompletion(): void {
       // Render / refresh the wildmenu with the highlighted match.
       renderWildmenu(cycle.matches, idx, target)
     },
-    true,
+    true
   )
 
   // Hide the wildmenu when the ex prompt's own input is detached from
@@ -1401,7 +1401,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
         index: handleIndex,
         startClient: isRow ? e.clientX : e.clientY,
         startSizes: split.sizes.slice(),
-        totalPx,
+        totalPx
       }
       const onMove = (ev: MouseEvent): void => {
         const st = dragState.current
@@ -1439,7 +1439,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
       document.body.style.cursor = isRow ? 'col-resize' : 'row-resize'
       document.body.style.userSelect = 'none'
     },
-    [isRow, resizeSplit, split.id, split.sizes],
+    [isRow, resizeSplit, split.id, split.sizes]
   )
 
   const nodes = useMemo(() => {
@@ -1450,12 +1450,12 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
         <div
           key={child.id}
           className={['flex min-h-0 min-w-0', isRow ? '' : 'flex-col'].join(
-            ' ',
+            ' '
           )}
           style={{ flex: `${basis} 1 0`, minWidth: 0, minHeight: 0 }}
         >
           <PaneTreeView node={child} />
-        </div>,
+        </div>
       )
       if (i < split.children.length - 1) {
         out.push(
@@ -1463,7 +1463,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
             key={`handle-${child.id}`}
             orientation={isRow ? 'vertical' : 'horizontal'}
             onMouseDown={onHandleMouseDown(i)}
-          />,
+          />
         )
       }
     })
@@ -1475,7 +1475,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
       ref={containerRef}
       className={[
         'flex min-h-0 min-w-0 flex-1',
-        isRow ? 'flex-row' : 'flex-col',
+        isRow ? 'flex-row' : 'flex-col'
       ].join(' ')}
     >
       {nodes}
@@ -1490,7 +1490,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
  */
 function ResizeDivider({
   orientation,
-  onMouseDown,
+  onMouseDown
 }: {
   orientation: 'vertical' | 'horizontal'
   onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void
@@ -1503,7 +1503,7 @@ function ResizeDivider({
       onMouseDown={onMouseDown}
       className={[
         'group relative z-10 shrink-0 select-none bg-paper-300/70 transition-colors hover:bg-accent/60 active:bg-accent',
-        isVertical ? 'w-px cursor-col-resize' : 'h-px cursor-row-resize',
+        isVertical ? 'w-px cursor-col-resize' : 'h-px cursor-row-resize'
       ].join(' ')}
     >
       {/* Wider hit zone centered on the divider line. */}
@@ -1512,7 +1512,7 @@ function ResizeDivider({
           'absolute',
           isVertical
             ? 'top-0 bottom-0 -left-1 w-[9px]'
-            : 'left-0 right-0 -top-1 h-[9px]',
+            : 'left-0 right-0 -top-1 h-[9px]'
         ].join(' ')}
       />
     </div>

--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -37,14 +37,23 @@ import {
   getKeymapBinding,
   getSequenceTokens,
   type KeymapId,
-  type KeymapOverrides
-} from '../lib/keymaps'
-import { navigateActiveBuffer } from '../lib/buffer-navigation'
-import { applyVimInsertEscape } from '../lib/vim-insert-escape'
+  type KeymapOverrides,
+} from '../lib/keymaps';
+import { navigateActiveBuffer } from '../lib/buffer-navigation';
+import { applyVimInsertEscape } from '../lib/vim-insert-escape';
+import {
+  type AppliedVimMapping,
+  type VimMapCmd,
+  type VimUnmapCmd,
+  VIM_MAP_CMD_MODES,
+  VIM_NOREMAP_CMDS,
+  VIM_UNMAP_CMD_MODES,
+  VIM_UNMAP_CMDS,
+} from '../lib/vim-mappings'
 
 let vimCommandsRegistered = false
 let syncedVimBindings: Partial<Record<KeymapId, string[]>> = {}
-let appliedVimMappingLhs: string[] = []
+let appliedVimMappings: AppliedVimMapping[] = []
 
 const DEFAULT_VIM_MAPPINGS_TO_CLEAR = [
   'gd',
@@ -167,32 +176,44 @@ function editorHalfPage(view: EditorView | undefined, forward: boolean): void {
   scroller.scrollTop = nextTop
 }
 
-function applyVimMappings(raw: string): void {
-  for (const lhs of appliedVimMappingLhs) {
+function applyVimMappings(raw: string, overrides: KeymapOverrides): void {
+  for (const { lhs, mode } of appliedVimMappings) {
     try {
-      Vim.unmap(lhs, 'normal')
-    } catch { 
-      /* ignore */ 
+      Vim.unmap(lhs, mode)
+    } catch {
+      /* ignore */
     }
   }
-  appliedVimMappingLhs = []
-  for (const line of raw.split('\n')) {
+  appliedVimMappings = []
+
+  const leaderKey =
+    toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix')) ?? '<Space>'
+  const resolve = (token: string): string =>
+    token.replace(/<leader>/gi, leaderKey)
+
+  const sanitized = raw.trim()
+  for (const line of sanitized.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed || trimmed.startsWith('"')) continue
-    const [cmd, lhs, rhs] = trimmed.split(/\s+/)
+    const parts = trimmed.split(/\s+/)
+    const cmd = parts[0]
+    const lhs = parts[1] ? resolve(parts[1]) : undefined
+    const rhs = parts[2] ? resolve(parts[2]) : undefined
     if (!lhs) continue
     try {
-      if ((cmd === 'noremap' || cmd === 'nnoremap') && rhs) {
-        Vim.noremap(lhs, rhs, 'normal')
-        appliedVimMappingLhs.push(lhs)
-      } else if ((cmd === 'map' || cmd === 'nmap') && rhs) {
-        Vim.map(lhs, rhs, 'normal')
-        appliedVimMappingLhs.push(lhs)
-      } else if (cmd === 'unmap' || cmd === 'nunmap') {
-        Vim.unmap(lhs, 'normal')
+      if (VIM_UNMAP_CMDS.has(cmd as VimUnmapCmd)) {
+        Vim.unmap(lhs, VIM_UNMAP_CMD_MODES[cmd as VimUnmapCmd])
+      } else {
+        const mode = VIM_MAP_CMD_MODES[cmd as VimMapCmd]
+        if (mode && rhs) {
+          VIM_NOREMAP_CMDS.has(cmd as VimMapCmd)
+            ? Vim.noremap(lhs, rhs, mode)
+            : Vim.map(lhs, rhs, mode)
+          appliedVimMappings.push({ lhs, mode })
+        }
       }
-    } catch { 
-      /* ignore bad mappings */ 
+    } catch {
+      /* ignore bad mappings */
     }
   }
 }
@@ -1293,7 +1314,7 @@ export function Editor(): JSX.Element {
   const vimInsertEscape = useStore((s) => s.vimInsertEscape)
   const zenMode = useStore((s) => s.zenMode)
   const vimMappings = useStore((s) => s.vimMappings)
-  const vimMode = useStore((s)=> s.vimMode)
+  const vimMode = useStore((s) => s.vimMode)
 
   useEffect(() => {
     registerVimCommands()
@@ -1310,8 +1331,8 @@ export function Editor(): JSX.Element {
 
   useEffect(() => {
     if (!vimMode) return
-    applyVimMappings(vimMappings)
-  }, [vimMappings, vimMode])
+    applyVimMappings(vimMappings, keymapOverrides)
+  }, [vimMappings, vimMode, keymapOverrides])
 
   return (
     <section className="flex min-w-0 flex-1 flex-col">

--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -17,20 +17,9 @@ import { rankItems } from '../lib/fuzzy-score'
 import { BUILTIN_TEMPLATES } from '@shared/builtin-templates'
 import { mergeTemplates } from '@shared/template-files'
 import type { PaneLayout, PaneSplit } from '../lib/pane-layout'
-import {
-  parseCreateNotePath,
-  resolveWikilinkTarget,
-  suggestCreateNotePath
-} from '../lib/wikilinks'
-import {
-  classifyLocalAssetHref,
-  resolveAssetVaultRelativePath
-} from '../lib/local-assets'
-import {
-  buildMoveNotePrompt,
-  parseMoveNoteTarget,
-  validateMoveNoteTarget
-} from '../lib/move-note'
+import { parseCreateNotePath, resolveWikilinkTarget, suggestCreateNotePath } from '../lib/wikilinks'
+import { classifyLocalAssetHref, resolveAssetVaultRelativePath } from '../lib/local-assets'
+import { buildMoveNotePrompt, parseMoveNoteTarget, validateMoveNoteTarget } from '../lib/move-note'
 import { promptApp } from '../lib/prompt-requests'
 import { StatusBar } from './StatusBar'
 import { EditorPane } from './EditorPane'
@@ -86,13 +75,8 @@ function clearKnownVimMappings(): void {
   }
 }
 
-function paneMapBindings(
-  overrides: KeymapOverrides,
-  actionId: KeymapId
-): string[] {
-  const prefixBinding = toVimSequence(
-    getKeymapBinding(overrides, 'vim.panePrefix')
-  )
+function paneMapBindings(overrides: KeymapOverrides, actionId: KeymapId): string[] {
+  const prefixBinding = toVimSequence(getKeymapBinding(overrides, 'vim.panePrefix'))
   const actionBinding = toVimSequence(getKeymapBinding(overrides, actionId))
   if (!prefixBinding || !actionBinding) return []
   const bindings = [`${prefixBinding}${actionBinding}`]
@@ -133,10 +117,7 @@ function editorHalfPage(view: EditorView | undefined, forward: boolean): void {
     range = next
   }
   const maxTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
-  const nextTop = Math.max(
-    0,
-    Math.min(maxTop, scroller.scrollTop + (forward ? half : -half))
-  )
+  const nextTop = Math.max(0, Math.min(maxTop, scroller.scrollTop + (forward ? half : -half)))
   view.dispatch({ selection: { anchor: range.head } })
   scroller.scrollTop = nextTop
 }
@@ -151,11 +132,8 @@ function applyVimMappings(raw: string, overrides: KeymapOverrides): void {
   }
   appliedVimMappings = []
 
-  const leaderKey = toVimSequence(
-    getKeymapBinding(overrides, 'vim.leaderPrefix')
-  )!
-  const resolve = (token: string): string =>
-    token.replace(/<leader>/gi, leaderKey)
+  const leaderKey = toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix'))!
+  const resolve = (token: string): string => token.replace(/<leader>/gi, leaderKey)
 
   const sanitized = raw.trim()
   for (const line of sanitized.split('\n')) {
@@ -185,106 +163,105 @@ function applyVimMappings(raw: string, overrides: KeymapOverrides): void {
 }
 
 function syncVimKeymaps(overrides: KeymapOverrides): void {
-  const mappings: Array<{ id: KeymapId; action: string; bindings: string[] }> =
-    [
-      {
-        id: 'vim.goToDefinition',
-        action: 'goToDefinition',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.goToDefinition'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'vim.paneFocusLeft',
-        action: 'focusPaneLeft',
-        bindings: paneMapBindings(overrides, 'vim.paneFocusLeft')
-      },
-      {
-        id: 'vim.paneFocusDown',
-        action: 'focusPaneDown',
-        bindings: paneMapBindings(overrides, 'vim.paneFocusDown')
-      },
-      {
-        id: 'vim.paneFocusUp',
-        action: 'focusPaneUp',
-        bindings: paneMapBindings(overrides, 'vim.paneFocusUp')
-      },
-      {
-        id: 'vim.paneFocusRight',
-        action: 'focusPaneRight',
-        bindings: paneMapBindings(overrides, 'vim.paneFocusRight')
-      },
-      {
-        id: 'vim.bufferPrevious',
-        action: 'previousBuffer',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.bufferPrevious'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'vim.bufferNext',
-        action: 'nextBuffer',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.bufferNext'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'vim.tabPrevious',
-        action: 'previousBuffer',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.tabPrevious'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'vim.tabNext',
-        action: 'nextBuffer',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.tabNext'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'vim.foldCurrent',
-        action: 'foldHeadingAtCursor',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.foldCurrent'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'vim.unfoldCurrent',
-        action: 'unfoldHeadingAtCursor',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldCurrent'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'vim.foldAll',
-        action: 'foldAllHeadings',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.foldAll'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'vim.unfoldAll',
-        action: 'unfoldAllHeadings',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldAll'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'nav.halfPageDown',
-        action: 'zenHalfPageDown',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown'))
-        ].filter((binding): binding is string => !!binding)
-      },
-      {
-        id: 'nav.halfPageUp',
-        action: 'zenHalfPageUp',
-        bindings: [
-          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageUp'))
-        ].filter((binding): binding is string => !!binding)
-      }
-    ]
+  const mappings: Array<{ id: KeymapId; action: string; bindings: string[] }> = [
+    {
+      id: 'vim.goToDefinition',
+      action: 'goToDefinition',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.goToDefinition'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'vim.paneFocusLeft',
+      action: 'focusPaneLeft',
+      bindings: paneMapBindings(overrides, 'vim.paneFocusLeft')
+    },
+    {
+      id: 'vim.paneFocusDown',
+      action: 'focusPaneDown',
+      bindings: paneMapBindings(overrides, 'vim.paneFocusDown')
+    },
+    {
+      id: 'vim.paneFocusUp',
+      action: 'focusPaneUp',
+      bindings: paneMapBindings(overrides, 'vim.paneFocusUp')
+    },
+    {
+      id: 'vim.paneFocusRight',
+      action: 'focusPaneRight',
+      bindings: paneMapBindings(overrides, 'vim.paneFocusRight')
+    },
+    {
+      id: 'vim.bufferPrevious',
+      action: 'previousBuffer',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.bufferPrevious'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'vim.bufferNext',
+      action: 'nextBuffer',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.bufferNext'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'vim.tabPrevious',
+      action: 'previousBuffer',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.tabPrevious'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'vim.tabNext',
+      action: 'nextBuffer',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.tabNext'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'vim.foldCurrent',
+      action: 'foldHeadingAtCursor',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.foldCurrent'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'vim.unfoldCurrent',
+      action: 'unfoldHeadingAtCursor',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.unfoldCurrent'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'vim.foldAll',
+      action: 'foldAllHeadings',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.foldAll'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'vim.unfoldAll',
+      action: 'unfoldAllHeadings',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.unfoldAll'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'nav.halfPageDown',
+      action: 'zenHalfPageDown',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown'))].filter(
+        (binding): binding is string => !!binding
+      )
+    },
+    {
+      id: 'nav.halfPageUp',
+      action: 'zenHalfPageUp',
+      bindings: [toVimSequence(getKeymapBinding(overrides, 'nav.halfPageUp'))].filter(
+        (binding): binding is string => !!binding
+      )
+    }
+  ]
 
   for (const mapping of mappings) {
     for (const binding of syncedVimBindings[mapping.id] ?? []) {
@@ -295,13 +272,7 @@ function syncVimKeymaps(overrides: KeymapOverrides): void {
       }
     }
     for (const binding of mapping.bindings) {
-      Vim.mapCommand(
-        binding,
-        'action',
-        mapping.action,
-        {},
-        { context: 'normal' }
-      )
+      Vim.mapCommand(binding, 'action', mapping.action, {}, { context: 'normal' })
     }
     syncedVimBindings[mapping.id] = mapping.bindings
   }
@@ -310,8 +281,7 @@ function syncVimKeymaps(overrides: KeymapOverrides): void {
 function unwrapMdUrl(url: string): string {
   // Markdown wraps URLs with spaces in angle brackets: `[x](<a b.pdf>)`.
   const trimmed = url.trim()
-  if (trimmed.startsWith('<') && trimmed.endsWith('>'))
-    return trimmed.slice(1, -1)
+  if (trimmed.startsWith('<') && trimmed.endsWith('>')) return trimmed.slice(1, -1)
   return trimmed
 }
 
@@ -397,10 +367,7 @@ function registerVimCommands(): void {
   // the picker and creates directly from the best name/id match. CM-Vim
   // requires a short name to be a prefix of the full name, so `tmpl` (not a
   // prefix of `template`) is registered as its own command sharing the handler.
-  const runTemplateEx = (
-    _cm: unknown,
-    params: { argString?: string } | undefined
-  ): void => {
+  const runTemplateEx = (_cm: unknown, params: { argString?: string } | undefined): void => {
     const state = useStore.getState()
     const arg = (params?.argString ?? '').trim()
     if (!arg) {
@@ -434,23 +401,19 @@ function registerVimCommands(): void {
   // `:tag foo bar baz` replaces the selection set wholesale. `:tag`
   // alone opens the Tags tab with whatever's currently selected (if
   // nothing is, the view shows a hint to pick tags).
-  Vim.defineEx(
-    'tag',
-    'tag',
-    (_cm: unknown, params: { argString?: string } | undefined) => {
-      const args = (params?.argString ?? '')
-        .split(/\s+/)
-        .map((t) => t.trim().replace(/^#/, ''))
-        .filter(Boolean)
-      const state = useStore.getState()
-      if (args.length === 0) {
-        void state.openTagView()
-        return
-      }
-      state.setSelectedTags(args)
+  Vim.defineEx('tag', 'tag', (_cm: unknown, params: { argString?: string } | undefined) => {
+    const args = (params?.argString ?? '')
+      .split(/\s+/)
+      .map((t) => t.trim().replace(/^#/, ''))
+      .filter(Boolean)
+    const state = useStore.getState()
+    if (args.length === 0) {
       void state.openTagView()
+      return
     }
-  )
+    state.setSelectedTags(args)
+    void state.openTagView()
+  })
 
   // Vim-style window splits. `:split` clones the current tab into a
   // new pane below; `:vsplit` clones it into a new pane to the right.
@@ -483,15 +446,10 @@ function registerVimCommands(): void {
   const focusDir = (dir: 'h' | 'j' | 'k' | 'l'): void => {
     focusPaneInDirection(dir)
   }
-  Vim.defineEx(
-    'wincmd',
-    'winc',
-    (_cm: unknown, params: { argString?: string } | undefined) => {
-      const dir = (params?.argString ?? '').trim().toLowerCase()[0]
-      if (dir === 'h' || dir === 'j' || dir === 'k' || dir === 'l')
-        focusDir(dir)
-    }
-  )
+  Vim.defineEx('wincmd', 'winc', (_cm: unknown, params: { argString?: string } | undefined) => {
+    const dir = (params?.argString ?? '').trim().toLowerCase()[0]
+    if (dir === 'h' || dir === 'j' || dir === 'k' || dir === 'l') focusDir(dir)
+  })
   Vim.defineEx('pane_focus_left', 'pane_focus_left', () => focusDir('h'))
   Vim.defineEx('pane_focus_down', 'pane_focus_down', () => focusDir('j'))
   Vim.defineEx('pane_focus_up', 'pane_focus_up', () => focusDir('k'))
@@ -557,15 +515,12 @@ function registerVimCommands(): void {
         const parsed = parseCreateNotePath(value)
         const existing = state.notes.find(
           (note) =>
-            note.folder !== 'trash' &&
-            note.path.toLowerCase() === parsed.relPath.toLowerCase()
+            note.folder !== 'trash' && note.path.toLowerCase() === parsed.relPath.toLowerCase()
         )
         if (existing) {
           await state.selectNote(existing.path)
           state.setFocusedPanel('editor')
-          requestAnimationFrame(() =>
-            useStore.getState().editorViewRef?.focus()
-          )
+          requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
           return
         }
         await state.createAndOpen(parsed.folder, parsed.subpath, {
@@ -650,9 +605,7 @@ function registerVimNoteCommands(): void {
     // If something already resolves to that target (wiki-style + case-
     // insensitive), open it instead of creating a duplicate.
     const existing = state.notes.find(
-      (n) =>
-        n.folder !== 'trash' &&
-        n.path.toLowerCase() === parsed.relPath.toLowerCase()
+      (n) => n.folder !== 'trash' && n.path.toLowerCase() === parsed.relPath.toLowerCase()
     )
     if (existing) {
       await state.selectNote(existing.path)
@@ -667,30 +620,20 @@ function registerVimNoteCommands(): void {
     requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
   }
 
-  Vim.defineEx(
-    'edit',
-    'e',
-    (_cm: unknown, params: { argString?: string } | undefined) => {
-      void openOrCreateByPath(params?.argString ?? '')
-    }
-  )
+  Vim.defineEx('edit', 'e', (_cm: unknown, params: { argString?: string } | undefined) => {
+    void openOrCreateByPath(params?.argString ?? '')
+  })
 
   // `:new` shadows vim's "horizontal split empty buffer" — for a notes
   // app, creating a new note at a path is what the user actually wants.
-  Vim.defineEx(
-    'new',
-    'new',
-    (_cm: unknown, params: { argString?: string } | undefined) => {
-      const arg = (params?.argString ?? '').trim()
-      if (!arg) {
-        void useStore
-          .getState()
-          .createAndOpen('inbox', '', { focusTitle: true })
-        return
-      }
-      void openOrCreateByPath(arg)
+  Vim.defineEx('new', 'new', (_cm: unknown, params: { argString?: string } | undefined) => {
+    const arg = (params?.argString ?? '').trim()
+    if (!arg) {
+      void useStore.getState().createAndOpen('inbox', '', { focusTitle: true })
+      return
     }
-  )
+    void openOrCreateByPath(arg)
+  })
 
   const moveActiveNote = async (raw: string): Promise<void> => {
     const state = useStore.getState()
@@ -700,8 +643,7 @@ function registerVimNoteCommands(): void {
     const value = raw.trim()
     let target = value
     if (!target) {
-      target =
-        (await promptApp(buildMoveNotePrompt(active, state.folders))) ?? ''
+      target = (await promptApp(buildMoveNotePrompt(active, state.folders))) ?? ''
       if (!target) return
     }
 
@@ -714,29 +656,18 @@ function registerVimNoteCommands(): void {
     await state.moveNote(active.path, dest.folder, dest.subpath)
   }
 
-  const runMoveEx = (
-    _cm: unknown,
-    params: { argString?: string } | undefined
-  ): void => {
+  const runMoveEx = (_cm: unknown, params: { argString?: string } | undefined): void => {
     void moveActiveNote(params?.argString ?? '')
   }
 
   Vim.defineEx('move', 'move', runMoveEx)
   Vim.defineEx('mv', 'mv', runMoveEx)
 
-  Vim.defineEx('bnext', 'bn', () =>
-    navigateActiveBuffer(useStore.getState(), 1)
-  )
-  Vim.defineEx('bprev', 'bp', () =>
-    navigateActiveBuffer(useStore.getState(), -1)
-  )
+  Vim.defineEx('bnext', 'bn', () => navigateActiveBuffer(useStore.getState(), 1))
+  Vim.defineEx('bprev', 'bp', () => navigateActiveBuffer(useStore.getState(), -1))
   // Vim tab aliases over the same active-pane tab navigation.
-  Vim.defineEx('tabnext', 'tabn', () =>
-    navigateActiveBuffer(useStore.getState(), 1)
-  )
-  Vim.defineEx('tabprevious', 'tabp', () =>
-    navigateActiveBuffer(useStore.getState(), -1)
-  )
+  Vim.defineEx('tabnext', 'tabn', () => navigateActiveBuffer(useStore.getState(), 1))
+  Vim.defineEx('tabprevious', 'tabp', () => navigateActiveBuffer(useStore.getState(), -1))
   // Vim aliases: :bNext and :bfirst/:blast — rare, skipped.
 
   const closeActiveTabLikeQuit = (): void => {
@@ -790,34 +721,22 @@ function registerVimNoteCommands(): void {
       requestPaneMode(mode)
     })
   }
-  Vim.defineEx(
-    'view',
-    'view',
-    (_cm: unknown, params: { argString?: string } | undefined) => {
-      const nextMode = (params?.argString ?? '').trim().toLowerCase()
-      if (
-        nextMode === 'edit' ||
-        nextMode === 'split' ||
-        nextMode === 'preview'
-      ) {
-        setPaneMode(nextMode)
-      }
+  Vim.defineEx('view', 'view', (_cm: unknown, params: { argString?: string } | undefined) => {
+    const nextMode = (params?.argString ?? '').trim().toLowerCase()
+    if (nextMode === 'edit' || nextMode === 'split' || nextMode === 'preview') {
+      setPaneMode(nextMode)
     }
-  )
-  Vim.defineEx(
-    'zen',
-    'zen',
-    (_cm: unknown, params: { argString?: string } | undefined) => {
-      const nextMode = (params?.argString ?? '').trim().toLowerCase()
-      if (!nextMode || nextMode === 'toggle') {
-        setZenMode('toggle')
-        return
-      }
-      if (nextMode === 'on' || nextMode === 'off') {
-        setZenMode(nextMode)
-      }
+  })
+  Vim.defineEx('zen', 'zen', (_cm: unknown, params: { argString?: string } | undefined) => {
+    const nextMode = (params?.argString ?? '').trim().toLowerCase()
+    if (!nextMode || nextMode === 'toggle') {
+      setZenMode('toggle')
+      return
     }
-  )
+    if (nextMode === 'on' || nextMode === 'off') {
+      setZenMode(nextMode)
+    }
+  })
   Vim.defineEx('zenmode', 'zenmode', () => setZenMode('toggle'))
   Vim.defineEx('editmode', 'editmode', () => setPaneMode('edit'))
   Vim.defineEx('splitmode', 'splitmode', () => setPaneMode('split'))
@@ -859,9 +778,7 @@ function registerVimNoteCommands(): void {
   // on the current heading; `:foldall` / `:unfoldall` cover the whole
   // note. We map vim's `zc` / `zo` / `zM` / `zR` keys explicitly so the
   // advertised fold chords work regardless of what CM-Vim ships by default.
-  const runFold = (
-    cmd: (view: { state: unknown; dispatch: unknown }) => boolean
-  ): void => {
+  const runFold = (cmd: (view: { state: unknown; dispatch: unknown }) => boolean): void => {
     const view = useStore.getState().editorViewRef
     if (!view) return
     cmd(view as unknown as Parameters<typeof foldCode>[0])
@@ -892,8 +809,7 @@ function allLeavesFlat(
   if (node.kind === 'leaf') {
     return [{ id: node.id, tabs: node.tabs, activeTab: node.activeTab }]
   }
-  const out: Array<{ id: string; tabs: string[]; activeTab: string | null }> =
-    []
+  const out: Array<{ id: string; tabs: string[]; activeTab: string | null }> = []
   for (const child of node.children) out.push(...allLeavesFlat(child))
   return out
 }
@@ -1004,25 +920,21 @@ function registerCommandPaletteEx(): void {
 
   // `:cmd` — fuzzy fallback. With a query, runs the best match directly.
   // Without, opens the command palette so the user can browse.
-  Vim.defineEx(
-    'cmd',
-    'cmd',
-    (_cm: unknown, params: { argString?: string } | undefined) => {
-      const query = (params?.argString ?? '').trim()
-      if (!query) {
-        useStore.getState().setCommandPaletteOpen(true)
-        return
-      }
-      const commands = buildCommands()
-      const ranked = rankItems(commands, query, [
-        { get: (c) => c.title, weight: 1 },
-        { get: (c) => c.keywords ?? '', weight: 0.6 },
-        { get: (c) => c.category, weight: 0.4 }
-      ])
-      const first = ranked.find((c) => !c.when || c.when())
-      if (first) runCommand(first)
+  Vim.defineEx('cmd', 'cmd', (_cm: unknown, params: { argString?: string } | undefined) => {
+    const query = (params?.argString ?? '').trim()
+    if (!query) {
+      useStore.getState().setCommandPaletteOpen(true)
+      return
     }
-  )
+    const commands = buildCommands()
+    const ranked = rankItems(commands, query, [
+      { get: (c) => c.title, weight: 1 },
+      { get: (c) => c.keywords ?? '', weight: 0.6 },
+      { get: (c) => c.category, weight: 0.4 }
+    ])
+    const first = ranked.find((c) => !c.when || c.when())
+    if (first) runCommand(first)
+  })
   names.add('cmd')
 
   // `:commands` — alias that always opens the palette (no implicit run).
@@ -1106,11 +1018,7 @@ interface ExCompletionMatch {
   apply: string
 }
 
-function renderWildmenu(
-  matches: ExCompletionMatch[],
-  cycleIdx: number,
-  anchor: HTMLElement
-): void {
+function renderWildmenu(matches: ExCompletionMatch[], cycleIdx: number, anchor: HTMLElement): void {
   const menu = ensureWildmenu()
   if (matches.length === 0) {
     menu.root.style.display = 'none'
@@ -1131,9 +1039,7 @@ function renderWildmenu(
       'padding: 3px 8px',
       'border-radius: 6px',
       'white-space: nowrap',
-      isActive
-        ? 'background: rgb(var(--z-accent) / 0.85); color: white'
-        : 'color: rgb(var(--z-fg))'
+      isActive ? 'background: rgb(var(--z-accent) / 0.85); color: white' : 'color: rgb(var(--z-fg))'
     ].join(';')
     menu.list.appendChild(row)
   })
@@ -1149,9 +1055,7 @@ function renderWildmenu(
   menu.root.style.display = 'block'
   positionWildmenu(anchor)
 
-  const activeRow = menu.list.querySelector<HTMLDivElement>(
-    `[data-idx="${cycleIdx}"]`
-  )
+  const activeRow = menu.list.querySelector<HTMLDivElement>(`[data-idx="${cycleIdx}"]`)
   if (activeRow) activeRow.scrollIntoView({ block: 'nearest' })
 }
 
@@ -1236,12 +1140,7 @@ function installExTabCompletion(): void {
         // the app shouldn't clobber our state (modifier keys fire even
         // when the input is focused too, so we ignore those explicitly
         // instead of resetting on them).
-        if (
-          e.key === 'Shift' ||
-          e.key === 'Control' ||
-          e.key === 'Alt' ||
-          e.key === 'Meta'
-        ) {
+        if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Alt' || e.key === 'Meta') {
           return
         }
         const target = e.target as HTMLElement | null
@@ -1271,8 +1170,7 @@ function installExTabCompletion(): void {
       e.stopImmediatePropagation()
 
       const step = e.shiftKey ? -1 : 1
-      const fresh =
-        !exCycle || exCycle.input !== target || exCycle.basePrefix === null
+      const fresh = !exCycle || exCycle.input !== target || exCycle.basePrefix === null
 
       if (fresh) {
         exCycle = {
@@ -1449,9 +1347,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
       out.push(
         <div
           key={child.id}
-          className={['flex min-h-0 min-w-0', isRow ? '' : 'flex-col'].join(
-            ' '
-          )}
+          className={['flex min-h-0 min-w-0', isRow ? '' : 'flex-col'].join(' ')}
           style={{ flex: `${basis} 1 0`, minWidth: 0, minHeight: 0 }}
         >
           <PaneTreeView node={child} />
@@ -1473,10 +1369,7 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
   return (
     <div
       ref={containerRef}
-      className={[
-        'flex min-h-0 min-w-0 flex-1',
-        isRow ? 'flex-row' : 'flex-col'
-      ].join(' ')}
+      className={['flex min-h-0 min-w-0 flex-1', isRow ? 'flex-row' : 'flex-col'].join(' ')}
     >
       {nodes}
     </div>
@@ -1510,9 +1403,7 @@ function ResizeDivider({
       <div
         className={[
           'absolute',
-          isVertical
-            ? 'top-0 bottom-0 -left-1 w-[9px]'
-            : 'left-0 right-0 -top-1 h-[9px]'
+          isVertical ? 'top-0 bottom-0 -left-1 w-[9px]' : 'left-0 right-0 -top-1 h-[9px]'
         ].join(' ')}
       />
     </div>

--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -151,8 +151,9 @@ function applyVimMappings(raw: string, overrides: KeymapOverrides): void {
   }
   appliedVimMappings = []
 
-  const leaderKey =
-    toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix')) ?? '<Space>'
+  const leaderKey = toVimSequence(
+    getKeymapBinding(overrides, 'vim.leaderPrefix'),
+  )!
   const resolve = (token: string): string =>
     token.replace(/<leader>/gi, leaderKey)
 

--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -17,9 +17,20 @@ import { rankItems } from '../lib/fuzzy-score'
 import { BUILTIN_TEMPLATES } from '@shared/builtin-templates'
 import { mergeTemplates } from '@shared/template-files'
 import type { PaneLayout, PaneSplit } from '../lib/pane-layout'
-import { parseCreateNotePath, resolveWikilinkTarget, suggestCreateNotePath } from '../lib/wikilinks'
-import { classifyLocalAssetHref, resolveAssetVaultRelativePath } from '../lib/local-assets'
-import { buildMoveNotePrompt, parseMoveNoteTarget, validateMoveNoteTarget } from '../lib/move-note'
+import {
+  parseCreateNotePath,
+  resolveWikilinkTarget,
+  suggestCreateNotePath
+} from '../lib/wikilinks'
+import {
+  classifyLocalAssetHref,
+  resolveAssetVaultRelativePath
+} from '../lib/local-assets'
+import {
+  buildMoveNotePrompt,
+  parseMoveNoteTarget,
+  validateMoveNoteTarget
+} from '../lib/move-note'
 import { promptApp } from '../lib/prompt-requests'
 import { StatusBar } from './StatusBar'
 import { EditorPane } from './EditorPane'
@@ -75,8 +86,13 @@ function clearKnownVimMappings(): void {
   }
 }
 
-function paneMapBindings(overrides: KeymapOverrides, actionId: KeymapId): string[] {
-  const prefixBinding = toVimSequence(getKeymapBinding(overrides, 'vim.panePrefix'))
+function paneMapBindings(
+  overrides: KeymapOverrides,
+  actionId: KeymapId
+): string[] {
+  const prefixBinding = toVimSequence(
+    getKeymapBinding(overrides, 'vim.panePrefix')
+  )
   const actionBinding = toVimSequence(getKeymapBinding(overrides, actionId))
   if (!prefixBinding || !actionBinding) return []
   const bindings = [`${prefixBinding}${actionBinding}`]
@@ -117,7 +133,10 @@ function editorHalfPage(view: EditorView | undefined, forward: boolean): void {
     range = next
   }
   const maxTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
-  const nextTop = Math.max(0, Math.min(maxTop, scroller.scrollTop + (forward ? half : -half)))
+  const nextTop = Math.max(
+    0,
+    Math.min(maxTop, scroller.scrollTop + (forward ? half : -half))
+  )
   view.dispatch({ selection: { anchor: range.head } })
   scroller.scrollTop = nextTop
 }
@@ -132,8 +151,11 @@ function applyVimMappings(raw: string, overrides: KeymapOverrides): void {
   }
   appliedVimMappings = []
 
-  const leaderKey = toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix'))!
-  const resolve = (token: string): string => token.replace(/<leader>/gi, leaderKey)
+  const leaderKey = toVimSequence(
+    getKeymapBinding(overrides, 'vim.leaderPrefix')
+  )!
+  const resolve = (token: string): string =>
+    token.replace(/<leader>/gi, leaderKey)
 
   const sanitized = raw.trim()
   for (const line of sanitized.split('\n')) {
@@ -163,105 +185,106 @@ function applyVimMappings(raw: string, overrides: KeymapOverrides): void {
 }
 
 function syncVimKeymaps(overrides: KeymapOverrides): void {
-  const mappings: Array<{ id: KeymapId; action: string; bindings: string[] }> = [
-    {
-      id: 'vim.goToDefinition',
-      action: 'goToDefinition',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.goToDefinition'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.paneFocusLeft',
-      action: 'focusPaneLeft',
-      bindings: paneMapBindings(overrides, 'vim.paneFocusLeft')
-    },
-    {
-      id: 'vim.paneFocusDown',
-      action: 'focusPaneDown',
-      bindings: paneMapBindings(overrides, 'vim.paneFocusDown')
-    },
-    {
-      id: 'vim.paneFocusUp',
-      action: 'focusPaneUp',
-      bindings: paneMapBindings(overrides, 'vim.paneFocusUp')
-    },
-    {
-      id: 'vim.paneFocusRight',
-      action: 'focusPaneRight',
-      bindings: paneMapBindings(overrides, 'vim.paneFocusRight')
-    },
-    {
-      id: 'vim.bufferPrevious',
-      action: 'previousBuffer',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.bufferPrevious'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.bufferNext',
-      action: 'nextBuffer',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.bufferNext'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.tabPrevious',
-      action: 'previousBuffer',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.tabPrevious'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.tabNext',
-      action: 'nextBuffer',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.tabNext'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.foldCurrent',
-      action: 'foldHeadingAtCursor',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.foldCurrent'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.unfoldCurrent',
-      action: 'unfoldHeadingAtCursor',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.unfoldCurrent'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.foldAll',
-      action: 'foldAllHeadings',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.foldAll'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'vim.unfoldAll',
-      action: 'unfoldAllHeadings',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'vim.unfoldAll'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'nav.halfPageDown',
-      action: 'zenHalfPageDown',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown'))].filter(
-        (binding): binding is string => !!binding
-      )
-    },
-    {
-      id: 'nav.halfPageUp',
-      action: 'zenHalfPageUp',
-      bindings: [toVimSequence(getKeymapBinding(overrides, 'nav.halfPageUp'))].filter(
-        (binding): binding is string => !!binding
-      )
-    }
-  ]
+  const mappings: Array<{ id: KeymapId; action: string; bindings: string[] }> =
+    [
+      {
+        id: 'vim.goToDefinition',
+        action: 'goToDefinition',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.goToDefinition'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'vim.paneFocusLeft',
+        action: 'focusPaneLeft',
+        bindings: paneMapBindings(overrides, 'vim.paneFocusLeft')
+      },
+      {
+        id: 'vim.paneFocusDown',
+        action: 'focusPaneDown',
+        bindings: paneMapBindings(overrides, 'vim.paneFocusDown')
+      },
+      {
+        id: 'vim.paneFocusUp',
+        action: 'focusPaneUp',
+        bindings: paneMapBindings(overrides, 'vim.paneFocusUp')
+      },
+      {
+        id: 'vim.paneFocusRight',
+        action: 'focusPaneRight',
+        bindings: paneMapBindings(overrides, 'vim.paneFocusRight')
+      },
+      {
+        id: 'vim.bufferPrevious',
+        action: 'previousBuffer',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.bufferPrevious'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'vim.bufferNext',
+        action: 'nextBuffer',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.bufferNext'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'vim.tabPrevious',
+        action: 'previousBuffer',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.tabPrevious'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'vim.tabNext',
+        action: 'nextBuffer',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.tabNext'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'vim.foldCurrent',
+        action: 'foldHeadingAtCursor',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.foldCurrent'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'vim.unfoldCurrent',
+        action: 'unfoldHeadingAtCursor',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldCurrent'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'vim.foldAll',
+        action: 'foldAllHeadings',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.foldAll'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'vim.unfoldAll',
+        action: 'unfoldAllHeadings',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'vim.unfoldAll'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'nav.halfPageDown',
+        action: 'zenHalfPageDown',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown'))
+        ].filter((binding): binding is string => !!binding)
+      },
+      {
+        id: 'nav.halfPageUp',
+        action: 'zenHalfPageUp',
+        bindings: [
+          toVimSequence(getKeymapBinding(overrides, 'nav.halfPageUp'))
+        ].filter((binding): binding is string => !!binding)
+      }
+    ]
 
   for (const mapping of mappings) {
     for (const binding of syncedVimBindings[mapping.id] ?? []) {
@@ -272,7 +295,13 @@ function syncVimKeymaps(overrides: KeymapOverrides): void {
       }
     }
     for (const binding of mapping.bindings) {
-      Vim.mapCommand(binding, 'action', mapping.action, {}, { context: 'normal' })
+      Vim.mapCommand(
+        binding,
+        'action',
+        mapping.action,
+        {},
+        { context: 'normal' }
+      )
     }
     syncedVimBindings[mapping.id] = mapping.bindings
   }
@@ -281,7 +310,8 @@ function syncVimKeymaps(overrides: KeymapOverrides): void {
 function unwrapMdUrl(url: string): string {
   // Markdown wraps URLs with spaces in angle brackets: `[x](<a b.pdf>)`.
   const trimmed = url.trim()
-  if (trimmed.startsWith('<') && trimmed.endsWith('>')) return trimmed.slice(1, -1)
+  if (trimmed.startsWith('<') && trimmed.endsWith('>'))
+    return trimmed.slice(1, -1)
   return trimmed
 }
 
@@ -367,7 +397,10 @@ function registerVimCommands(): void {
   // the picker and creates directly from the best name/id match. CM-Vim
   // requires a short name to be a prefix of the full name, so `tmpl` (not a
   // prefix of `template`) is registered as its own command sharing the handler.
-  const runTemplateEx = (_cm: unknown, params: { argString?: string } | undefined): void => {
+  const runTemplateEx = (
+    _cm: unknown,
+    params: { argString?: string } | undefined
+  ): void => {
     const state = useStore.getState()
     const arg = (params?.argString ?? '').trim()
     if (!arg) {
@@ -401,19 +434,23 @@ function registerVimCommands(): void {
   // `:tag foo bar baz` replaces the selection set wholesale. `:tag`
   // alone opens the Tags tab with whatever's currently selected (if
   // nothing is, the view shows a hint to pick tags).
-  Vim.defineEx('tag', 'tag', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const args = (params?.argString ?? '')
-      .split(/\s+/)
-      .map((t) => t.trim().replace(/^#/, ''))
-      .filter(Boolean)
-    const state = useStore.getState()
-    if (args.length === 0) {
+  Vim.defineEx(
+    'tag',
+    'tag',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const args = (params?.argString ?? '')
+        .split(/\s+/)
+        .map((t) => t.trim().replace(/^#/, ''))
+        .filter(Boolean)
+      const state = useStore.getState()
+      if (args.length === 0) {
+        void state.openTagView()
+        return
+      }
+      state.setSelectedTags(args)
       void state.openTagView()
-      return
     }
-    state.setSelectedTags(args)
-    void state.openTagView()
-  })
+  )
 
   // Vim-style window splits. `:split` clones the current tab into a
   // new pane below; `:vsplit` clones it into a new pane to the right.
@@ -446,10 +483,15 @@ function registerVimCommands(): void {
   const focusDir = (dir: 'h' | 'j' | 'k' | 'l'): void => {
     focusPaneInDirection(dir)
   }
-  Vim.defineEx('wincmd', 'winc', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const dir = (params?.argString ?? '').trim().toLowerCase()[0]
-    if (dir === 'h' || dir === 'j' || dir === 'k' || dir === 'l') focusDir(dir)
-  })
+  Vim.defineEx(
+    'wincmd',
+    'winc',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const dir = (params?.argString ?? '').trim().toLowerCase()[0]
+      if (dir === 'h' || dir === 'j' || dir === 'k' || dir === 'l')
+        focusDir(dir)
+    }
+  )
   Vim.defineEx('pane_focus_left', 'pane_focus_left', () => focusDir('h'))
   Vim.defineEx('pane_focus_down', 'pane_focus_down', () => focusDir('j'))
   Vim.defineEx('pane_focus_up', 'pane_focus_up', () => focusDir('k'))
@@ -515,12 +557,15 @@ function registerVimCommands(): void {
         const parsed = parseCreateNotePath(value)
         const existing = state.notes.find(
           (note) =>
-            note.folder !== 'trash' && note.path.toLowerCase() === parsed.relPath.toLowerCase()
+            note.folder !== 'trash' &&
+            note.path.toLowerCase() === parsed.relPath.toLowerCase()
         )
         if (existing) {
           await state.selectNote(existing.path)
           state.setFocusedPanel('editor')
-          requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
+          requestAnimationFrame(() =>
+            useStore.getState().editorViewRef?.focus()
+          )
           return
         }
         await state.createAndOpen(parsed.folder, parsed.subpath, {
@@ -605,7 +650,9 @@ function registerVimNoteCommands(): void {
     // If something already resolves to that target (wiki-style + case-
     // insensitive), open it instead of creating a duplicate.
     const existing = state.notes.find(
-      (n) => n.folder !== 'trash' && n.path.toLowerCase() === parsed.relPath.toLowerCase()
+      (n) =>
+        n.folder !== 'trash' &&
+        n.path.toLowerCase() === parsed.relPath.toLowerCase()
     )
     if (existing) {
       await state.selectNote(existing.path)
@@ -620,20 +667,30 @@ function registerVimNoteCommands(): void {
     requestAnimationFrame(() => useStore.getState().editorViewRef?.focus())
   }
 
-  Vim.defineEx('edit', 'e', (_cm: unknown, params: { argString?: string } | undefined) => {
-    void openOrCreateByPath(params?.argString ?? '')
-  })
+  Vim.defineEx(
+    'edit',
+    'e',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      void openOrCreateByPath(params?.argString ?? '')
+    }
+  )
 
   // `:new` shadows vim's "horizontal split empty buffer" — for a notes
   // app, creating a new note at a path is what the user actually wants.
-  Vim.defineEx('new', 'new', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const arg = (params?.argString ?? '').trim()
-    if (!arg) {
-      void useStore.getState().createAndOpen('inbox', '', { focusTitle: true })
-      return
+  Vim.defineEx(
+    'new',
+    'new',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const arg = (params?.argString ?? '').trim()
+      if (!arg) {
+        void useStore
+          .getState()
+          .createAndOpen('inbox', '', { focusTitle: true })
+        return
+      }
+      void openOrCreateByPath(arg)
     }
-    void openOrCreateByPath(arg)
-  })
+  )
 
   const moveActiveNote = async (raw: string): Promise<void> => {
     const state = useStore.getState()
@@ -643,7 +700,8 @@ function registerVimNoteCommands(): void {
     const value = raw.trim()
     let target = value
     if (!target) {
-      target = (await promptApp(buildMoveNotePrompt(active, state.folders))) ?? ''
+      target =
+        (await promptApp(buildMoveNotePrompt(active, state.folders))) ?? ''
       if (!target) return
     }
 
@@ -656,18 +714,29 @@ function registerVimNoteCommands(): void {
     await state.moveNote(active.path, dest.folder, dest.subpath)
   }
 
-  const runMoveEx = (_cm: unknown, params: { argString?: string } | undefined): void => {
+  const runMoveEx = (
+    _cm: unknown,
+    params: { argString?: string } | undefined
+  ): void => {
     void moveActiveNote(params?.argString ?? '')
   }
 
   Vim.defineEx('move', 'move', runMoveEx)
   Vim.defineEx('mv', 'mv', runMoveEx)
 
-  Vim.defineEx('bnext', 'bn', () => navigateActiveBuffer(useStore.getState(), 1))
-  Vim.defineEx('bprev', 'bp', () => navigateActiveBuffer(useStore.getState(), -1))
+  Vim.defineEx('bnext', 'bn', () =>
+    navigateActiveBuffer(useStore.getState(), 1)
+  )
+  Vim.defineEx('bprev', 'bp', () =>
+    navigateActiveBuffer(useStore.getState(), -1)
+  )
   // Vim tab aliases over the same active-pane tab navigation.
-  Vim.defineEx('tabnext', 'tabn', () => navigateActiveBuffer(useStore.getState(), 1))
-  Vim.defineEx('tabprevious', 'tabp', () => navigateActiveBuffer(useStore.getState(), -1))
+  Vim.defineEx('tabnext', 'tabn', () =>
+    navigateActiveBuffer(useStore.getState(), 1)
+  )
+  Vim.defineEx('tabprevious', 'tabp', () =>
+    navigateActiveBuffer(useStore.getState(), -1)
+  )
   // Vim aliases: :bNext and :bfirst/:blast — rare, skipped.
 
   const closeActiveTabLikeQuit = (): void => {
@@ -721,22 +790,34 @@ function registerVimNoteCommands(): void {
       requestPaneMode(mode)
     })
   }
-  Vim.defineEx('view', 'view', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const nextMode = (params?.argString ?? '').trim().toLowerCase()
-    if (nextMode === 'edit' || nextMode === 'split' || nextMode === 'preview') {
-      setPaneMode(nextMode)
+  Vim.defineEx(
+    'view',
+    'view',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const nextMode = (params?.argString ?? '').trim().toLowerCase()
+      if (
+        nextMode === 'edit' ||
+        nextMode === 'split' ||
+        nextMode === 'preview'
+      ) {
+        setPaneMode(nextMode)
+      }
     }
-  })
-  Vim.defineEx('zen', 'zen', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const nextMode = (params?.argString ?? '').trim().toLowerCase()
-    if (!nextMode || nextMode === 'toggle') {
-      setZenMode('toggle')
-      return
+  )
+  Vim.defineEx(
+    'zen',
+    'zen',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const nextMode = (params?.argString ?? '').trim().toLowerCase()
+      if (!nextMode || nextMode === 'toggle') {
+        setZenMode('toggle')
+        return
+      }
+      if (nextMode === 'on' || nextMode === 'off') {
+        setZenMode(nextMode)
+      }
     }
-    if (nextMode === 'on' || nextMode === 'off') {
-      setZenMode(nextMode)
-    }
-  })
+  )
   Vim.defineEx('zenmode', 'zenmode', () => setZenMode('toggle'))
   Vim.defineEx('editmode', 'editmode', () => setPaneMode('edit'))
   Vim.defineEx('splitmode', 'splitmode', () => setPaneMode('split'))
@@ -778,7 +859,9 @@ function registerVimNoteCommands(): void {
   // on the current heading; `:foldall` / `:unfoldall` cover the whole
   // note. We map vim's `zc` / `zo` / `zM` / `zR` keys explicitly so the
   // advertised fold chords work regardless of what CM-Vim ships by default.
-  const runFold = (cmd: (view: { state: unknown; dispatch: unknown }) => boolean): void => {
+  const runFold = (
+    cmd: (view: { state: unknown; dispatch: unknown }) => boolean
+  ): void => {
     const view = useStore.getState().editorViewRef
     if (!view) return
     cmd(view as unknown as Parameters<typeof foldCode>[0])
@@ -809,7 +892,8 @@ function allLeavesFlat(
   if (node.kind === 'leaf') {
     return [{ id: node.id, tabs: node.tabs, activeTab: node.activeTab }]
   }
-  const out: Array<{ id: string; tabs: string[]; activeTab: string | null }> = []
+  const out: Array<{ id: string; tabs: string[]; activeTab: string | null }> =
+    []
   for (const child of node.children) out.push(...allLeavesFlat(child))
   return out
 }
@@ -920,21 +1004,25 @@ function registerCommandPaletteEx(): void {
 
   // `:cmd` — fuzzy fallback. With a query, runs the best match directly.
   // Without, opens the command palette so the user can browse.
-  Vim.defineEx('cmd', 'cmd', (_cm: unknown, params: { argString?: string } | undefined) => {
-    const query = (params?.argString ?? '').trim()
-    if (!query) {
-      useStore.getState().setCommandPaletteOpen(true)
-      return
+  Vim.defineEx(
+    'cmd',
+    'cmd',
+    (_cm: unknown, params: { argString?: string } | undefined) => {
+      const query = (params?.argString ?? '').trim()
+      if (!query) {
+        useStore.getState().setCommandPaletteOpen(true)
+        return
+      }
+      const commands = buildCommands()
+      const ranked = rankItems(commands, query, [
+        { get: (c) => c.title, weight: 1 },
+        { get: (c) => c.keywords ?? '', weight: 0.6 },
+        { get: (c) => c.category, weight: 0.4 }
+      ])
+      const first = ranked.find((c) => !c.when || c.when())
+      if (first) runCommand(first)
     }
-    const commands = buildCommands()
-    const ranked = rankItems(commands, query, [
-      { get: (c) => c.title, weight: 1 },
-      { get: (c) => c.keywords ?? '', weight: 0.6 },
-      { get: (c) => c.category, weight: 0.4 }
-    ])
-    const first = ranked.find((c) => !c.when || c.when())
-    if (first) runCommand(first)
-  })
+  )
   names.add('cmd')
 
   // `:commands` — alias that always opens the palette (no implicit run).
@@ -1018,7 +1106,11 @@ interface ExCompletionMatch {
   apply: string
 }
 
-function renderWildmenu(matches: ExCompletionMatch[], cycleIdx: number, anchor: HTMLElement): void {
+function renderWildmenu(
+  matches: ExCompletionMatch[],
+  cycleIdx: number,
+  anchor: HTMLElement
+): void {
   const menu = ensureWildmenu()
   if (matches.length === 0) {
     menu.root.style.display = 'none'
@@ -1039,7 +1131,9 @@ function renderWildmenu(matches: ExCompletionMatch[], cycleIdx: number, anchor: 
       'padding: 3px 8px',
       'border-radius: 6px',
       'white-space: nowrap',
-      isActive ? 'background: rgb(var(--z-accent) / 0.85); color: white' : 'color: rgb(var(--z-fg))'
+      isActive
+        ? 'background: rgb(var(--z-accent) / 0.85); color: white'
+        : 'color: rgb(var(--z-fg))'
     ].join(';')
     menu.list.appendChild(row)
   })
@@ -1055,7 +1149,9 @@ function renderWildmenu(matches: ExCompletionMatch[], cycleIdx: number, anchor: 
   menu.root.style.display = 'block'
   positionWildmenu(anchor)
 
-  const activeRow = menu.list.querySelector<HTMLDivElement>(`[data-idx="${cycleIdx}"]`)
+  const activeRow = menu.list.querySelector<HTMLDivElement>(
+    `[data-idx="${cycleIdx}"]`
+  )
   if (activeRow) activeRow.scrollIntoView({ block: 'nearest' })
 }
 
@@ -1140,7 +1236,12 @@ function installExTabCompletion(): void {
         // the app shouldn't clobber our state (modifier keys fire even
         // when the input is focused too, so we ignore those explicitly
         // instead of resetting on them).
-        if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Alt' || e.key === 'Meta') {
+        if (
+          e.key === 'Shift' ||
+          e.key === 'Control' ||
+          e.key === 'Alt' ||
+          e.key === 'Meta'
+        ) {
           return
         }
         const target = e.target as HTMLElement | null
@@ -1170,7 +1271,8 @@ function installExTabCompletion(): void {
       e.stopImmediatePropagation()
 
       const step = e.shiftKey ? -1 : 1
-      const fresh = !exCycle || exCycle.input !== target || exCycle.basePrefix === null
+      const fresh =
+        !exCycle || exCycle.input !== target || exCycle.basePrefix === null
 
       if (fresh) {
         exCycle = {
@@ -1347,7 +1449,9 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
       out.push(
         <div
           key={child.id}
-          className={['flex min-h-0 min-w-0', isRow ? '' : 'flex-col'].join(' ')}
+          className={['flex min-h-0 min-w-0', isRow ? '' : 'flex-col'].join(
+            ' '
+          )}
           style={{ flex: `${basis} 1 0`, minWidth: 0, minHeight: 0 }}
         >
           <PaneTreeView node={child} />
@@ -1369,7 +1473,10 @@ function PaneSplitView({ split }: { split: PaneSplit }): JSX.Element {
   return (
     <div
       ref={containerRef}
-      className={['flex min-h-0 min-w-0 flex-1', isRow ? 'flex-row' : 'flex-col'].join(' ')}
+      className={[
+        'flex min-h-0 min-w-0 flex-1',
+        isRow ? 'flex-row' : 'flex-col'
+      ].join(' ')}
     >
       {nodes}
     </div>
@@ -1403,7 +1510,9 @@ function ResizeDivider({
       <div
         className={[
           'absolute',
-          isVertical ? 'top-0 bottom-0 -left-1 w-[9px]' : 'left-0 right-0 -top-1 h-[9px]'
+          isVertical
+            ? 'top-0 bottom-0 -left-1 w-[9px]'
+            : 'left-0 right-0 -top-1 h-[9px]'
         ].join(' ')}
       />
     </div>

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -2436,6 +2436,8 @@ function KeymapSettings({
   onSetBinding: (id: KeymapId, binding: string | null) => void
   onResetAll: () => void
 }): JSX.Element {
+  const vimMappings = useStore((s)=> s.vimMappings)
+  const setVimMappings = useStore((s)=> s.setVimMappings)
   const [query, setQuery] = useState('')
   const [recording, setRecording] = useState<KeymapDefinition | null>(null)
 
@@ -2465,6 +2467,21 @@ function KeymapSettings({
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="flex min-h-0 flex-1 flex-col rounded-3xl border border-paper-300/60 bg-paper-50/45 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
+        <div className="z-10 rounded-t-[22px] border-b border-paper-300/55 bg-paper-50/95 px-5 py-4 backdrop-blur flex flex-col gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-ink-900">.vimrc</div>
+            <div className="mt-1 text-xs leading-5 text-ink-500">
+              Paste in your config here, one mapping per line. This will only apply into vim motions.
+            </div>
+          </div>
+           <textarea
+              value={vimMappings}
+              onChange={(e) => setVimMappings(e.target.value)}
+              placeholder={"noremap L $\nnoremap H ^\n\" comment"}
+              spellCheck={false}
+              className="h-40 w-full resize-y rounded-xl border border-paper-300/70 bg-paper-50/80 px-3.5 py-3 font-mono text-xs leading-5 text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
+            /> 
+        </div>
         <div className="sticky top-0 z-10 rounded-t-[22px] border-b border-paper-300/55 bg-paper-50/95 px-5 py-4 backdrop-blur">
           <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="min-w-0">

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -2436,8 +2436,8 @@ function KeymapSettings({
   onSetBinding: (id: KeymapId, binding: string | null) => void
   onResetAll: () => void
 }): JSX.Element {
-  const vimMappings = useStore((s)=> s.vimMappings)
-  const setVimMappings = useStore((s)=> s.setVimMappings)
+  const vimMappings = useStore((s) => s.vimMappings)
+  const setVimMappings = useStore((s) => s.setVimMappings)
   const [query, setQuery] = useState('')
   const [recording, setRecording] = useState<KeymapDefinition | null>(null)
 
@@ -2471,16 +2471,17 @@ function KeymapSettings({
           <div className="min-w-0">
             <div className="text-sm font-medium text-ink-900">.vimrc</div>
             <div className="mt-1 text-xs leading-5 text-ink-500">
-              Paste in your config here, one mapping per line. This will only apply into vim motions.
+              Extend custom key mappings using Vimscript syntax. Supports
+              noremap, map, and unmap across normal, visual, and insert modes.
             </div>
           </div>
-           <textarea
-              value={vimMappings}
-              onChange={(e) => setVimMappings(e.target.value)}
-              placeholder={"noremap L $\nnoremap H ^\n\" comment"}
-              spellCheck={false}
-              className="h-40 w-full resize-y rounded-xl border border-paper-300/70 bg-paper-50/80 px-3.5 py-3 font-mono text-xs leading-5 text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
-            /> 
+          <textarea
+            value={vimMappings}
+            onChange={(e) => setVimMappings(e.target.value)}
+            placeholder={'noremap L $\nnoremap H ^\n" comment'}
+            spellCheck={false}
+            className="h-40 w-full resize-none rounded-xl border border-paper-300/70 bg-paper-50/80 px-3.5 py-3 font-mono text-xs leading-5 text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
+          />
         </div>
         <div className="sticky top-0 z-10 rounded-t-[22px] border-b border-paper-300/55 bg-paper-50/95 px-5 py-4 backdrop-blur">
           <div className="flex flex-wrap items-center justify-between gap-3">

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -1,6 +1,16 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import { createPortal } from 'react-dom'
-import { DEFAULT_DAILY_NOTES_DIRECTORY, DEFAULT_WEEKLY_NOTES_DIRECTORY } from '@shared/ipc'
+import {
+  DEFAULT_DAILY_NOTES_DIRECTORY,
+  DEFAULT_WEEKLY_NOTES_DIRECTORY
+} from '@shared/ipc'
 import type {
   AppUpdateState,
   CliInstallStatus,
@@ -20,7 +30,11 @@ import {
 } from '@shared/mcp-clients'
 import { useStore } from '../store'
 import type { LineNumberMode, WhichKeyHintMode } from '../store'
-import type { KeymapDefinition, KeymapId, KeymapOverrides } from '../lib/keymaps'
+import type {
+  KeymapDefinition,
+  KeymapId,
+  KeymapOverrides
+} from '../lib/keymaps'
 import {
   findConflictingKeymaps,
   formatKeymapBinding,
@@ -33,15 +47,29 @@ import {
   shortcutBindingFromEvent
 } from '../lib/keymaps'
 import { diagnoseVimMappings, toVimSequence } from '../lib/vim-mappings'
-import { resolveAuto, THEMES, type ThemeFamily, type ThemeMode } from '../lib/themes'
+import {
+  resolveAuto,
+  THEMES,
+  type ThemeFamily,
+  type ThemeMode
+} from '../lib/themes'
 import { hasSystemFontAccess, listSystemFonts } from '../lib/system-fonts'
-import { DEFAULT_SYSTEM_FOLDER_LABELS, getSystemFolderLabel } from '../lib/system-folder-labels'
-import { normalizeDailyNotesDirectory, normalizeWeeklyNotesDirectory } from '../lib/vault-layout'
+import {
+  DEFAULT_SYSTEM_FOLDER_LABELS,
+  getSystemFolderLabel
+} from '../lib/system-folder-labels'
+import {
+  normalizeDailyNotesDirectory,
+  normalizeWeeklyNotesDirectory
+} from '../lib/vault-layout'
 import { BUILTIN_TEMPLATES } from '@shared/builtin-templates'
 import { composeTemplateFile, mergeTemplates } from '@shared/template-files'
 import { TemplateEditorModal } from './TemplateEditorModal'
 import type { NoteTemplate } from '@bridge-contract/templates'
-import { getSettingsSearchResults, type SettingsSearchCategory } from '../lib/settings-search'
+import {
+  getSettingsSearchResults,
+  type SettingsSearchCategory
+} from '../lib/settings-search'
 import { useAppUpdateState } from '../lib/app-update-state'
 import { getZenBridge } from '@zennotes/bridge-contract/bridge'
 import companyLogo from '../assets/lumary-labs-logo.svg'
@@ -76,8 +104,13 @@ function settingsSearchTargetProps(settingId: string | undefined): {
   return settingId ? { 'data-settings-search-id': settingId } : {}
 }
 
-function findSettingsSearchTarget(root: HTMLElement, targetId: string): HTMLElement | null {
-  for (const element of root.querySelectorAll<HTMLElement>('[data-settings-search-id]')) {
+function findSettingsSearchTarget(
+  root: HTMLElement,
+  targetId: string
+): HTMLElement | null {
+  for (const element of root.querySelectorAll<HTMLElement>(
+    '[data-settings-search-id]'
+  )) {
     if (element.dataset.settingsSearchId === targetId) return element
   }
   return null
@@ -97,7 +130,8 @@ function resolveVaultTextSearchBackend(
 ): ResolvedVaultTextSearchBackend | null {
   if (!capabilities) return null
   if (preferred === 'builtin') return 'builtin'
-  if (preferred === 'ripgrep') return capabilities.ripgrep ? 'ripgrep' : 'builtin'
+  if (preferred === 'ripgrep')
+    return capabilities.ripgrep ? 'ripgrep' : 'builtin'
   if (preferred === 'fzf') return capabilities.fzf ? 'fzf' : 'builtin'
   if (capabilities.fzf) return 'fzf'
   if (capabilities.ripgrep) return 'ripgrep'
@@ -165,7 +199,11 @@ function formatBytes(bytes: number | null): string | null {
     unit = units[i]
   }
   const rounded =
-    value >= 100 ? value.toFixed(0) : value >= 10 ? value.toFixed(1) : value.toFixed(2)
+    value >= 100
+      ? value.toFixed(0)
+      : value >= 10
+        ? value.toFixed(1)
+        : value.toFixed(2)
   return `${rounded} ${unit}`
 }
 
@@ -191,7 +229,8 @@ function formatReleaseNotesForDisplay(notes: string | null): string | null {
 
 function statusChipClass(tone: 'ok' | 'warn' | 'off'): string {
   if (tone === 'ok') return 'border-accent/25 bg-accent/10 text-accent'
-  if (tone === 'warn') return 'border-amber-500/30 bg-amber-500/10 text-amber-500'
+  if (tone === 'warn')
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-500'
   return 'border-paper-300/70 bg-paper-100/85 text-ink-500'
 }
 
@@ -199,7 +238,8 @@ export function SettingsModal(): JSX.Element {
   const zenBridge = getZenBridge()
   const appInfo = zenBridge.getAppInfo()
   const supportsRemoteWorkspace =
-    appInfo.runtime === 'desktop' && zenBridge.getCapabilities().supportsRemoteWorkspace
+    appInfo.runtime === 'desktop' &&
+    zenBridge.getCapabilities().supportsRemoteWorkspace
   const setSettingsOpen = useStore((s) => s.setSettingsOpen)
   const vimMode = useStore((s) => s.vimMode)
   const setVimMode = useStore((s) => s.setVimMode)
@@ -248,11 +288,19 @@ export function SettingsModal(): JSX.Element {
   const persistVaultSettings = useStore((s) => s.setVaultSettings)
   const openVaultPicker = useStore((s) => s.openVaultPicker)
   const connectRemoteWorkspace = useStore((s) => s.connectRemoteWorkspace)
-  const connectRemoteWorkspaceProfile = useStore((s) => s.connectRemoteWorkspaceProfile)
-  const changeRemoteWorkspaceVaultPath = useStore((s) => s.changeRemoteWorkspaceVaultPath)
+  const connectRemoteWorkspaceProfile = useStore(
+    (s) => s.connectRemoteWorkspaceProfile
+  )
+  const changeRemoteWorkspaceVaultPath = useStore(
+    (s) => s.changeRemoteWorkspaceVaultPath
+  )
   const disconnectRemoteWorkspace = useStore((s) => s.disconnectRemoteWorkspace)
-  const saveRemoteWorkspaceProfile = useStore((s) => s.saveRemoteWorkspaceProfile)
-  const deleteRemoteWorkspaceProfile = useStore((s) => s.deleteRemoteWorkspaceProfile)
+  const saveRemoteWorkspaceProfile = useStore(
+    (s) => s.saveRemoteWorkspaceProfile
+  )
+  const deleteRemoteWorkspaceProfile = useStore(
+    (s) => s.deleteRemoteWorkspaceProfile
+  )
   const openTodayDailyNote = useStore((s) => s.openTodayDailyNote)
   const openThisWeekWeeklyNote = useStore((s) => s.openThisWeekWeeklyNote)
   const autoCalendarPanel = useStore((s) => s.autoCalendarPanel)
@@ -260,17 +308,24 @@ export function SettingsModal(): JSX.Element {
   const calendarWeekStart = useStore((s) => s.calendarWeekStart)
   const setCalendarWeekStart = useStore((s) => s.setCalendarWeekStart)
   const calendarShowWeekNumbers = useStore((s) => s.calendarShowWeekNumbers)
-  const setCalendarShowWeekNumbers = useStore((s) => s.setCalendarShowWeekNumbers)
+  const setCalendarShowWeekNumbers = useStore(
+    (s) => s.setCalendarShowWeekNumbers
+  )
   const customTemplates = useStore((s) => s.customTemplates)
   const deleteCustomTemplate = useStore((s) => s.deleteCustomTemplate)
   const hideBuiltinTemplates = useStore((s) => s.hideBuiltinTemplates)
   const setHideBuiltinTemplates = useStore((s) => s.setHideBuiltinTemplates)
   const allTemplates = useMemo(
-    () => mergeTemplates(hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES, customTemplates),
+    () =>
+      mergeTemplates(
+        hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES,
+        customTemplates
+      ),
     [customTemplates, hideBuiltinTemplates]
   )
   const supportsCustomTemplates =
-    zenBridge.getCapabilities().supportsCustomTemplates && workspaceMode !== 'remote'
+    zenBridge.getCapabilities().supportsCustomTemplates &&
+    workspaceMode !== 'remote'
   const [templateEditor, setTemplateEditor] = useState<{
     initialRaw?: string
     sourcePath?: string
@@ -397,7 +452,8 @@ export function SettingsModal(): JSX.Element {
         if (!cancelled) setVaultTextSearchCapabilities(capabilities)
       },
       () => {
-        if (!cancelled) setVaultTextSearchCapabilities({ ripgrep: false, fzf: false })
+        if (!cancelled)
+          setVaultTextSearchCapabilities({ ripgrep: false, fzf: false })
       }
     )
     return () => {
@@ -423,7 +479,10 @@ export function SettingsModal(): JSX.Element {
         }
       },
       (error) => {
-        const message = error instanceof Error ? error.message : 'Could not check for updates.'
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Could not check for updates.'
         window.alert(message)
       }
     )
@@ -453,18 +512,21 @@ export function SettingsModal(): JSX.Element {
     })
   }, [remoteWorkspaceInfo?.baseUrl, vault?.root, workspaceMode])
 
-  const openEditRemoteProfile = useCallback((profile: RemoteWorkspaceProfile) => {
-    setEditingRemoteProfile({
-      mode: 'edit',
-      value: {
-        id: profile.id,
-        name: profile.name,
-        baseUrl: profile.baseUrl,
-        vaultPath: profile.vaultPath
-      },
-      hasStoredCredential: profile.hasCredential
-    })
-  }, [])
+  const openEditRemoteProfile = useCallback(
+    (profile: RemoteWorkspaceProfile) => {
+      setEditingRemoteProfile({
+        mode: 'edit',
+        value: {
+          id: profile.id,
+          name: profile.name,
+          baseUrl: profile.baseUrl,
+          vaultPath: profile.vaultPath
+        },
+        hasStoredCredential: profile.hasCredential
+      })
+    },
+    []
+  )
 
   const submitRemoteProfile = useCallback(
     async (input: RemoteWorkspaceProfileInput) => {
@@ -547,13 +609,18 @@ export function SettingsModal(): JSX.Element {
    *  mode this is whatever `resolveAuto` produced, since the stored
    *  themeId may not match what's painted on screen. */
   const renderedThemeId = useMemo(
-    () => (themeMode === 'auto' ? resolveAuto(themeFamily, prefersDark, themeId) : themeId),
+    () =>
+      themeMode === 'auto'
+        ? resolveAuto(themeFamily, prefersDark, themeId)
+        : themeId,
     [themeId, themeFamily, themeMode, prefersDark]
   )
 
   const visibleVariants = useMemo(() => {
     if (themeFamily === 'gruvbox') {
-      return THEMES.filter((t) => t.family === 'gruvbox' && t.mode === effectiveMode)
+      return THEMES.filter(
+        (t) => t.family === 'gruvbox' && t.mode === effectiveMode
+      )
     }
     // Families with only a light/dark pair don't need a variant picker —
     // the Mode selector above already handles the toggle.
@@ -598,7 +665,10 @@ export function SettingsModal(): JSX.Element {
     const currentVariant = THEMES.find((t) => t.id === themeId)?.variant
     const candidate =
       THEMES.find(
-        (t) => t.family === themeFamily && t.mode === mode && t.variant === currentVariant
+        (t) =>
+          t.family === themeFamily &&
+          t.mode === mode &&
+          t.variant === currentVariant
       ) ?? THEMES.find((t) => t.family === themeFamily && t.mode === mode)
     if (candidate) setTheme({ id: candidate.id, family: themeFamily, mode })
   }
@@ -617,15 +687,22 @@ export function SettingsModal(): JSX.Element {
 
   const ref = useRef<HTMLDivElement | null>(null)
   const settingsSearchHighlightTimerRef = useRef<number | null>(null)
-  const [activeCategory, setActiveCategory] = useState<SettingsCategoryId>('appearance')
-  const [activeSearchResultId, setActiveSearchResultId] = useState<string | null>(null)
+  const [activeCategory, setActiveCategory] =
+    useState<SettingsCategoryId>('appearance')
+  const [activeSearchResultId, setActiveSearchResultId] = useState<
+    string | null
+  >(null)
   const [navQuery, setNavQuery] = useState('')
   const availableVaultTextSearchTools = [
     vaultTextSearchCapabilities?.ripgrep ? 'ripgrep' : null,
     vaultTextSearchCapabilities?.fzf ? 'fzf' : null
   ].filter((value): value is string => !!value)
   const resolvedVaultTextSearchBackend = useMemo(
-    () => resolveVaultTextSearchBackend(vaultTextSearchBackend, vaultTextSearchCapabilities),
+    () =>
+      resolveVaultTextSearchBackend(
+        vaultTextSearchBackend,
+        vaultTextSearchCapabilities
+      ),
     [vaultTextSearchBackend, vaultTextSearchCapabilities]
   )
   const resolvedVaultTextSearchMessage = useMemo(() => {
@@ -752,13 +829,17 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'sidebar-arrows',
           title: 'Sidebar arrows',
-          description: 'Show disclosure arrows for collapsible folders and sidebar sections.',
+          description:
+            'Show disclosure arrows for collapsible folders and sidebar sections.',
           keywords: ['chevrons', 'disclosure']
         }
       ],
       content: (
         <div className="space-y-6">
-          <Section title="Theme" description="Pick the visual system ZenNotes uses across the app.">
+          <Section
+            title="Theme"
+            description="Pick the visual system ZenNotes uses across the app."
+          >
             <div className="flex flex-col gap-5 px-5 py-5">
               <div {...settingsSearchTargetProps('theme-family')}>
                 <div className="mb-2 text-xs font-medium uppercase tracking-[0.18em] text-ink-500">
@@ -859,7 +940,8 @@ export function SettingsModal(): JSX.Element {
     {
       id: 'editor',
       title: 'Editor',
-      description: 'Vim, leader hints, live preview, tabs, and writing behavior.',
+      description:
+        'Vim, leader hints, live preview, tabs, and writing behavior.',
       keywords: [
         'vim',
         'leader',
@@ -884,7 +966,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'vim-insert-escape',
           title: 'Exit insert mode with',
-          description: 'Map a key sequence like jk or jj to Escape in insert mode.',
+          description:
+            'Map a key sequence like jk or jj to Escape in insert mode.',
           keywords: ['vim', 'jk', 'jj', 'escape', 'insert mode', 'esc']
         },
         {
@@ -939,7 +1022,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'note-tabs',
           title: 'Note tabs',
-          description: 'Open notes in tabs and allow split-friendly tab workflows.',
+          description:
+            'Open notes in tabs and allow split-friendly tab workflows.',
           keywords: ['tabs']
         },
         {
@@ -959,7 +1043,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'smooth-preview-scroll',
           title: 'Smooth preview scroll',
-          description: 'Animate Ctrl+D / Ctrl+U half-page jumps in preview mode.',
+          description:
+            'Animate Ctrl+D / Ctrl+U half-page jumps in preview mode.',
           keywords: ['preview', 'scroll']
         },
         {
@@ -972,7 +1057,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'date-titled-quick-notes',
           title: 'Date-titled Quick Notes',
-          description: 'New Quick Notes use YYYY-MM-DD instead of timestamp-style titles.',
+          description:
+            'New Quick Notes use YYYY-MM-DD instead of timestamp-style titles.',
           keywords: ['quick note', 'date', 'title']
         },
         {
@@ -984,13 +1070,17 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'quick-capture-hotkey',
           title: 'Quick capture hotkey',
-          description: 'System-wide shortcut to open the floating capture window.',
+          description:
+            'System-wide shortcut to open the floating capture window.',
           keywords: ['quick capture', 'hotkey', 'shortcut']
         }
       ],
       content: (
         <div className="space-y-6">
-          <Section title="Vim" description="Keyboard-first editing behavior and leader guidance.">
+          <Section
+            title="Vim"
+            description="Keyboard-first editing behavior and leader guidance."
+          >
             <ToggleRow
               label="Vim mode"
               description="First-class Vim motions in the markdown editor."
@@ -1026,7 +1116,9 @@ export function SettingsModal(): JSX.Element {
                         { value: 'timed', label: 'Timed' },
                         { value: 'sticky', label: 'Sticky' }
                       ]}
-                      onChange={(next) => setWhichKeyHintMode(next as WhichKeyHintMode)}
+                      onChange={(next) =>
+                        setWhichKeyHintMode(next as WhichKeyHintMode)
+                      }
                     />
                     {whichKeyHintMode === 'timed' && (
                       <SliderRow
@@ -1051,7 +1143,10 @@ export function SettingsModal(): JSX.Element {
             )}
           </Section>
 
-          <Section title="Search" description="Choose how vault-wide text search is powered.">
+          <Section
+            title="Search"
+            description="Choose how vault-wide text search is powered."
+          >
             <SegmentedRow
               label="Vault text search backend"
               description="Auto prefers fzf when available, then ripgrep, and falls back to the built-in searcher."
@@ -1064,7 +1159,9 @@ export function SettingsModal(): JSX.Element {
                 { value: 'fzf', label: 'fzf' }
               ]}
               onChange={(next) =>
-                setVaultTextSearchBackend(next as VaultTextSearchBackendPreference)
+                setVaultTextSearchBackend(
+                  next as VaultTextSearchBackendPreference
+                )
               }
             />
             <TextInputRow
@@ -1084,7 +1181,10 @@ export function SettingsModal(): JSX.Element {
               onChange={(next) => setFzfBinaryPath(next)}
             />
             <InlineNote>
-              Runtime backend: {resolvedVaultTextSearchBackendLabel(resolvedVaultTextSearchBackend)}
+              Runtime backend:{' '}
+              {resolvedVaultTextSearchBackendLabel(
+                resolvedVaultTextSearchBackend
+              )}
             </InlineNote>
             <InlineNote>{resolvedVaultTextSearchMessage}</InlineNote>
             <InlineNote>
@@ -1181,12 +1281,23 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'shortcut-editor',
           title: 'Shortcut editor',
-          description: 'Record a new key or sequence for the app’s keyboard-first actions.',
-          keywords: ['shortcuts', 'bindings', 'leader', 'vim', 'remap', 'keyboard']
+          description:
+            'Record a new key or sequence for the app’s keyboard-first actions.',
+          keywords: [
+            'shortcuts',
+            'bindings',
+            'leader',
+            'vim',
+            'remap',
+            'keyboard'
+          ]
         }
       ],
       content: (
-        <div className="h-full" {...settingsSearchTargetProps('shortcut-editor')}>
+        <div
+          className="h-full"
+          {...settingsSearchTargetProps('shortcut-editor')}
+        >
           <KeymapSettings
             vimMode={vimMode}
             overrides={keymapOverrides}
@@ -1199,8 +1310,16 @@ export function SettingsModal(): JSX.Element {
     {
       id: 'typography',
       title: 'Typography',
-      description: 'Fonts, line height, reading width, alignment, and line numbers.',
-      keywords: ['font', 'size', 'line height', 'width', 'alignment', 'numbers'],
+      description:
+        'Fonts, line height, reading width, alignment, and line numbers.',
+      keywords: [
+        'font',
+        'size',
+        'line height',
+        'width',
+        'alignment',
+        'numbers'
+      ],
       searchItems: [
         {
           id: 'interface-font',
@@ -1248,7 +1367,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'content-alignment',
           title: 'Content alignment',
-          description: 'Center note content within the column or left-align it to the pane edge.',
+          description:
+            'Center note content within the column or left-align it to the pane edge.',
           keywords: ['alignment', 'center', 'left']
         },
         {
@@ -1290,7 +1410,10 @@ export function SettingsModal(): JSX.Element {
             />
           </Section>
 
-          <Section title="Layout" description="Tune reading density and how notes sit in the pane.">
+          <Section
+            title="Layout"
+            description="Tune reading density and how notes sit in the pane."
+          >
             <SliderRow
               label="Font size"
               description="Editor and preview text size."
@@ -1371,13 +1494,15 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'vault-location',
           title: 'Vault location',
-          description: 'ZenNotes reads markdown directly from the selected vault folder.',
+          description:
+            'ZenNotes reads markdown directly from the selected vault folder.',
           keywords: ['folder', 'root', 'location', 'open vault', 'change']
         },
         {
           id: 'saved-remote-workspaces',
           title: 'Saved Remote Workspaces',
-          description: 'Keep multiple ZenNotes servers and vaults ready to reconnect.',
+          description:
+            'Keep multiple ZenNotes servers and vaults ready to reconnect.',
           keywords: ['remote', 'server', 'workspace', 'connect'],
           available: supportsRemoteWorkspace
         },
@@ -1416,7 +1541,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'enable-weekly-notes',
           title: 'Enable weekly notes',
-          description: 'Adds a dedicated weekly-notes workflow alongside daily notes.',
+          description:
+            'Adds a dedicated weekly-notes workflow alongside daily notes.',
           keywords: ['weekly notes']
         },
         {
@@ -1434,7 +1560,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'open-this-week-note',
           title: "Open this week's note",
-          description: "Opens this week's note if it exists, otherwise creates it.",
+          description:
+            "Opens this week's note if it exists, otherwise creates it.",
           keywords: ['weekly notes', 'this week']
         },
         {
@@ -1442,7 +1569,13 @@ export function SettingsModal(): JSX.Element {
           title: 'Show calendar in daily & weekly notes',
           description:
             'Auto-open a calendar panel on the right while viewing a daily or weekly note.',
-          keywords: ['calendar', 'daily notes', 'weekly notes', 'date', 'navigate']
+          keywords: [
+            'calendar',
+            'daily notes',
+            'weekly notes',
+            'date',
+            'navigate'
+          ]
         },
         {
           id: 'calendar-week-start',
@@ -1459,7 +1592,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'inbox-label',
           title: 'Inbox label',
-          description: 'Shown in the sidebar, breadcrumbs, commands, and note actions.',
+          description:
+            'Shown in the sidebar, breadcrumbs, commands, and note actions.',
           keywords: ['system folders', 'folder label']
         },
         {
@@ -1493,7 +1627,9 @@ export function SettingsModal(): JSX.Element {
             >
               <div className="min-w-0">
                 <div className="text-sm font-medium text-ink-900">
-                  {workspaceMode === 'remote' ? 'Remote workspace' : 'Vault location'}
+                  {workspaceMode === 'remote'
+                    ? 'Remote workspace'
+                    : 'Vault location'}
                 </div>
                 <div className="mt-1 truncate text-xs text-ink-500">
                   {vault?.root ?? 'No vault selected'}
@@ -1512,7 +1648,9 @@ export function SettingsModal(): JSX.Element {
                 }
                 className="shrink-0 rounded-xl border border-paper-300/70 bg-paper-100/80 px-3.5 py-2 text-xs font-medium text-ink-800 transition-colors hover:bg-paper-200"
               >
-                {workspaceMode === 'remote' ? 'Change Remote Vault…' : 'Change…'}
+                {workspaceMode === 'remote'
+                  ? 'Change Remote Vault…'
+                  : 'Change…'}
               </button>
               {workspaceMode === 'remote' && (
                 <button
@@ -1550,8 +1688,8 @@ export function SettingsModal(): JSX.Element {
               <div className="space-y-3 px-5 py-5">
                 <div className="flex items-center justify-between gap-4">
                   <div className="text-xs text-ink-500">
-                    Saved connections can point at different servers or different vaults on the same
-                    server.
+                    Saved connections can point at different servers or
+                    different vaults on the same server.
                   </div>
                   <button
                     type="button"
@@ -1564,8 +1702,10 @@ export function SettingsModal(): JSX.Element {
                 {remoteWorkspaceProfiles.length === 0 ? (
                   <div className="rounded-xl border border-paper-300/60 bg-paper-50/60 px-4 py-4 text-sm text-ink-500">
                     No saved remote workspaces yet. Use{' '}
-                    <span className="font-medium text-ink-700">Quick Connect…</span> once and
-                    ZenNotes will remember it here.
+                    <span className="font-medium text-ink-700">
+                      Quick Connect…
+                    </span>{' '}
+                    once and ZenNotes will remember it here.
                   </div>
                 ) : (
                   <div className="space-y-3">
@@ -1600,7 +1740,9 @@ export function SettingsModal(): JSX.Element {
                             {!isCurrent && (
                               <button
                                 type="button"
-                                onClick={() => void connectRemoteWorkspaceProfile(profile.id)}
+                                onClick={() =>
+                                  void connectRemoteWorkspaceProfile(profile.id)
+                                }
                                 className="rounded-xl border border-paper-300/70 bg-paper-100/80 px-3 py-2 text-xs font-medium text-ink-800 transition-colors hover:bg-paper-200"
                               >
                                 Connect
@@ -1705,9 +1847,12 @@ export function SettingsModal(): JSX.Element {
               {...settingsSearchTargetProps('open-todays-daily-note')}
             >
               <div className="min-w-0">
-                <div className="text-sm font-medium text-ink-900">Open today's daily note</div>
+                <div className="text-sm font-medium text-ink-900">
+                  Open today's daily note
+                </div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
-                  Opens today's note if it exists, otherwise creates it with a YYYY-MM-DD title.
+                  Opens today's note if it exists, otherwise creates it with a
+                  YYYY-MM-DD title.
                 </div>
               </div>
               <button
@@ -1779,9 +1924,12 @@ export function SettingsModal(): JSX.Element {
               {...settingsSearchTargetProps('open-this-week-note')}
             >
               <div className="min-w-0">
-                <div className="text-sm font-medium text-ink-900">Open this week's note</div>
+                <div className="text-sm font-medium text-ink-900">
+                  Open this week's note
+                </div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
-                  Opens this week's note if it exists, otherwise creates it with a YYYY-Www title.
+                  Opens this week's note if it exists, otherwise creates it with
+                  a YYYY-Www title.
                 </div>
               </div>
               <button
@@ -1863,7 +2011,8 @@ export function SettingsModal(): JSX.Element {
               onChange={(next) => setSystemFolderLabel('trash', next)}
             />
             <InlineNote>
-              Current labels: {getSystemFolderLabel('quick', systemFolderLabels)},{' '}
+              Current labels:{' '}
+              {getSystemFolderLabel('quick', systemFolderLabels)},{' '}
               {getSystemFolderLabel('inbox', systemFolderLabels)},{' '}
               {getSystemFolderLabel('archive', systemFolderLabels)}, and{' '}
               {getSystemFolderLabel('trash', systemFolderLabels)}.
@@ -1918,7 +2067,9 @@ export function SettingsModal(): JSX.Element {
                 {...settingsSearchTargetProps('templates-new')}
               >
                 <div className="min-w-0">
-                  <div className="text-sm font-medium text-ink-900">Create a custom template</div>
+                  <div className="text-sm font-medium text-ink-900">
+                    Create a custom template
+                  </div>
                   <div className="mt-1 text-xs leading-5 text-ink-500">
                     Stored as a markdown file in `.zennotes/templates`.
                   </div>
@@ -1934,13 +2085,16 @@ export function SettingsModal(): JSX.Element {
               </div>
             ) : (
               <InlineNote>
-                Custom templates require a local vault. Built-in templates still work here.
+                Custom templates require a local vault. Built-in templates still
+                work here.
               </InlineNote>
             )}
             <div className="flex items-center justify-between gap-4 border-t border-paper-300/40 px-5 py-4">
               <div className="min-w-0">
                 <div className="text-sm font-medium text-ink-900">
-                  {hideBuiltinTemplates ? 'Built-in templates are hidden' : 'Built-in templates'}
+                  {hideBuiltinTemplates
+                    ? 'Built-in templates are hidden'
+                    : 'Built-in templates'}
                 </div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
                   {hideBuiltinTemplates
@@ -1954,13 +2108,20 @@ export function SettingsModal(): JSX.Element {
                 onClick={() => void toggleBuiltinTemplates()}
                 className="shrink-0"
               >
-                {hideBuiltinTemplates ? 'Restore built-in templates' : 'Remove built-in templates'}
+                {hideBuiltinTemplates
+                  ? 'Restore built-in templates'
+                  : 'Remove built-in templates'}
               </Button>
             </div>
             {allTemplates.map((template) => (
-              <div key={template.id} className="flex items-center justify-between gap-4 px-5 py-3">
+              <div
+                key={template.id}
+                className="flex items-center justify-between gap-4 px-5 py-3"
+              >
                 <div className="min-w-0">
-                  <div className="text-sm font-medium text-ink-900">{template.name}</div>
+                  <div className="text-sm font-medium text-ink-900">
+                    {template.name}
+                  </div>
                   <div className="mt-0.5 truncate text-xs text-ink-500">
                     {template.category}
                     {template.description ? ` — ${template.description}` : ''}
@@ -2033,7 +2194,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'mcp-server',
           title: 'MCP server',
-          description: 'ZenNotes bundles a local MCP server that connected clients use.',
+          description:
+            'ZenNotes bundles a local MCP server that connected clients use.',
           keywords: ['mcp', 'server', 'runtime', 'command']
         },
         {
@@ -2045,7 +2207,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'mcp-instructions',
           title: 'MCP instructions',
-          description: 'Edit the system prompt ZenNotes ships to any connected MCP client.',
+          description:
+            'Edit the system prompt ZenNotes ships to any connected MCP client.',
           keywords: ['mcp', 'prompt', 'instructions', 'system prompt']
         }
       ],
@@ -2074,8 +2237,17 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'zen-command-line-tool',
           title: 'zen command-line tool',
-          description: 'Install the `zen` shell command for terminal-based note workflows.',
-          keywords: ['cli', 'command line', 'terminal', 'shell', 'zen', 'install', 'path']
+          description:
+            'Install the `zen` shell command for terminal-based note workflows.',
+          keywords: [
+            'cli',
+            'command line',
+            'terminal',
+            'shell',
+            'zen',
+            'install',
+            'path'
+          ]
         },
         {
           id: 'cli-quick-reference',
@@ -2086,7 +2258,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'raycast-extension',
           title: 'Raycast Extension',
-          description: 'Install the ZenNotes Raycast extension locally from this app.',
+          description:
+            'Install the ZenNotes Raycast extension locally from this app.',
           keywords: ['raycast', 'launcher', 'extension', 'install']
         }
       ],
@@ -2095,7 +2268,8 @@ export function SettingsModal(): JSX.Element {
     {
       id: 'about',
       title: 'About',
-      description: 'App identity, version, updater status, and company information.',
+      description:
+        'App identity, version, updater status, and company information.',
       keywords: ['version', 'company', 'lumary', 'about', 'logo', 'updates'],
       searchItems: [
         {
@@ -2141,7 +2315,9 @@ export function SettingsModal(): JSX.Element {
                           updatePhaseBadgeClass(appUpdateState?.phase ?? 'idle')
                         ].join(' ')}
                       >
-                        {formatUpdatePhaseLabel(appUpdateState?.phase ?? 'idle')}
+                        {formatUpdatePhaseLabel(
+                          appUpdateState?.phase ?? 'idle'
+                        )}
                       </span>
                       {appUpdateState?.availableVersion && (
                         <span className="text-xs text-ink-500">
@@ -2185,7 +2361,8 @@ export function SettingsModal(): JSX.Element {
                     )}
                     <a
                       href={
-                        appInfo.homepage ?? 'https://github.com/ZenNotes/zennotes/releases/latest'
+                        appInfo.homepage ??
+                        'https://github.com/ZenNotes/zennotes/releases/latest'
                       }
                       target="_blank"
                       rel="noreferrer"
@@ -2196,7 +2373,8 @@ export function SettingsModal(): JSX.Element {
                   </div>
                 </div>
                 <p className="mt-3 text-sm leading-6 text-ink-600">
-                  {appUpdateState?.message ?? 'Check GitHub releases for a newer ZenNotes build.'}
+                  {appUpdateState?.message ??
+                    'Check GitHub releases for a newer ZenNotes build.'}
                 </p>
                 {appUpdateState?.phase === 'downloading' && (
                   <div className="mt-3">
@@ -2209,7 +2387,9 @@ export function SettingsModal(): JSX.Element {
                       />
                     </div>
                     <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-500">
-                      <span>{Math.round(appUpdateState.progressPercent ?? 0)}%</span>
+                      <span>
+                        {Math.round(appUpdateState.progressPercent ?? 0)}%
+                      </span>
                       {formatBytes(appUpdateState.transferredBytes) &&
                         formatBytes(appUpdateState.totalBytes) && (
                           <span>
@@ -2218,7 +2398,9 @@ export function SettingsModal(): JSX.Element {
                           </span>
                         )}
                       {formatBytes(appUpdateState.bytesPerSecond) && (
-                        <span>{formatBytes(appUpdateState.bytesPerSecond)}/s</span>
+                        <span>
+                          {formatBytes(appUpdateState.bytesPerSecond)}/s
+                        </span>
                       )}
                     </div>
                   </div>
@@ -2234,8 +2416,8 @@ export function SettingsModal(): JSX.Element {
                   </details>
                 )}
                 <div className="mt-3 text-xs leading-5 text-ink-500">
-                  In-app updates use the published GitHub release feed. For general users, that feed
-                  must be publicly reachable.
+                  In-app updates use the published GitHub release feed. For
+                  general users, that feed must be publicly reachable.
                 </div>
               </div>
               <p className="mx-auto mt-2 max-w-[44rem] text-center">
@@ -2362,7 +2544,9 @@ export function SettingsModal(): JSX.Element {
                       ].join(' ')}
                     >
                       <div className="flex min-w-0 items-center justify-between gap-2">
-                        <div className="truncate text-sm font-medium">{result.title}</div>
+                        <div className="truncate text-sm font-medium">
+                          {result.title}
+                        </div>
                         {result.type === 'setting' && (
                           <span className="shrink-0 rounded-full border border-paper-300/60 bg-paper-100/70 px-2 py-0.5 text-2xs font-medium text-ink-500">
                             {result.category.title}
@@ -2417,8 +2601,8 @@ export function SettingsModal(): JSX.Element {
                 visibleCategory.content
               ) : (
                 <div className="flex h-full min-h-[280px] items-center justify-center rounded-3xl border border-dashed border-paper-300/70 bg-paper-50/35 px-6 text-center text-sm leading-6 text-ink-500">
-                  Try a broader search term, or clear the search field to browse every settings
-                  section.
+                  Try a broader search term, or clear the search field to browse
+                  every settings section.
                 </div>
               )}
             </div>
@@ -2438,7 +2622,10 @@ export function SettingsModal(): JSX.Element {
                 : 'Save a ZenNotes server so you can reconnect without re-entering the details.',
             initialValue: editingRemoteProfile.value,
             hasStoredCredential: editingRemoteProfile.hasStoredCredential,
-            submitLabel: editingRemoteProfile.mode === 'edit' ? 'Save Changes' : 'Save Remote'
+            submitLabel:
+              editingRemoteProfile.mode === 'edit'
+                ? 'Save Changes'
+                : 'Save Remote'
           }}
           onSubmit={submitRemoteProfile}
           onCancel={() => setEditingRemoteProfile(null)}
@@ -2471,10 +2658,15 @@ function KeymapSettings({
   const [query, setQuery] = useState('')
   const [recording, setRecording] = useState<KeymapDefinition | null>(null)
 
-  const keymapDiagnostics = useMemo(() => findConflictingKeymaps(overrides), [overrides])
+  const keymapDiagnostics = useMemo(
+    () => findConflictingKeymaps(overrides),
+    [overrides]
+  )
 
   const vimMappingDiagnostics = useMemo(() => {
-    const leaderKey = toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix')) ?? '<Space>'
+    const leaderKey =
+      toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix')) ??
+      '<Space>'
     const appSeqMap = getAppVimSequenceMap(overrides)
     return diagnoseVimMappings(vimMappings, leaderKey, appSeqMap)
   }, [vimMappings, overrides])
@@ -2483,7 +2675,8 @@ function KeymapSettings({
     () =>
       new Set(
         vimMappingDiagnostics.reduce<KeymapId[]>((acc, d) => {
-          if (d.kind === 'app-conflict' && d.keymapId) acc.push(d.keymapId as KeymapId)
+          if (d.kind === 'app-conflict' && d.keymapId)
+            acc.push(d.keymapId as KeymapId)
           return acc
         }, [])
       ),
@@ -2495,7 +2688,11 @@ function KeymapSettings({
     return getKeymapDefinitionsByGroup()
       .map((group) => {
         const items = group.items.filter((definition) => {
-          if (definition.vimOnly && !vimMode && definition.id !== 'global.searchNotesNonVim') {
+          if (
+            definition.vimOnly &&
+            !vimMode &&
+            definition.id !== 'global.searchNotesNonVim'
+          ) {
             // Keep Vim-only bindings visible so users can prep their layout
             // before turning Vim mode back on, but still let the filter work.
           }
@@ -2508,7 +2705,12 @@ function KeymapSettings({
         })
         return items.length > 0 ? { ...group, items } : null
       })
-      .filter((group): group is ReturnType<typeof getKeymapDefinitionsByGroup>[number] => !!group)
+      .filter(
+        (
+          group
+        ): group is ReturnType<typeof getKeymapDefinitionsByGroup>[number] =>
+          !!group
+      )
   }, [overrides, query, vimMode])
 
   const totalConflicts = keymapDiagnostics.size + vimrcOverriddenIds.size
@@ -2521,8 +2723,9 @@ function KeymapSettings({
         <div className="min-w-0">
           <div className="text-sm font-medium text-ink-900">Vimrc</div>
           <div className="mt-1 text-xs leading-5 text-ink-500">
-            Extend custom key mappings using Vimscript syntax, takes precedence over vim keymaps.
-            Supports noremap, map, and unmap across normal, visual, and insert modes.
+            Extend custom key mappings using Vimscript syntax, takes precedence
+            over vim keymaps. Supports noremap, map, and unmap across normal,
+            visual, and insert modes.
           </div>
         </div>
         <textarea
@@ -2537,7 +2740,9 @@ function KeymapSettings({
             <ul className="space-y-1">
               {vimMappingDiagnostics.map((d, i) => (
                 <li key={i} className="flex gap-2 text-xs text-amber-500">
-                  <span className="shrink-0">Line {String(d.line).padStart(2, ' ')}:</span>
+                  <span className="shrink-0">
+                    Line {String(d.line).padStart(2, ' ')}:
+                  </span>
                   <span>{d.message}</span>
                 </li>
               ))}
@@ -2563,8 +2768,9 @@ function KeymapSettings({
                 )}
               </div>
               <div className="mt-1 text-xs leading-5 text-ink-500">
-                Record a new key or sequence for the app’s keyboard-first actions. Standard
-                accessibility fallbacks like arrows, Enter, and Escape still work.
+                Record a new key or sequence for the app’s keyboard-first
+                actions. Standard accessibility fallbacks like arrows, Enter,
+                and Escape still work.
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -2602,7 +2808,8 @@ function KeymapSettings({
                   const current = getKeymapBinding(overrides, definition.id)
                   const custom = !!overrides[definition.id]
                   const inactive =
-                    (definition.vimOnly && !vimMode) || (definition.nonVimOnly && vimMode)
+                    (definition.vimOnly && !vimMode) ||
+                    (definition.nonVimOnly && vimMode)
                   return (
                     <div
                       key={definition.id}
@@ -2693,7 +2900,10 @@ function KeymapSettings({
           currentBinding={getKeymapBinding(overrides, recording.id)}
           onClose={() => setRecording(null)}
           onSave={(binding) => {
-            onSetBinding(recording.id, binding === recording.defaultBinding ? null : binding)
+            onSetBinding(
+              recording.id,
+              binding === recording.defaultBinding ? null : binding
+            )
             setRecording(null)
           }}
         />
@@ -2719,7 +2929,11 @@ function KeymapRecorderModal({
   useEffect(() => {
     const onKey = (event: KeyboardEvent): void => {
       const target = event.target as HTMLElement | null
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return
+      if (
+        target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')
+      )
+        return
       const key = event.key
       if (key === 'Backspace' || key === 'Delete') {
         event.preventDefault()
@@ -2763,21 +2977,29 @@ function KeymapRecorderModal({
     return () => window.removeEventListener('keydown', onKey, true)
   }, [definition])
 
-  const display = binding ? formatKeymapBinding(binding, definition.kind) : 'Press a key…'
+  const display = binding
+    ? formatKeymapBinding(binding, definition.kind)
+    : 'Press a key…'
 
   return createPortal(
     <div className="fixed inset-0 z-toast flex items-center justify-center bg-black/35 px-4 backdrop-blur-sm">
       <div className="w-[min(440px,92vw)] overflow-hidden rounded-2xl border border-paper-300/70 bg-paper-100 shadow-float">
         <div className="border-b border-paper-300/60 px-5 py-4">
-          <div className="text-base font-semibold text-ink-900">{definition.title}</div>
-          <div className="mt-1 text-sm text-ink-500">{definition.description}</div>
+          <div className="text-base font-semibold text-ink-900">
+            {definition.title}
+          </div>
+          <div className="mt-1 text-sm text-ink-500">
+            {definition.description}
+          </div>
         </div>
         <div className="px-5 py-4">
           <div className="rounded-xl border border-paper-300/70 bg-paper-50/80 px-4 py-4">
             <div className="text-xs font-medium uppercase tracking-[0.16em] text-ink-500">
               Recording
             </div>
-            <div className="mt-2 text-2xl font-semibold text-ink-900">{display}</div>
+            <div className="mt-2 text-2xl font-semibold text-ink-900">
+              {display}
+            </div>
             <div className="mt-2 text-xs leading-5 text-ink-500">
               {definition.kind === 'shortcut'
                 ? `Press the shortcut you want. ${mac ? 'Command' : 'Ctrl'}-style chords are saved in the app’s cross-platform format.`
@@ -2788,7 +3010,8 @@ function KeymapRecorderModal({
             Current: {formatKeymapBinding(currentBinding, definition.kind)}
           </div>
           <div className="mt-1 text-xs text-ink-500">
-            Default: {formatKeymapBinding(definition.defaultBinding, definition.kind)}
+            Default:{' '}
+            {formatKeymapBinding(definition.defaultBinding, definition.kind)}
           </div>
         </div>
         <div className="flex items-center justify-between gap-3 border-t border-paper-300/60 px-5 py-3">
@@ -2807,7 +3030,12 @@ function KeymapRecorderModal({
             >
               Cancel
             </button>
-            <Button variant="primary" size="sm" disabled={!binding} onClick={() => onSave(binding)}>
+            <Button
+              variant="primary"
+              size="sm"
+              disabled={!binding}
+              onClick={() => onSave(binding)}
+            >
               Save
             </Button>
           </div>
@@ -2832,9 +3060,13 @@ function Section({
   return (
     <section className="space-y-3" {...settingsSearchTargetProps(settingId)}>
       <div>
-        <div className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">{title}</div>
+        <div className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">
+          {title}
+        </div>
         {description && (
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-ink-500">{description}</p>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-ink-500">
+            {description}
+          </p>
         )}
       </div>
       <div className="overflow-hidden rounded-3xl border border-paper-300/60 bg-paper-50/45 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
@@ -2845,7 +3077,9 @@ function Section({
 }
 
 function InlineNote({ children }: { children: React.ReactNode }): JSX.Element {
-  return <div className="px-5 py-4 text-xs leading-5 text-ink-500">{children}</div>
+  return (
+    <div className="px-5 py-4 text-xs leading-5 text-ink-500">{children}</div>
+  )
 }
 
 const DEFAULT_QUICK_CAPTURE_HOTKEY = 'CommandOrControl+Shift+Space'
@@ -2863,8 +3097,10 @@ function formatAcceleratorForDisplay(accelerator: string): string {
   return accelerator
     .split('+')
     .map((part) => {
-      if (part === 'CommandOrControl' || part === 'CmdOrCtrl') return mac ? '⌘' : 'Ctrl'
-      if (part === 'Command' || part === 'Cmd' || part === 'Meta') return mac ? '⌘' : 'Meta'
+      if (part === 'CommandOrControl' || part === 'CmdOrCtrl')
+        return mac ? '⌘' : 'Ctrl'
+      if (part === 'Command' || part === 'Cmd' || part === 'Meta')
+        return mac ? '⌘' : 'Meta'
       if (part === 'Control' || part === 'Ctrl') return mac ? '⌃' : 'Ctrl'
       if (part === 'Alt' || part === 'Option') return mac ? '⌥' : 'Alt'
       if (part === 'Shift') return mac ? '⇧' : 'Shift'
@@ -2874,7 +3110,9 @@ function formatAcceleratorForDisplay(accelerator: string): string {
     .join(mac ? '' : '+')
 }
 
-function QuickCaptureHotkeyRow({ settingId }: { settingId?: string } = {}): JSX.Element {
+function QuickCaptureHotkeyRow({
+  settingId
+}: { settingId?: string } = {}): JSX.Element {
   const [current, setCurrent] = useState<string>('')
   const [recording, setRecording] = useState(false)
   const [draft, setDraft] = useState<string>('')
@@ -2931,13 +3169,19 @@ function QuickCaptureHotkeyRow({ settingId }: { settingId?: string } = {}): JSX.
 
   const display = draft || current
   return (
-    <div className="flex flex-col gap-2 px-5 py-4" {...settingsSearchTargetProps(settingId)}>
+    <div
+      className="flex flex-col gap-2 px-5 py-4"
+      {...settingsSearchTargetProps(settingId)}
+    >
       <div className="flex items-center justify-between gap-5">
         <div className="min-w-0">
-          <div className="text-sm font-medium text-ink-900">Quick capture hotkey</div>
+          <div className="text-sm font-medium text-ink-900">
+            Quick capture hotkey
+          </div>
           <div className="mt-1 text-xs leading-5 text-ink-500">
-            System-wide shortcut to open the floating capture window. Works even when ZenNotes is
-            hidden or another app is focused. Click Record, then press the chord; Esc cancels.
+            System-wide shortcut to open the floating capture window. Works even
+            when ZenNotes is hidden or another app is focused. Click Record,
+            then press the chord; Esc cancels.
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -3031,7 +3275,11 @@ function TextInputRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <input
         value={value}
@@ -3071,7 +3319,11 @@ function TemplateSelectRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <select
         value={missing ? '__missing__' : (value ?? '')}
@@ -3175,14 +3427,19 @@ function FontRow({
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
-    const base = q ? options.filter((o) => o.toLowerCase().includes(q)) : options
+    const base = q
+      ? options.filter((o) => o.toLowerCase().includes(q))
+      : options
     return base.slice(0, 120)
   }, [query, options])
 
   // Virtual item list: entry 0 is the "Default" reset, then every filtered
   // font. A single index tracks which row is keyboard-highlighted.
   // `null` represents the default / reset row.
-  const items: Array<string | null> = useMemo(() => [null, ...filtered], [filtered])
+  const items: Array<string | null> = useMemo(
+    () => [null, ...filtered],
+    [filtered]
+  )
 
   // Clamp the active index whenever the filter narrows/widens.
   useEffect(() => {
@@ -3192,7 +3449,9 @@ function FontRow({
   // Scroll the keyboard-selected row into view.
   useEffect(() => {
     if (!open || !listRef.current) return
-    const el = listRef.current.querySelector<HTMLElement>(`[data-idx="${activeIdx}"]`)
+    const el = listRef.current.querySelector<HTMLElement>(
+      `[data-idx="${activeIdx}"]`
+    )
     el?.scrollIntoView({ block: 'nearest' })
   }, [activeIdx, open])
 
@@ -3231,7 +3490,11 @@ function FontRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <button
         ref={buttonRef}
@@ -3242,7 +3505,9 @@ function FontRow({
         <span
           className="truncate"
           style={{
-            fontFamily: value ? `"${value}", ui-monospace, monospace` : undefined
+            fontFamily: value
+              ? `"${value}", ui-monospace, monospace`
+              : undefined
           }}
         >
           {value ?? 'Default'}
@@ -3300,7 +3565,9 @@ function FontRow({
               </button>
               {filtered.length === 0 ? (
                 <div className="px-3 py-4 text-center text-xs text-ink-400">
-                  {options.length === 0 ? 'No fonts available' : 'No fonts match your search'}
+                  {options.length === 0
+                    ? 'No fonts available'
+                    : 'No fonts match your search'}
                 </div>
               ) : (
                 filtered.map((f, i) => {
@@ -3359,7 +3626,8 @@ function SliderRow({
   settingId?: string
   onChange: (next: number) => void
 }): JSX.Element {
-  const display = (format ? format(value) : String(value)) + (unit && !format ? unit : '')
+  const display =
+    (format ? format(value) : String(value)) + (unit && !format ? unit : '')
   return (
     <div
       className="flex items-center justify-between gap-5 px-5 py-4"
@@ -3367,7 +3635,11 @@ function SliderRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <div className="flex shrink-0 items-center gap-3">
         <input
@@ -3379,7 +3651,9 @@ function SliderRow({
           onChange={(e) => onChange(Number(e.target.value))}
           className="zen-slider h-1 w-[140px] cursor-pointer appearance-none rounded-full"
         />
-        <div className="min-w-[54px] text-right text-sm tabular-nums text-ink-800">{display}</div>
+        <div className="min-w-[54px] text-right text-sm tabular-nums text-ink-800">
+          {display}
+        </div>
       </div>
     </div>
   )
@@ -3417,7 +3691,9 @@ function NumberRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="text-xs text-ink-500">{description}</div>}
+        {description && (
+          <div className="text-xs text-ink-500">{description}</div>
+        )}
       </div>
       <div className="flex items-center gap-2">
         <button
@@ -3427,7 +3703,9 @@ function NumberRow({
         >
           −
         </button>
-        <div className="min-w-[56px] text-center text-sm tabular-nums text-ink-800">{display}</div>
+        <div className="min-w-[56px] text-center text-sm tabular-nums text-ink-800">
+          {display}
+        </div>
         <button
           type="button"
           onClick={() => onChange(clamp(+(value + step).toFixed(2)))}
@@ -3460,7 +3738,11 @@ function ToggleRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <button
         type="button"
@@ -3505,7 +3787,11 @@ function SegmentedRow<T extends string>({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <div className="inline-flex shrink-0 rounded-xl border border-paper-300/70 bg-paper-100/75 p-1">
         {options.map((option) => (
@@ -3599,7 +3885,9 @@ function CliSettings(): JSX.Element {
           description="Install the `zen` shell command for terminal-based note workflows."
           settingId="zen-command-line-tool"
         >
-          <InlineNote>{status.reason ?? 'Not supported on this platform yet.'}</InlineNote>
+          <InlineNote>
+            {status.reason ?? 'Not supported on this platform yet.'}
+          </InlineNote>
         </Section>
       </div>
     )
@@ -3646,12 +3934,15 @@ function CliSettings(): JSX.Element {
                       : `Symlinks ${status.defaultTarget} to ZenNotes' bundled wrapper.`}
               </div>
               {status.reason && (
-                <div className="mt-1.5 text-xs leading-5 text-amber-500">{status.reason}</div>
+                <div className="mt-1.5 text-xs leading-5 text-amber-500">
+                  {status.reason}
+                </div>
               )}
               {!installed && status.pathHint && (
                 <div className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs leading-5 text-ink-700">
                   <div className="font-medium text-amber-600">
-                    {status.defaultTarget.replace(/\/[^/]+$/, '')} is not on your PATH.
+                    {status.defaultTarget.replace(/\/[^/]+$/, '')} is not on
+                    your PATH.
                   </div>
                   <div className="mt-1 text-ink-500">
                     After install, run this once so your shell can find{' '}
@@ -3708,7 +3999,9 @@ function CliSettings(): JSX.Element {
             </code>
             <button
               type="button"
-              onClick={() => copyToClipboard(status.installedAt ?? status.defaultTarget)}
+              onClick={() =>
+                copyToClipboard(status.installedAt ?? status.defaultTarget)
+              }
               className="shrink-0 rounded-md border border-paper-300/70 bg-paper-100/80 px-2 py-1 text-xs font-medium text-ink-700 hover:bg-paper-200"
             >
               Copy
@@ -3717,7 +4010,10 @@ function CliSettings(): JSX.Element {
         </div>
       </Section>
 
-      <RaycastExtensionSettings cliInstalled={installed} copyToClipboard={copyToClipboard} />
+      <RaycastExtensionSettings
+        cliInstalled={installed}
+        copyToClipboard={copyToClipboard}
+      />
 
       <Section
         title="Quick reference"
@@ -3820,7 +4116,9 @@ function RaycastExtensionSettings({
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-              <span className="text-sm font-medium text-ink-900">ZenNotes for Raycast</span>
+              <span className="text-sm font-medium text-ink-900">
+                ZenNotes for Raycast
+              </span>
               <span
                 className={[
                   'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
@@ -3831,15 +4129,19 @@ function RaycastExtensionSettings({
               </span>
             </div>
             <div className="mt-1 text-xs leading-5 text-ink-500">{detail}</div>
-            <div className="mt-1 text-xs leading-5 text-ink-400">{toolchainDetail}</div>
+            <div className="mt-1 text-xs leading-5 text-ink-400">
+              {toolchainDetail}
+            </div>
             {!cliInstalled && (
               <div className="mt-1.5 text-xs leading-5 text-amber-500">
-                Install the <code className="font-mono">zen</code> CLI above first. The Raycast
-                command calls it to read your local vault.
+                Install the <code className="font-mono">zen</code> CLI above
+                first. The Raycast command calls it to read your local vault.
               </div>
             )}
             {cliInstalled && status.reason && (
-              <div className="mt-1.5 text-xs leading-5 text-amber-500">{status.reason}</div>
+              <div className="mt-1.5 text-xs leading-5 text-amber-500">
+                {status.reason}
+              </div>
             )}
           </div>
           <Button
@@ -3884,13 +4186,18 @@ function raycastStatusChip(
   cliInstalled: boolean
 ): { label: string; tone: 'ok' | 'warn' | 'off' } {
   if (!status.supportedPlatform) return { label: 'Not supported', tone: 'off' }
-  if (status.installed && status.upToDate) return { label: 'Installed', tone: 'ok' }
-  if (status.installed && !status.upToDate) return { label: 'Update available', tone: 'warn' }
+  if (status.installed && status.upToDate)
+    return { label: 'Installed', tone: 'ok' }
+  if (status.installed && !status.upToDate)
+    return { label: 'Update available', tone: 'warn' }
   if (status.available && cliInstalled) return { label: 'Ready', tone: 'off' }
   return { label: 'Not ready', tone: 'off' }
 }
 
-function raycastStatusDetail(status: RaycastExtensionStatus, cliInstalled: boolean): string {
+function raycastStatusDetail(
+  status: RaycastExtensionStatus,
+  cliInstalled: boolean
+): string {
   if (!status.supportedPlatform) {
     return status.reason ?? 'Raycast extensions are available on macOS only.'
   }
@@ -3918,7 +4225,10 @@ function McpSettings(): JSX.Element {
 
   const refresh = useCallback(async (): Promise<void> => {
     try {
-      const [s, r] = await Promise.all([window.zen.mcpGetStatuses(), window.zen.mcpGetRuntime()])
+      const [s, r] = await Promise.all([
+        window.zen.mcpGetStatuses(),
+        window.zen.mcpGetRuntime()
+      ])
       setStatuses(s)
       setRuntime(r)
       setError(null)
@@ -3966,7 +4276,8 @@ function McpSettings(): JSX.Element {
 
   const serverStatusLabel =
     runtime == null ? 'Checking\u2026' : entryMissing ? 'Not built' : 'Ready'
-  const serverStatusTone = runtime == null ? 'off' : entryMissing ? 'warn' : 'ok'
+  const serverStatusTone =
+    runtime == null ? 'off' : entryMissing ? 'warn' : 'ok'
   const serverStatusClass = statusChipClass(serverStatusTone)
 
   return (
@@ -4181,10 +4492,13 @@ function McpInstructionsEditor(): JSX.Element {
         <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-ink-500">
           <span>
             Saved at:{' '}
-            <code className="font-mono text-xs text-ink-600">{payload?.filePath ?? '—'}</code>
+            <code className="font-mono text-xs text-ink-600">
+              {payload?.filePath ?? '—'}
+            </code>
           </span>
           <span>
-            {draft.length.toLocaleString()} chars · {draft.split(/\r?\n/).length} lines
+            {draft.length.toLocaleString()} chars ·{' '}
+            {draft.split(/\r?\n/).length} lines
           </span>
         </div>
         {error && (
@@ -4237,9 +4551,13 @@ function McpClientRow({
               {chip.label}
             </span>
           </div>
-          <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
           {status.note && (
-            <div className="mt-1.5 text-xs leading-5 text-ink-500">{status.note}</div>
+            <div className="mt-1.5 text-xs leading-5 text-ink-500">
+              {status.note}
+            </div>
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -4275,7 +4593,12 @@ function McpClientRow({
               </button>
             </>
           ) : (
-            <Button variant="primary" size="sm" onClick={onInstall} disabled={busy || entryMissing}>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={onInstall}
+              disabled={busy || entryMissing}
+            >
               {busy ? 'Installing…' : 'Install'}
             </Button>
           )}

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -4,12 +4,12 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
+  useState
 } from 'react'
 import { createPortal } from 'react-dom'
 import {
   DEFAULT_DAILY_NOTES_DIRECTORY,
-  DEFAULT_WEEKLY_NOTES_DIRECTORY,
+  DEFAULT_WEEKLY_NOTES_DIRECTORY
 } from '@shared/ipc'
 import type {
   AppUpdateState,
@@ -19,21 +19,21 @@ import type {
   RemoteWorkspaceProfileInput,
   VaultTextSearchBackendPreference,
   VaultTextSearchCapabilities,
-  VaultTextSearchToolPaths,
+  VaultTextSearchToolPaths
 } from '@shared/ipc'
 import {
   MCP_CLIENTS,
   type McpClientId,
   type McpClientStatus,
   type McpInstructionsPayload,
-  type McpServerRuntime,
+  type McpServerRuntime
 } from '@shared/mcp-clients'
 import { useStore } from '../store'
 import type { LineNumberMode, WhichKeyHintMode } from '../store'
 import type {
   KeymapDefinition,
   KeymapId,
-  KeymapOverrides,
+  KeymapOverrides
 } from '../lib/keymaps'
 import {
   findConflictingKeymaps,
@@ -44,23 +44,23 @@ import {
   getKeymapDisplay,
   isMacPlatform,
   sequenceTokenFromEvent,
-  shortcutBindingFromEvent,
+  shortcutBindingFromEvent
 } from '../lib/keymaps'
 import { diagnoseVimMappings, toVimSequence } from '../lib/vim-mappings'
 import {
   resolveAuto,
   THEMES,
   type ThemeFamily,
-  type ThemeMode,
+  type ThemeMode
 } from '../lib/themes'
 import { hasSystemFontAccess, listSystemFonts } from '../lib/system-fonts'
 import {
   DEFAULT_SYSTEM_FOLDER_LABELS,
-  getSystemFolderLabel,
+  getSystemFolderLabel
 } from '../lib/system-folder-labels'
 import {
   normalizeDailyNotesDirectory,
-  normalizeWeeklyNotesDirectory,
+  normalizeWeeklyNotesDirectory
 } from '../lib/vault-layout'
 import { BUILTIN_TEMPLATES } from '@shared/builtin-templates'
 import { composeTemplateFile, mergeTemplates } from '@shared/template-files'
@@ -68,7 +68,7 @@ import { TemplateEditorModal } from './TemplateEditorModal'
 import type { NoteTemplate } from '@bridge-contract/templates'
 import {
   getSettingsSearchResults,
-  type SettingsSearchCategory,
+  type SettingsSearchCategory
 } from '../lib/settings-search'
 import { useAppUpdateState } from '../lib/app-update-state'
 import { getZenBridge } from '@zennotes/bridge-contract/bridge'
@@ -106,10 +106,10 @@ function settingsSearchTargetProps(settingId: string | undefined): {
 
 function findSettingsSearchTarget(
   root: HTMLElement,
-  targetId: string,
+  targetId: string
 ): HTMLElement | null {
   for (const element of root.querySelectorAll<HTMLElement>(
-    '[data-settings-search-id]',
+    '[data-settings-search-id]'
   )) {
     if (element.dataset.settingsSearchId === targetId) return element
   }
@@ -126,7 +126,7 @@ function clearSettingsSearchHighlights(root: HTMLElement): void {
 
 function resolveVaultTextSearchBackend(
   preferred: VaultTextSearchBackendPreference,
-  capabilities: VaultTextSearchCapabilities | null,
+  capabilities: VaultTextSearchCapabilities | null
 ): ResolvedVaultTextSearchBackend | null {
   if (!capabilities) return null
   if (preferred === 'builtin') return 'builtin'
@@ -139,7 +139,7 @@ function resolveVaultTextSearchBackend(
 }
 
 function resolvedVaultTextSearchBackendLabel(
-  backend: ResolvedVaultTextSearchBackend | null,
+  backend: ResolvedVaultTextSearchBackend | null
 ): string {
   if (backend === 'ripgrep') return 'ripgrep'
   if (backend === 'fzf') return 'fzf'
@@ -289,17 +289,17 @@ export function SettingsModal(): JSX.Element {
   const openVaultPicker = useStore((s) => s.openVaultPicker)
   const connectRemoteWorkspace = useStore((s) => s.connectRemoteWorkspace)
   const connectRemoteWorkspaceProfile = useStore(
-    (s) => s.connectRemoteWorkspaceProfile,
+    (s) => s.connectRemoteWorkspaceProfile
   )
   const changeRemoteWorkspaceVaultPath = useStore(
-    (s) => s.changeRemoteWorkspaceVaultPath,
+    (s) => s.changeRemoteWorkspaceVaultPath
   )
   const disconnectRemoteWorkspace = useStore((s) => s.disconnectRemoteWorkspace)
   const saveRemoteWorkspaceProfile = useStore(
-    (s) => s.saveRemoteWorkspaceProfile,
+    (s) => s.saveRemoteWorkspaceProfile
   )
   const deleteRemoteWorkspaceProfile = useStore(
-    (s) => s.deleteRemoteWorkspaceProfile,
+    (s) => s.deleteRemoteWorkspaceProfile
   )
   const openTodayDailyNote = useStore((s) => s.openTodayDailyNote)
   const openThisWeekWeeklyNote = useStore((s) => s.openThisWeekWeeklyNote)
@@ -309,7 +309,7 @@ export function SettingsModal(): JSX.Element {
   const setCalendarWeekStart = useStore((s) => s.setCalendarWeekStart)
   const calendarShowWeekNumbers = useStore((s) => s.calendarShowWeekNumbers)
   const setCalendarShowWeekNumbers = useStore(
-    (s) => s.setCalendarShowWeekNumbers,
+    (s) => s.setCalendarShowWeekNumbers
   )
   const customTemplates = useStore((s) => s.customTemplates)
   const deleteCustomTemplate = useStore((s) => s.deleteCustomTemplate)
@@ -319,9 +319,9 @@ export function SettingsModal(): JSX.Element {
     () =>
       mergeTemplates(
         hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES,
-        customTemplates,
+        customTemplates
       ),
-    [customTemplates, hideBuiltinTemplates],
+    [customTemplates, hideBuiltinTemplates]
   )
   const supportsCustomTemplates =
     zenBridge.getCapabilities().supportsCustomTemplates &&
@@ -351,8 +351,8 @@ export function SettingsModal(): JSX.Element {
         targetFolder: template.targetFolder,
         targetSubpath: template.targetSubpath,
         builtinId: template.id,
-        body: template.body,
-      }),
+        body: template.body
+      })
     })
   }
   const removeTemplate = async (template: NoteTemplate): Promise<void> => {
@@ -366,7 +366,7 @@ export function SettingsModal(): JSX.Element {
         ? 'This removes your customizations and restores the built-in template.'
         : 'This removes the template file. Notes already created from it are unaffected.',
       confirmLabel: isOverride ? 'Reset' : 'Delete',
-      danger: true,
+      danger: true
     })
     if (!confirmed) return
     await deleteCustomTemplate(template.sourcePath)
@@ -381,7 +381,7 @@ export function SettingsModal(): JSX.Element {
       description:
         'The shipped templates will be hidden from the picker and palette. Your custom templates are unaffected, and you can restore the built-ins anytime.',
       confirmLabel: 'Remove',
-      danger: true,
+      danger: true
     })
     if (!confirmed) return
     setHideBuiltinTemplates(true)
@@ -425,9 +425,9 @@ export function SettingsModal(): JSX.Element {
   const searchToolPaths = useMemo<VaultTextSearchToolPaths>(
     () => ({
       ripgrepPath: ripgrepBinaryPath,
-      fzfPath: fzfBinaryPath,
+      fzfPath: fzfBinaryPath
     }),
-    [fzfBinaryPath, ripgrepBinaryPath],
+    [fzfBinaryPath, ripgrepBinaryPath]
   )
   useEffect(() => {
     let cancelled = false
@@ -454,7 +454,7 @@ export function SettingsModal(): JSX.Element {
       () => {
         if (!cancelled)
           setVaultTextSearchCapabilities({ ripgrep: false, fzf: false })
-      },
+      }
     )
     return () => {
       cancelled = true
@@ -466,7 +466,7 @@ export function SettingsModal(): JSX.Element {
       (state) => {
         if (state.phase === 'available') {
           window.alert(
-            `ZenNotes ${state.availableVersion ?? ''} is available. Use “Download Update” to fetch it.`,
+            `ZenNotes ${state.availableVersion ?? ''} is available. Use “Download Update” to fetch it.`
           )
           return
         }
@@ -484,7 +484,7 @@ export function SettingsModal(): JSX.Element {
             ? error.message
             : 'Could not check for updates.'
         window.alert(message)
-      },
+      }
     )
   }, [])
 
@@ -506,9 +506,9 @@ export function SettingsModal(): JSX.Element {
         name: '',
         baseUrl: remoteWorkspaceInfo?.baseUrl ?? 'http://localhost:7878',
         authToken: null,
-        vaultPath: workspaceMode === 'remote' ? (vault?.root ?? null) : null,
+        vaultPath: workspaceMode === 'remote' ? (vault?.root ?? null) : null
       },
-      hasStoredCredential: false,
+      hasStoredCredential: false
     })
   }, [remoteWorkspaceInfo?.baseUrl, vault?.root, workspaceMode])
 
@@ -520,12 +520,12 @@ export function SettingsModal(): JSX.Element {
           id: profile.id,
           name: profile.name,
           baseUrl: profile.baseUrl,
-          vaultPath: profile.vaultPath,
+          vaultPath: profile.vaultPath
         },
-        hasStoredCredential: profile.hasCredential,
+        hasStoredCredential: profile.hasCredential
       })
     },
-    [],
+    []
   )
 
   const submitRemoteProfile = useCallback(
@@ -533,7 +533,7 @@ export function SettingsModal(): JSX.Element {
       await saveRemoteWorkspaceProfile(input)
       setEditingRemoteProfile(null)
     },
-    [saveRemoteWorkspaceProfile],
+    [saveRemoteWorkspaceProfile]
   )
 
   const removeRemoteProfile = useCallback(
@@ -543,17 +543,17 @@ export function SettingsModal(): JSX.Element {
         description:
           'This only removes the saved connection from ZenNotes. It does not delete anything on the server.',
         confirmLabel: 'Remove',
-        danger: true,
+        danger: true
       })
       if (!confirmed) return
       await deleteRemoteWorkspaceProfile(profile.id)
     },
-    [deleteRemoteWorkspaceProfile],
+    [deleteRemoteWorkspaceProfile]
   )
 
   const displayedReleaseNotes = useMemo(
     () => formatReleaseNotesForDisplay(appUpdateState?.releaseNotes ?? null),
-    [appUpdateState?.releaseNotes],
+    [appUpdateState?.releaseNotes]
   )
 
   // Family list — Apple is the default, followed by the other families.
@@ -567,9 +567,9 @@ export function SettingsModal(): JSX.Element {
       { id: 'one', label: 'One' },
       { id: 'nord', label: 'Nord' },
       { id: 'tokyo-night', label: 'Tokyo Night' },
-      { id: 'black-metal', label: 'Black Metal' },
+      { id: 'black-metal', label: 'Black Metal' }
     ],
-    [],
+    []
   )
 
   // Variants to show in the variant picker.
@@ -590,7 +590,7 @@ export function SettingsModal(): JSX.Element {
   const [prefersDark, setPrefersDark] = useState(() =>
     typeof window !== 'undefined'
       ? window.matchMedia('(prefers-color-scheme: dark)').matches
-      : false,
+      : false
   )
   useEffect(() => {
     const mql = window.matchMedia('(prefers-color-scheme: dark)')
@@ -613,13 +613,13 @@ export function SettingsModal(): JSX.Element {
       themeMode === 'auto'
         ? resolveAuto(themeFamily, prefersDark, themeId)
         : themeId,
-    [themeId, themeFamily, themeMode, prefersDark],
+    [themeId, themeFamily, themeMode, prefersDark]
   )
 
   const visibleVariants = useMemo(() => {
     if (themeFamily === 'gruvbox') {
       return THEMES.filter(
-        (t) => t.family === 'gruvbox' && t.mode === effectiveMode,
+        (t) => t.family === 'gruvbox' && t.mode === effectiveMode
       )
     }
     // Families with only a light/dark pair don't need a variant picker —
@@ -630,7 +630,7 @@ export function SettingsModal(): JSX.Element {
       'one',
       'nord',
       'tokyo-night',
-      'black-metal',
+      'black-metal'
     ]
     if (simpleFamilies.includes(themeFamily)) return []
     return THEMES.filter((t) => t.family === themeFamily)
@@ -649,7 +649,7 @@ export function SettingsModal(): JSX.Element {
       one: { light: 'one-light', dark: 'one-dark' },
       nord: { light: 'nord-light', dark: 'nord-dark' },
       'tokyo-night': { light: 'tokyo-night-day', dark: 'tokyo-night-storm' },
-      'black-metal': { light: 'black-metal-day', dark: 'black-metal' },
+      'black-metal': { light: 'black-metal-day', dark: 'black-metal' }
     }
     const targetId = preferred[family][effectiveMode]
     setTheme({ id: targetId, family, mode: themeMode })
@@ -668,7 +668,7 @@ export function SettingsModal(): JSX.Element {
         (t) =>
           t.family === themeFamily &&
           t.mode === mode &&
-          t.variant === currentVariant,
+          t.variant === currentVariant
       ) ?? THEMES.find((t) => t.family === themeFamily && t.mode === mode)
     if (candidate) setTheme({ id: candidate.id, family: themeFamily, mode })
   }
@@ -695,15 +695,15 @@ export function SettingsModal(): JSX.Element {
   const [navQuery, setNavQuery] = useState('')
   const availableVaultTextSearchTools = [
     vaultTextSearchCapabilities?.ripgrep ? 'ripgrep' : null,
-    vaultTextSearchCapabilities?.fzf ? 'fzf' : null,
+    vaultTextSearchCapabilities?.fzf ? 'fzf' : null
   ].filter((value): value is string => !!value)
   const resolvedVaultTextSearchBackend = useMemo(
     () =>
       resolveVaultTextSearchBackend(
         vaultTextSearchBackend,
-        vaultTextSearchCapabilities,
+        vaultTextSearchCapabilities
       ),
-    [vaultTextSearchBackend, vaultTextSearchCapabilities],
+    [vaultTextSearchBackend, vaultTextSearchCapabilities]
   )
   const resolvedVaultTextSearchMessage = useMemo(() => {
     if (!vaultTextSearchCapabilities) return 'Checking configured search tools…'
@@ -804,35 +804,35 @@ export function SettingsModal(): JSX.Element {
             'github',
             'solarized',
             'nord',
-            'tokyo night',
-          ],
+            'tokyo night'
+          ]
         },
         {
           id: 'theme-mode',
           title: 'Theme mode',
           description: 'Choose light, dark, or automatic theme mode.',
-          keywords: ['light', 'dark', 'auto', 'mode'],
+          keywords: ['light', 'dark', 'auto', 'mode']
         },
         {
           id: 'theme-variant',
           title: 'Theme variant',
           description: 'Choose a family-specific contrast, flavor, or variant.',
           keywords: ['variant', 'contrast', 'flavor'],
-          available: visibleVariants.length > 1,
+          available: visibleVariants.length > 1
         },
         {
           id: 'dark-sidebar',
           title: 'Dark sidebar',
           description:
-            'Tint the sidebar one step darker than the canvas so the chrome reads as a separate surface.',
+            'Tint the sidebar one step darker than the canvas so the chrome reads as a separate surface.'
         },
         {
           id: 'sidebar-arrows',
           title: 'Sidebar arrows',
           description:
             'Show disclosure arrows for collapsible folders and sidebar sections.',
-          keywords: ['chevrons', 'disclosure'],
-        },
+          keywords: ['chevrons', 'disclosure']
+        }
       ],
       content: (
         <div className="space-y-6">
@@ -854,7 +854,7 @@ export function SettingsModal(): JSX.Element {
                         'rounded-xl border px-3 py-2.5 text-left text-sm transition-colors',
                         themeFamily === f.id
                           ? 'border-accent/45 bg-accent/10 text-ink-900'
-                          : 'border-paper-300/70 bg-paper-100/70 text-ink-700 hover:bg-paper-200/80',
+                          : 'border-paper-300/70 bg-paper-100/70 text-ink-700 hover:bg-paper-200/80'
                       ].join(' ')}
                     >
                       {f.label}
@@ -876,7 +876,7 @@ export function SettingsModal(): JSX.Element {
                         'rounded-lg px-3 py-1.5 text-xs capitalize transition-colors',
                         themeMode === m
                           ? 'bg-paper-50 text-ink-900 shadow-sm'
-                          : 'text-ink-600 hover:text-ink-900',
+                          : 'text-ink-600 hover:text-ink-900'
                       ].join(' ')}
                     >
                       {m}
@@ -903,7 +903,7 @@ export function SettingsModal(): JSX.Element {
                           'rounded-xl border px-3 py-1.5 text-xs transition-colors',
                           renderedThemeId === v.id
                             ? 'border-accent/45 bg-accent/10 text-ink-900'
-                            : 'border-paper-300/70 bg-paper-100/70 text-ink-700 hover:bg-paper-200/80',
+                            : 'border-paper-300/70 bg-paper-100/70 text-ink-700 hover:bg-paper-200/80'
                         ].join(' ')}
                       >
                         {v.label}
@@ -935,7 +935,7 @@ export function SettingsModal(): JSX.Element {
             />
           </Section>
         </div>
-      ),
+      )
     },
     {
       id: 'editor',
@@ -954,21 +954,21 @@ export function SettingsModal(): JSX.Element {
         'hotkey',
         'shortcut',
         'task',
-        'tasks',
+        'tasks'
       ],
       searchItems: [
         {
           id: 'vim-mode',
           title: 'Vim mode',
           description: 'First-class Vim motions in the markdown editor.',
-          keywords: ['vim', 'motions'],
+          keywords: ['vim', 'motions']
         },
         {
           id: 'vim-insert-escape',
           title: 'Exit insert mode with',
           description:
             'Map a key sequence like jk or jj to Escape in insert mode.',
-          keywords: ['vim', 'jk', 'jj', 'escape', 'insert mode', 'esc'],
+          keywords: ['vim', 'jk', 'jj', 'escape', 'insert mode', 'esc']
         },
         {
           id: 'leader-key-hints',
@@ -976,7 +976,7 @@ export function SettingsModal(): JSX.Element {
           description:
             'Show a which-key style guide after pressing the Leader key so the next available actions stay visible.',
           keywords: ['leader', 'which-key'],
-          targetId: leaderKeyHintsTargetId,
+          targetId: leaderKeyHintsTargetId
         },
         {
           id: 'leader-hint-behavior',
@@ -984,7 +984,7 @@ export function SettingsModal(): JSX.Element {
           description:
             'Timed auto-hides after a short delay. Sticky keeps the leader overlay open until you dismiss it.',
           keywords: ['leader', 'sticky', 'timed'],
-          targetId: leaderHintBehaviorTargetId,
+          targetId: leaderHintBehaviorTargetId
         },
         {
           id: 'leader-hint-duration',
@@ -992,88 +992,88 @@ export function SettingsModal(): JSX.Element {
           description:
             'How long the leader overlay stays visible, and how long the pending leader sequence remains armed.',
           keywords: ['leader', 'timeout', 'delay'],
-          targetId: leaderHintDurationTargetId,
+          targetId: leaderHintDurationTargetId
         },
         {
           id: 'vault-text-search-backend',
           title: 'Vault text search backend',
           description:
             'Auto prefers fzf when available, then ripgrep, and falls back to the built-in searcher.',
-          keywords: ['search', 'backend', 'ripgrep', 'rg', 'fzf', 'built-in'],
+          keywords: ['search', 'backend', 'ripgrep', 'rg', 'fzf', 'built-in']
         },
         {
           id: 'ripgrep-binary-path',
           title: 'ripgrep binary path',
           description: 'Optional. Leave blank to use `rg` from your PATH.',
-          keywords: ['search', 'rg', 'path'],
+          keywords: ['search', 'rg', 'path']
         },
         {
           id: 'fzf-binary-path',
           title: 'fzf binary path',
           description: 'Optional. Leave blank to use `fzf` from your PATH.',
-          keywords: ['search', 'path'],
+          keywords: ['search', 'path']
         },
         {
           id: 'live-preview',
           title: 'Live preview',
           description: 'Hide markdown syntax on lines you are not editing.',
-          keywords: ['preview', 'markdown'],
+          keywords: ['preview', 'markdown']
         },
         {
           id: 'note-tabs',
           title: 'Note tabs',
           description:
             'Open notes in tabs and allow split-friendly tab workflows.',
-          keywords: ['tabs'],
+          keywords: ['tabs']
         },
         {
           id: 'wrap-note-tabs',
           title: 'Wrap note tabs',
           description:
             'Move overflowing tabs onto additional rows instead of horizontal scrolling.',
-          keywords: ['tabs', 'wrap', 'new line', 'overflow'],
+          keywords: ['tabs', 'wrap', 'new line', 'overflow']
         },
         {
           id: 'word-wrap',
           title: 'Word wrap',
           description:
             'Wrap long lines to the editor width. Turn off to scroll horizontally instead.',
-          keywords: ['wrap', 'line wrap'],
+          keywords: ['wrap', 'line wrap']
         },
         {
           id: 'smooth-preview-scroll',
           title: 'Smooth preview scroll',
           description:
             'Animate Ctrl+D / Ctrl+U half-page jumps in preview mode.',
-          keywords: ['preview', 'scroll'],
+          keywords: ['preview', 'scroll']
         },
         {
           id: 'pdfs-in-edit-mode',
           title: 'PDFs in edit mode',
           description:
             'Compact keeps the editor focused. Full inlines the PDF viewer under your cursor.',
-          keywords: ['pdf', 'embed'],
+          keywords: ['pdf', 'embed']
         },
         {
           id: 'date-titled-quick-notes',
           title: 'Date-titled Quick Notes',
           description:
             'New Quick Notes use YYYY-MM-DD instead of timestamp-style titles.',
-          keywords: ['quick note', 'date', 'title'],
+          keywords: ['quick note', 'date', 'title']
         },
         {
           id: 'quick-note-prefix',
           title: 'Quick Note prefix',
           description: 'Used when naming new Quick Notes.',
-          keywords: ['quick note', 'prefix'],
+          keywords: ['quick note', 'prefix']
         },
         {
           id: 'quick-capture-hotkey',
           title: 'Quick capture hotkey',
           description:
             'System-wide shortcut to open the floating capture window.',
-          keywords: ['quick capture', 'hotkey', 'shortcut'],
-        },
+          keywords: ['quick capture', 'hotkey', 'shortcut']
+        }
       ],
       content: (
         <div className="space-y-6">
@@ -1114,7 +1114,7 @@ export function SettingsModal(): JSX.Element {
                       settingId="leader-hint-behavior"
                       options={[
                         { value: 'timed', label: 'Timed' },
-                        { value: 'sticky', label: 'Sticky' },
+                        { value: 'sticky', label: 'Sticky' }
                       ]}
                       onChange={(next) =>
                         setWhichKeyHintMode(next as WhichKeyHintMode)
@@ -1156,11 +1156,11 @@ export function SettingsModal(): JSX.Element {
                 { value: 'auto', label: 'Auto' },
                 { value: 'builtin', label: 'Built-in' },
                 { value: 'ripgrep', label: 'ripgrep' },
-                { value: 'fzf', label: 'fzf' },
+                { value: 'fzf', label: 'fzf' }
               ]}
               onChange={(next) =>
                 setVaultTextSearchBackend(
-                  next as VaultTextSearchBackendPreference,
+                  next as VaultTextSearchBackendPreference
                 )
               }
             />
@@ -1183,7 +1183,7 @@ export function SettingsModal(): JSX.Element {
             <InlineNote>
               Runtime backend:{' '}
               {resolvedVaultTextSearchBackendLabel(
-                resolvedVaultTextSearchBackend,
+                resolvedVaultTextSearchBackend
               )}
             </InlineNote>
             <InlineNote>{resolvedVaultTextSearchMessage}</InlineNote>
@@ -1242,7 +1242,7 @@ export function SettingsModal(): JSX.Element {
               settingId="pdfs-in-edit-mode"
               options={[
                 { value: 'compact', label: 'Compact' },
-                { value: 'full', label: 'Full' },
+                { value: 'full', label: 'Full' }
               ]}
               onChange={(next) => setPdfEmbedInEditMode(next)}
             />
@@ -1270,7 +1270,7 @@ export function SettingsModal(): JSX.Element {
             <QuickCaptureHotkeyRow settingId="quick-capture-hotkey" />
           </Section>
         </div>
-      ),
+      )
     },
     {
       id: 'keymaps',
@@ -1289,9 +1289,9 @@ export function SettingsModal(): JSX.Element {
             'leader',
             'vim',
             'remap',
-            'keyboard',
-          ],
-        },
+            'keyboard'
+          ]
+        }
       ],
       content: (
         <div
@@ -1305,7 +1305,7 @@ export function SettingsModal(): JSX.Element {
             onResetAll={resetAllKeymaps}
           />
         </div>
-      ),
+      )
     },
     {
       id: 'typography',
@@ -1318,65 +1318,65 @@ export function SettingsModal(): JSX.Element {
         'line height',
         'width',
         'alignment',
-        'numbers',
+        'numbers'
       ],
       searchItems: [
         {
           id: 'interface-font',
           title: 'Interface font',
           description: 'Used for the sidebar, menus, and window chrome.',
-          keywords: ['font'],
+          keywords: ['font']
         },
         {
           id: 'text-font',
           title: 'Text font',
           description: 'Used for editing and reading views.',
-          keywords: ['font'],
+          keywords: ['font']
         },
         {
           id: 'monospace-font',
           title: 'Monospace font',
           description: 'Used for code blocks, inline code, and frontmatter.',
-          keywords: ['font', 'mono', 'code'],
+          keywords: ['font', 'mono', 'code']
         },
         {
           id: 'font-size',
           title: 'Font size',
           description: 'Editor and preview text size.',
-          keywords: ['size'],
+          keywords: ['size']
         },
         {
           id: 'line-height',
           title: 'Line height',
           description: 'Editor and preview line spacing.',
-          keywords: ['spacing'],
+          keywords: ['spacing']
         },
         {
           id: 'reading-width',
           title: 'Reading width',
           description: 'Maximum width for preview and split-preview content.',
-          keywords: ['width', 'preview'],
+          keywords: ['width', 'preview']
         },
         {
           id: 'editor-width',
           title: 'Editor width',
           description:
             'Caps and centers the editor column so lines do not stretch edge-to-edge on large windows.',
-          keywords: ['width'],
+          keywords: ['width']
         },
         {
           id: 'content-alignment',
           title: 'Content alignment',
           description:
             'Center note content within the column or left-align it to the pane edge.',
-          keywords: ['alignment', 'center', 'left'],
+          keywords: ['alignment', 'center', 'left']
         },
         {
           id: 'line-numbers',
           title: 'Line numbers',
           description: 'Show editor gutter numbers.',
-          keywords: ['numbers', 'gutter', 'relative', 'absolute'],
-        },
+          keywords: ['numbers', 'gutter', 'relative', 'absolute']
+        }
       ],
       content: (
         <div className="space-y-6">
@@ -1465,7 +1465,7 @@ export function SettingsModal(): JSX.Element {
               settingId="content-alignment"
               options={[
                 { value: 'center', label: 'Center' },
-                { value: 'left', label: 'Left' },
+                { value: 'left', label: 'Left' }
               ]}
               onChange={(next) => setContentAlign(next)}
             />
@@ -1477,13 +1477,13 @@ export function SettingsModal(): JSX.Element {
               options={[
                 { value: 'off', label: 'Off' },
                 { value: 'absolute', label: 'Absolute' },
-                { value: 'relative', label: 'Relative' },
+                { value: 'relative', label: 'Relative' }
               ]}
               onChange={(next) => setLineNumberMode(next)}
             />
           </Section>
         </div>
-      ),
+      )
     },
     {
       id: 'vault',
@@ -1496,7 +1496,7 @@ export function SettingsModal(): JSX.Element {
           title: 'Vault location',
           description:
             'ZenNotes reads markdown directly from the selected vault folder.',
-          keywords: ['folder', 'root', 'location', 'open vault', 'change'],
+          keywords: ['folder', 'root', 'location', 'open vault', 'change']
         },
         {
           id: 'saved-remote-workspaces',
@@ -1504,65 +1504,65 @@ export function SettingsModal(): JSX.Element {
           description:
             'Keep multiple ZenNotes servers and vaults ready to reconnect.',
           keywords: ['remote', 'server', 'workspace', 'connect'],
-          available: supportsRemoteWorkspace,
+          available: supportsRemoteWorkspace
         },
         {
           id: 'primary-notes-location',
           title: 'Primary notes location',
           description:
             'Choose whether ZenNotes treats `inbox/` as the main notes area or uses the vault root directly.',
-          keywords: ['primary notes', 'inbox', 'vault root'],
+          keywords: ['primary notes', 'inbox', 'vault root']
         },
         {
           id: 'enable-daily-notes',
           title: 'Enable daily notes',
           description:
             'Adds a dedicated daily-notes workflow without changing ordinary note creation.',
-          keywords: ['daily notes'],
+          keywords: ['daily notes']
         },
         {
           id: 'daily-notes-directory',
           title: 'Daily notes directory',
           description: 'Stored inside your primary notes area.',
-          keywords: ['daily notes', 'directory', 'folder'],
+          keywords: ['daily notes', 'directory', 'folder']
         },
         {
           id: 'open-todays-daily-note',
           title: "Open today's daily note",
           description: "Opens today's note if it exists, otherwise creates it.",
-          keywords: ['daily notes', 'today'],
+          keywords: ['daily notes', 'today']
         },
         {
           id: 'daily-notes-template',
           title: 'Daily note template',
           description: 'Template applied when a daily note is created.',
-          keywords: ['daily notes', 'template'],
+          keywords: ['daily notes', 'template']
         },
         {
           id: 'enable-weekly-notes',
           title: 'Enable weekly notes',
           description:
             'Adds a dedicated weekly-notes workflow alongside daily notes.',
-          keywords: ['weekly notes'],
+          keywords: ['weekly notes']
         },
         {
           id: 'weekly-notes-directory',
           title: 'Weekly notes directory',
           description: 'Stored inside your primary notes area.',
-          keywords: ['weekly notes', 'directory', 'folder'],
+          keywords: ['weekly notes', 'directory', 'folder']
         },
         {
           id: 'weekly-notes-template',
           title: 'Weekly note template',
           description: 'Template applied when a weekly note is created.',
-          keywords: ['weekly notes', 'template'],
+          keywords: ['weekly notes', 'template']
         },
         {
           id: 'open-this-week-note',
           title: "Open this week's note",
           description:
             "Opens this week's note if it exists, otherwise creates it.",
-          keywords: ['weekly notes', 'this week'],
+          keywords: ['weekly notes', 'this week']
         },
         {
           id: 'auto-calendar-panel',
@@ -1574,46 +1574,46 @@ export function SettingsModal(): JSX.Element {
             'daily notes',
             'weekly notes',
             'date',
-            'navigate',
-          ],
+            'navigate'
+          ]
         },
         {
           id: 'calendar-week-start',
           title: 'Calendar starts week on',
           description: 'Which weekday the calendar grid begins with.',
-          keywords: ['calendar', 'week start', 'monday', 'sunday', 'locale'],
+          keywords: ['calendar', 'week start', 'monday', 'sunday', 'locale']
         },
         {
           id: 'calendar-week-numbers',
           title: 'Show week numbers',
           description: 'Display the ISO week-number column in the calendar.',
-          keywords: ['calendar', 'week numbers', 'iso week', 'weekly notes'],
+          keywords: ['calendar', 'week numbers', 'iso week', 'weekly notes']
         },
         {
           id: 'inbox-label',
           title: 'Inbox label',
           description:
             'Shown in the sidebar, breadcrumbs, commands, and note actions.',
-          keywords: ['system folders', 'folder label'],
+          keywords: ['system folders', 'folder label']
         },
         {
           id: 'quick-notes-label',
           title: 'Quick Notes label',
           description: 'Display name for the quick-capture area.',
-          keywords: ['system folders', 'folder label', 'quick'],
+          keywords: ['system folders', 'folder label', 'quick']
         },
         {
           id: 'archive-label',
           title: 'Archive label',
           description: 'Display name for cold-storage notes.',
-          keywords: ['system folders', 'folder label'],
+          keywords: ['system folders', 'folder label']
         },
         {
           id: 'trash-label',
           title: 'Trash label',
           description: 'Display name for deleted-note recovery.',
-          keywords: ['system folders', 'folder label'],
-        },
+          keywords: ['system folders', 'folder label']
+        }
       ],
       content: (
         <div className="space-y-6">
@@ -1783,12 +1783,12 @@ export function SettingsModal(): JSX.Element {
               settingId="primary-notes-location"
               options={[
                 { value: 'inbox', label: 'Inbox' },
-                { value: 'root', label: 'Vault root' },
+                { value: 'root', label: 'Vault root' }
               ]}
               onChange={(primaryNotesLocation) =>
                 void persistVaultSettings({
                   ...vaultSettings,
-                  primaryNotesLocation,
+                  primaryNotesLocation
                 })
               }
             />
@@ -1808,8 +1808,8 @@ export function SettingsModal(): JSX.Element {
                   ...vaultSettings,
                   dailyNotes: {
                     ...vaultSettings.dailyNotes,
-                    enabled,
-                  },
+                    enabled
+                  }
                 })
               }
             />
@@ -1824,8 +1824,8 @@ export function SettingsModal(): JSX.Element {
                   ...vaultSettings,
                   dailyNotes: {
                     ...vaultSettings.dailyNotes,
-                    directory: normalizeDailyNotesDirectory(next),
-                  },
+                    directory: normalizeDailyNotesDirectory(next)
+                  }
                 })
               }
             />
@@ -1838,7 +1838,7 @@ export function SettingsModal(): JSX.Element {
               onChange={(templateId) =>
                 void persistVaultSettings({
                   ...vaultSettings,
-                  dailyNotes: { ...vaultSettings.dailyNotes, templateId },
+                  dailyNotes: { ...vaultSettings.dailyNotes, templateId }
                 })
               }
             />
@@ -1863,7 +1863,7 @@ export function SettingsModal(): JSX.Element {
                   'shrink-0 rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors',
                   vaultSettings.dailyNotes.enabled
                     ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
+                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
                 ].join(' ')}
               >
                 Open today
@@ -1885,8 +1885,8 @@ export function SettingsModal(): JSX.Element {
                   ...vaultSettings,
                   weeklyNotes: {
                     ...vaultSettings.weeklyNotes,
-                    enabled,
-                  },
+                    enabled
+                  }
                 })
               }
             />
@@ -1901,8 +1901,8 @@ export function SettingsModal(): JSX.Element {
                   ...vaultSettings,
                   weeklyNotes: {
                     ...vaultSettings.weeklyNotes,
-                    directory: normalizeWeeklyNotesDirectory(next),
-                  },
+                    directory: normalizeWeeklyNotesDirectory(next)
+                  }
                 })
               }
             />
@@ -1915,7 +1915,7 @@ export function SettingsModal(): JSX.Element {
               onChange={(templateId) =>
                 void persistVaultSettings({
                   ...vaultSettings,
-                  weeklyNotes: { ...vaultSettings.weeklyNotes, templateId },
+                  weeklyNotes: { ...vaultSettings.weeklyNotes, templateId }
                 })
               }
             />
@@ -1940,7 +1940,7 @@ export function SettingsModal(): JSX.Element {
                   'shrink-0 rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors',
                   vaultSettings.weeklyNotes.enabled
                     ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
+                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
                 ].join(' ')}
               >
                 Open this week
@@ -1961,7 +1961,7 @@ export function SettingsModal(): JSX.Element {
               options={[
                 { value: 'monday', label: 'Monday' },
                 { value: 'sunday', label: 'Sunday' },
-                { value: 'locale', label: 'Locale' },
+                { value: 'locale', label: 'Locale' }
               ]}
               onChange={setCalendarWeekStart}
             />
@@ -2019,7 +2019,7 @@ export function SettingsModal(): JSX.Element {
             </InlineNote>
           </Section>
         </div>
-      ),
+      )
     },
     {
       id: 'templates',
@@ -2037,22 +2037,22 @@ export function SettingsModal(): JSX.Element {
         'journal',
         'custom',
         'scaffold',
-        'boilerplate',
+        'boilerplate'
       ],
       searchItems: [
         {
           id: 'templates-list',
           title: 'Template library',
           description: 'Browse built-in templates and manage your custom ones.',
-          keywords: ['templates', 'library', 'built-in', 'custom'],
+          keywords: ['templates', 'library', 'built-in', 'custom']
         },
         {
           id: 'templates-new',
           title: 'Create a custom template',
           description: 'Author a new template stored in .zennotes/templates.',
           keywords: ['template', 'new', 'create', 'custom'],
-          available: supportsCustomTemplates,
-        },
+          available: supportsCustomTemplates
+        }
       ],
       content: (
         <div className="space-y-6">
@@ -2171,7 +2171,7 @@ export function SettingsModal(): JSX.Element {
             ))}
           </Section>
         </div>
-      ),
+      )
     },
     {
       id: 'mcp',
@@ -2188,7 +2188,7 @@ export function SettingsModal(): JSX.Element {
         'openai',
         'integration',
         'agent',
-        'model context protocol',
+        'model context protocol'
       ],
       searchItems: [
         {
@@ -2196,30 +2196,23 @@ export function SettingsModal(): JSX.Element {
           title: 'MCP server',
           description:
             'ZenNotes bundles a local MCP server that connected clients use.',
-          keywords: ['mcp', 'server', 'runtime', 'command'],
+          keywords: ['mcp', 'server', 'runtime', 'command']
         },
         {
           id: 'mcp-integrations',
           title: 'MCP integrations',
           description: 'Pick the clients you want connected to this vault.',
-          keywords: [
-            'mcp',
-            'claude',
-            'codex',
-            'client',
-            'install',
-            'uninstall',
-          ],
+          keywords: ['mcp', 'claude', 'codex', 'client', 'install', 'uninstall']
         },
         {
           id: 'mcp-instructions',
           title: 'MCP instructions',
           description:
             'Edit the system prompt ZenNotes ships to any connected MCP client.',
-          keywords: ['mcp', 'prompt', 'instructions', 'system prompt'],
-        },
+          keywords: ['mcp', 'prompt', 'instructions', 'system prompt']
+        }
       ],
-      content: <McpSettings />,
+      content: <McpSettings />
     },
     {
       id: 'cli',
@@ -2238,7 +2231,7 @@ export function SettingsModal(): JSX.Element {
         'automation',
         'pipe',
         'capture',
-        'developer',
+        'developer'
       ],
       searchItems: [
         {
@@ -2253,24 +2246,24 @@ export function SettingsModal(): JSX.Element {
             'shell',
             'zen',
             'install',
-            'path',
-          ],
+            'path'
+          ]
         },
         {
           id: 'cli-quick-reference',
           title: 'CLI quick reference',
           description: 'A handful of the most useful `zen` commands.',
-          keywords: ['cli', 'help', 'commands', 'reference'],
+          keywords: ['cli', 'help', 'commands', 'reference']
         },
         {
           id: 'raycast-extension',
           title: 'Raycast Extension',
           description:
             'Install the ZenNotes Raycast extension locally from this app.',
-          keywords: ['raycast', 'launcher', 'extension', 'install'],
-        },
+          keywords: ['raycast', 'launcher', 'extension', 'install']
+        }
       ],
-      content: <CliSettings />,
+      content: <CliSettings />
     },
     {
       id: 'about',
@@ -2283,20 +2276,20 @@ export function SettingsModal(): JSX.Element {
           id: 'zen-notes-version',
           title: 'ZenNotes version',
           description: 'App identity, current version, and product details.',
-          keywords: ['about', 'version', 'identity'],
+          keywords: ['about', 'version', 'identity']
         },
         {
           id: 'updates',
           title: 'Updates',
           description: 'Check GitHub releases for a newer ZenNotes build.',
-          keywords: ['release', 'download', 'install', 'updater'],
+          keywords: ['release', 'download', 'install', 'updater']
         },
         {
           id: 'lumary-labs',
           title: 'Lumary Labs',
           description: 'Company and product details.',
-          keywords: ['company', 'lumary', 'logo'],
-        },
+          keywords: ['company', 'lumary', 'logo']
+        }
       ],
       content: (
         <Section title="ZenNotes" settingId="zen-notes-version">
@@ -2319,13 +2312,11 @@ export function SettingsModal(): JSX.Element {
                       <span
                         className={[
                           'rounded-full border px-2.5 py-1 text-xs font-medium',
-                          updatePhaseBadgeClass(
-                            appUpdateState?.phase ?? 'idle',
-                          ),
+                          updatePhaseBadgeClass(appUpdateState?.phase ?? 'idle')
                         ].join(' ')}
                       >
                         {formatUpdatePhaseLabel(
-                          appUpdateState?.phase ?? 'idle',
+                          appUpdateState?.phase ?? 'idle'
                         )}
                       </span>
                       {appUpdateState?.availableVersion && (
@@ -2362,7 +2353,7 @@ export function SettingsModal(): JSX.Element {
                           appUpdateState?.phase === 'checking' ||
                           appUpdateState?.phase === 'downloading'
                             ? 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-                            : 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200',
+                            : 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
                         ].join(' ')}
                       >
                         Check for Updates
@@ -2391,7 +2382,7 @@ export function SettingsModal(): JSX.Element {
                       <div
                         className="h-full rounded-full bg-accent transition-[width] duration-200"
                         style={{
-                          width: `${Math.max(0, Math.min(100, appUpdateState.progressPercent ?? 0))}%`,
+                          width: `${Math.max(0, Math.min(100, appUpdateState.progressPercent ?? 0))}%`
                         }}
                       />
                     </div>
@@ -2465,7 +2456,7 @@ export function SettingsModal(): JSX.Element {
                       WebkitMaskPosition: 'center',
                       maskPosition: 'center',
                       WebkitMaskSize: 'contain',
-                      maskSize: 'contain',
+                      maskSize: 'contain'
                     }}
                   />
                 </a>
@@ -2473,8 +2464,8 @@ export function SettingsModal(): JSX.Element {
             </div>
           </div>
         </Section>
-      ),
-    },
+      )
+    }
   ]
 
   const query = navQuery.trim().toLowerCase()
@@ -2549,7 +2540,7 @@ export function SettingsModal(): JSX.Element {
                         'w-full rounded-xl px-3 py-2.5 text-left transition-colors',
                         selected
                           ? 'bg-paper-200/85 text-ink-900 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)]'
-                          : 'text-ink-600 hover:bg-paper-200/45 hover:text-ink-900',
+                          : 'text-ink-600 hover:bg-paper-200/45 hover:text-ink-900'
                       ].join(' ')}
                     >
                       <div className="flex min-w-0 items-center justify-between gap-2">
@@ -2634,7 +2625,7 @@ export function SettingsModal(): JSX.Element {
             submitLabel:
               editingRemoteProfile.mode === 'edit'
                 ? 'Save Changes'
-                : 'Save Remote',
+                : 'Save Remote'
           }}
           onSubmit={submitRemoteProfile}
           onCancel={() => setEditingRemoteProfile(null)}
@@ -2655,7 +2646,7 @@ function KeymapSettings({
   vimMode,
   overrides,
   onSetBinding,
-  onResetAll,
+  onResetAll
 }: {
   vimMode: boolean
   overrides: KeymapOverrides
@@ -2669,7 +2660,7 @@ function KeymapSettings({
 
   const keymapDiagnostics = useMemo(
     () => findConflictingKeymaps(overrides),
-    [overrides],
+    [overrides]
   )
 
   const vimMappingDiagnostics = useMemo(() => {
@@ -2687,9 +2678,9 @@ function KeymapSettings({
           if (d.kind === 'app-conflict' && d.keymapId)
             acc.push(d.keymapId as KeymapId)
           return acc
-        }, []),
+        }, [])
       ),
-    [vimMappingDiagnostics],
+    [vimMappingDiagnostics]
   )
 
   const groups = useMemo(() => {
@@ -2716,9 +2707,9 @@ function KeymapSettings({
       })
       .filter(
         (
-          group,
+          group
         ): group is ReturnType<typeof getKeymapDefinitionsByGroup>[number] =>
-          !!group,
+          !!group
       )
   }, [overrides, query, vimMode])
 
@@ -2769,7 +2760,7 @@ function KeymapSettings({
                   <span
                     className={[
                       'rounded-full px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                      statusChipClass('warn'),
+                      statusChipClass('warn')
                     ].join(' ')}
                   >
                     {totalConflicts} Conflict{totalConflicts > 0 ? 's' : ''}
@@ -2797,7 +2788,7 @@ function KeymapSettings({
                   'rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors',
                   hasOverrides
                     ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
+                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
                 ].join(' ')}
               >
                 Reset all
@@ -2843,7 +2834,7 @@ function KeymapSettings({
                             <span
                               className={[
                                 'rounded-full px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                                statusChipClass('warn'),
+                                statusChipClass('warn')
                               ].join(' ')}
                             >
                               Conflict
@@ -2853,7 +2844,7 @@ function KeymapSettings({
                             <span
                               className={[
                                 'rounded-full px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                                statusChipClass('warn'),
+                                statusChipClass('warn')
                               ].join(' ')}
                             >
                               vimrc
@@ -2883,7 +2874,7 @@ function KeymapSettings({
                             'rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors',
                             custom
                               ? 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200'
-                              : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
+                              : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
                           ].join(' ')}
                         >
                           Reset
@@ -2911,7 +2902,7 @@ function KeymapSettings({
           onSave={(binding) => {
             onSetBinding(
               recording.id,
-              binding === recording.defaultBinding ? null : binding,
+              binding === recording.defaultBinding ? null : binding
             )
             setRecording(null)
           }}
@@ -2925,7 +2916,7 @@ function KeymapRecorderModal({
   definition,
   currentBinding,
   onClose,
-  onSave,
+  onSave
 }: {
   definition: KeymapDefinition
   currentBinding: string
@@ -3051,7 +3042,7 @@ function KeymapRecorderModal({
         </div>
       </div>
     </div>,
-    document.body,
+    document.body
   )
 }
 
@@ -3059,7 +3050,7 @@ function Section({
   title,
   description,
   settingId,
-  children,
+  children
 }: {
   title: string
   description?: string
@@ -3120,7 +3111,7 @@ function formatAcceleratorForDisplay(accelerator: string): string {
 }
 
 function QuickCaptureHotkeyRow({
-  settingId,
+  settingId
 }: { settingId?: string } = {}): JSX.Element {
   const [current, setCurrent] = useState<string>('')
   const [recording, setRecording] = useState(false)
@@ -3205,7 +3196,7 @@ function QuickCaptureHotkeyRow({
               'rounded-xl border px-3 py-1.5 text-sm tabular-nums',
               recording
                 ? 'border-accent/60 bg-accent/10 text-accent'
-                : 'border-paper-300/70 bg-paper-100/80 text-ink-900 hover:border-paper-300',
+                : 'border-paper-300/70 bg-paper-100/80 text-ink-900 hover:border-paper-300'
             ].join(' ')}
           >
             {recording
@@ -3268,7 +3259,7 @@ function TextInputRow({
   value,
   placeholder,
   settingId,
-  onChange,
+  onChange
 }: {
   label: string
   description?: string
@@ -3309,7 +3300,7 @@ function TemplateSelectRow({
   value,
   templates,
   settingId,
-  onChange,
+  onChange
 }: {
   label: string
   description?: string
@@ -3361,7 +3352,7 @@ function FontRow({
   value,
   options,
   settingId,
-  onChange,
+  onChange
 }: {
   label: string
   description?: string
@@ -3422,7 +3413,7 @@ function FontRow({
       setRect({
         left: r.left,
         top: r.bottom + 4,
-        width: Math.max(260, r.width),
+        width: Math.max(260, r.width)
       })
     }
     update()
@@ -3447,7 +3438,7 @@ function FontRow({
   // `null` represents the default / reset row.
   const items: Array<string | null> = useMemo(
     () => [null, ...filtered],
-    [filtered],
+    [filtered]
   )
 
   // Clamp the active index whenever the filter narrows/widens.
@@ -3459,7 +3450,7 @@ function FontRow({
   useEffect(() => {
     if (!open || !listRef.current) return
     const el = listRef.current.querySelector<HTMLElement>(
-      `[data-idx="${activeIdx}"]`,
+      `[data-idx="${activeIdx}"]`
     )
     el?.scrollIntoView({ block: 'nearest' })
   }, [activeIdx, open])
@@ -3516,7 +3507,7 @@ function FontRow({
           style={{
             fontFamily: value
               ? `"${value}", ui-monospace, monospace`
-              : undefined,
+              : undefined
           }}
         >
           {value ?? 'Default'}
@@ -3567,7 +3558,7 @@ function FontRow({
                     ? 'bg-paper-200 text-ink-900'
                     : value === null
                       ? 'text-ink-900'
-                      : 'text-ink-700',
+                      : 'text-ink-700'
                 ].join(' ')}
               >
                 Default
@@ -3595,7 +3586,7 @@ function FontRow({
                           ? 'bg-paper-200 text-ink-900'
                           : value === f
                             ? 'text-ink-900'
-                            : 'text-ink-800',
+                            : 'text-ink-800'
                       ].join(' ')}
                       style={{ fontFamily: `"${f}", ui-monospace, monospace` }}
                     >
@@ -3606,7 +3597,7 @@ function FontRow({
               )}
             </div>
           </div>,
-          document.body,
+          document.body
         )}
     </div>
   )
@@ -3622,7 +3613,7 @@ function SliderRow({
   unit,
   format,
   settingId,
-  onChange,
+  onChange
 }: {
   label: string
   description?: string
@@ -3678,7 +3669,7 @@ function NumberRow({
   unit,
   format,
   settingId,
-  onChange,
+  onChange
 }: {
   label: string
   description?: string
@@ -3732,7 +3723,7 @@ function ToggleRow({
   description,
   value,
   settingId,
-  onChange,
+  onChange
 }: {
   label: string
   description?: string
@@ -3760,13 +3751,13 @@ function ToggleRow({
         onClick={() => onChange(!value)}
         className={[
           'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors',
-          value ? 'bg-accent' : 'bg-paper-300',
+          value ? 'bg-accent' : 'bg-paper-300'
         ].join(' ')}
       >
         <span
           className={[
             'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-            value ? 'translate-x-4' : 'translate-x-0.5',
+            value ? 'translate-x-4' : 'translate-x-0.5'
           ].join(' ')}
         />
       </button>
@@ -3780,7 +3771,7 @@ function SegmentedRow<T extends string>({
   value,
   options,
   settingId,
-  onChange,
+  onChange
 }: {
   label: string
   description?: string
@@ -3812,7 +3803,7 @@ function SegmentedRow<T extends string>({
               'rounded-lg px-3 py-1.5 text-xs transition-colors',
               value === option.value
                 ? 'bg-paper-50 text-ink-900 shadow-sm'
-                : 'text-ink-600 hover:text-ink-900',
+                : 'text-ink-600 hover:text-ink-900'
             ].join(' ')}
           >
             {option.label}
@@ -3927,7 +3918,7 @@ function CliSettings(): JSX.Element {
                 <span
                   className={[
                     'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                    statusChipClass(chip.tone),
+                    statusChipClass(chip.tone)
                   ].join(' ')}
                 >
                   {chip.label}
@@ -3982,7 +3973,7 @@ function CliSettings(): JSX.Element {
                     'rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors',
                     busy || (installed && !ours)
                       ? 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-                      : 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200',
+                      : 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200'
                   ].join(' ')}
                 >
                   {busy ? 'Working…' : 'Uninstall'}
@@ -4051,7 +4042,7 @@ function CliSettings(): JSX.Element {
 
 function RaycastExtensionSettings({
   cliInstalled,
-  copyToClipboard,
+  copyToClipboard
 }: {
   cliInstalled: boolean
   copyToClipboard: (text: string) => void
@@ -4112,7 +4103,7 @@ function RaycastExtensionSettings({
   const toolchainDetail = [
     `Raycast ${status.raycastInstalled ? 'found' : 'missing'}`,
     `Node ${status.nodeVersion ?? 'missing'}`,
-    `npm ${status.npmVersion ?? 'missing'}`,
+    `npm ${status.npmVersion ?? 'missing'}`
   ].join(' · ')
 
   return (
@@ -4131,7 +4122,7 @@ function RaycastExtensionSettings({
               <span
                 className={[
                   'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                  statusChipClass(chip.tone),
+                  statusChipClass(chip.tone)
                 ].join(' ')}
               >
                 {chip.label}
@@ -4192,7 +4183,7 @@ function RaycastExtensionSettings({
 
 function raycastStatusChip(
   status: RaycastExtensionStatus,
-  cliInstalled: boolean,
+  cliInstalled: boolean
 ): { label: string; tone: 'ok' | 'warn' | 'off' } {
   if (!status.supportedPlatform) return { label: 'Not supported', tone: 'off' }
   if (status.installed && status.upToDate)
@@ -4205,7 +4196,7 @@ function raycastStatusChip(
 
 function raycastStatusDetail(
   status: RaycastExtensionStatus,
-  cliInstalled: boolean,
+  cliInstalled: boolean
 ): string {
   if (!status.supportedPlatform) {
     return status.reason ?? 'Raycast extensions are available on macOS only.'
@@ -4236,7 +4227,7 @@ function McpSettings(): JSX.Element {
     try {
       const [s, r] = await Promise.all([
         window.zen.mcpGetStatuses(),
-        window.zen.mcpGetRuntime(),
+        window.zen.mcpGetRuntime()
       ])
       setStatuses(s)
       setRuntime(r)
@@ -4302,7 +4293,7 @@ function McpSettings(): JSX.Element {
               <span
                 className={[
                   'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                  serverStatusClass,
+                  serverStatusClass
                 ].join(' ')}
               >
                 {serverStatusLabel}
@@ -4463,7 +4454,7 @@ function McpInstructionsEditor(): JSX.Element {
                 'rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors',
                 payload != null && draft !== payload.defaultValue
                   ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
+                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
               ].join(' ')}
             >
               Reset to default
@@ -4476,7 +4467,7 @@ function McpInstructionsEditor(): JSX.Element {
                 'rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors',
                 dirty
                   ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
+                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
               ].join(' ')}
             >
               Revert
@@ -4528,7 +4519,7 @@ function McpClientRow({
   entryMissing,
   onInstall,
   onUninstall,
-  onCopyConfigPath,
+  onCopyConfigPath
 }: {
   title: string
   description: string
@@ -4554,7 +4545,7 @@ function McpClientRow({
             <span
               className={[
                 'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                statusChipClass(chip.tone),
+                statusChipClass(chip.tone)
               ].join(' ')}
             >
               {chip.label}
@@ -4581,7 +4572,7 @@ function McpClientRow({
                     'rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors',
                     busy || entryMissing
                       ? 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-                      : 'border-accent/30 bg-accent/15 text-accent hover:bg-accent/25',
+                      : 'border-accent/30 bg-accent/15 text-accent hover:bg-accent/25'
                   ].join(' ')}
                 >
                   Update
@@ -4595,7 +4586,7 @@ function McpClientRow({
                   'rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors',
                   busy
                     ? 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-                    : 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200',
+                    : 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200'
                 ].join(' ')}
               >
                 Uninstall

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -1,16 +1,6 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import {
-  DEFAULT_DAILY_NOTES_DIRECTORY,
-  DEFAULT_WEEKLY_NOTES_DIRECTORY
-} from '@shared/ipc'
+import { DEFAULT_DAILY_NOTES_DIRECTORY, DEFAULT_WEEKLY_NOTES_DIRECTORY } from '@shared/ipc'
 import type {
   AppUpdateState,
   CliInstallStatus,
@@ -30,11 +20,7 @@ import {
 } from '@shared/mcp-clients'
 import { useStore } from '../store'
 import type { LineNumberMode, WhichKeyHintMode } from '../store'
-import type {
-  KeymapDefinition,
-  KeymapId,
-  KeymapOverrides
-} from '../lib/keymaps'
+import type { KeymapDefinition, KeymapId, KeymapOverrides } from '../lib/keymaps'
 import {
   findConflictingKeymaps,
   formatKeymapBinding,
@@ -47,29 +33,15 @@ import {
   shortcutBindingFromEvent
 } from '../lib/keymaps'
 import { diagnoseVimMappings, toVimSequence } from '../lib/vim-mappings'
-import {
-  resolveAuto,
-  THEMES,
-  type ThemeFamily,
-  type ThemeMode
-} from '../lib/themes'
+import { resolveAuto, THEMES, type ThemeFamily, type ThemeMode } from '../lib/themes'
 import { hasSystemFontAccess, listSystemFonts } from '../lib/system-fonts'
-import {
-  DEFAULT_SYSTEM_FOLDER_LABELS,
-  getSystemFolderLabel
-} from '../lib/system-folder-labels'
-import {
-  normalizeDailyNotesDirectory,
-  normalizeWeeklyNotesDirectory
-} from '../lib/vault-layout'
+import { DEFAULT_SYSTEM_FOLDER_LABELS, getSystemFolderLabel } from '../lib/system-folder-labels'
+import { normalizeDailyNotesDirectory, normalizeWeeklyNotesDirectory } from '../lib/vault-layout'
 import { BUILTIN_TEMPLATES } from '@shared/builtin-templates'
 import { composeTemplateFile, mergeTemplates } from '@shared/template-files'
 import { TemplateEditorModal } from './TemplateEditorModal'
 import type { NoteTemplate } from '@bridge-contract/templates'
-import {
-  getSettingsSearchResults,
-  type SettingsSearchCategory
-} from '../lib/settings-search'
+import { getSettingsSearchResults, type SettingsSearchCategory } from '../lib/settings-search'
 import { useAppUpdateState } from '../lib/app-update-state'
 import { getZenBridge } from '@zennotes/bridge-contract/bridge'
 import companyLogo from '../assets/lumary-labs-logo.svg'
@@ -104,13 +76,8 @@ function settingsSearchTargetProps(settingId: string | undefined): {
   return settingId ? { 'data-settings-search-id': settingId } : {}
 }
 
-function findSettingsSearchTarget(
-  root: HTMLElement,
-  targetId: string
-): HTMLElement | null {
-  for (const element of root.querySelectorAll<HTMLElement>(
-    '[data-settings-search-id]'
-  )) {
+function findSettingsSearchTarget(root: HTMLElement, targetId: string): HTMLElement | null {
+  for (const element of root.querySelectorAll<HTMLElement>('[data-settings-search-id]')) {
     if (element.dataset.settingsSearchId === targetId) return element
   }
   return null
@@ -130,8 +97,7 @@ function resolveVaultTextSearchBackend(
 ): ResolvedVaultTextSearchBackend | null {
   if (!capabilities) return null
   if (preferred === 'builtin') return 'builtin'
-  if (preferred === 'ripgrep')
-    return capabilities.ripgrep ? 'ripgrep' : 'builtin'
+  if (preferred === 'ripgrep') return capabilities.ripgrep ? 'ripgrep' : 'builtin'
   if (preferred === 'fzf') return capabilities.fzf ? 'fzf' : 'builtin'
   if (capabilities.fzf) return 'fzf'
   if (capabilities.ripgrep) return 'ripgrep'
@@ -199,11 +165,7 @@ function formatBytes(bytes: number | null): string | null {
     unit = units[i]
   }
   const rounded =
-    value >= 100
-      ? value.toFixed(0)
-      : value >= 10
-        ? value.toFixed(1)
-        : value.toFixed(2)
+    value >= 100 ? value.toFixed(0) : value >= 10 ? value.toFixed(1) : value.toFixed(2)
   return `${rounded} ${unit}`
 }
 
@@ -229,8 +191,7 @@ function formatReleaseNotesForDisplay(notes: string | null): string | null {
 
 function statusChipClass(tone: 'ok' | 'warn' | 'off'): string {
   if (tone === 'ok') return 'border-accent/25 bg-accent/10 text-accent'
-  if (tone === 'warn')
-    return 'border-amber-500/30 bg-amber-500/10 text-amber-500'
+  if (tone === 'warn') return 'border-amber-500/30 bg-amber-500/10 text-amber-500'
   return 'border-paper-300/70 bg-paper-100/85 text-ink-500'
 }
 
@@ -238,8 +199,7 @@ export function SettingsModal(): JSX.Element {
   const zenBridge = getZenBridge()
   const appInfo = zenBridge.getAppInfo()
   const supportsRemoteWorkspace =
-    appInfo.runtime === 'desktop' &&
-    zenBridge.getCapabilities().supportsRemoteWorkspace
+    appInfo.runtime === 'desktop' && zenBridge.getCapabilities().supportsRemoteWorkspace
   const setSettingsOpen = useStore((s) => s.setSettingsOpen)
   const vimMode = useStore((s) => s.vimMode)
   const setVimMode = useStore((s) => s.setVimMode)
@@ -288,19 +248,11 @@ export function SettingsModal(): JSX.Element {
   const persistVaultSettings = useStore((s) => s.setVaultSettings)
   const openVaultPicker = useStore((s) => s.openVaultPicker)
   const connectRemoteWorkspace = useStore((s) => s.connectRemoteWorkspace)
-  const connectRemoteWorkspaceProfile = useStore(
-    (s) => s.connectRemoteWorkspaceProfile
-  )
-  const changeRemoteWorkspaceVaultPath = useStore(
-    (s) => s.changeRemoteWorkspaceVaultPath
-  )
+  const connectRemoteWorkspaceProfile = useStore((s) => s.connectRemoteWorkspaceProfile)
+  const changeRemoteWorkspaceVaultPath = useStore((s) => s.changeRemoteWorkspaceVaultPath)
   const disconnectRemoteWorkspace = useStore((s) => s.disconnectRemoteWorkspace)
-  const saveRemoteWorkspaceProfile = useStore(
-    (s) => s.saveRemoteWorkspaceProfile
-  )
-  const deleteRemoteWorkspaceProfile = useStore(
-    (s) => s.deleteRemoteWorkspaceProfile
-  )
+  const saveRemoteWorkspaceProfile = useStore((s) => s.saveRemoteWorkspaceProfile)
+  const deleteRemoteWorkspaceProfile = useStore((s) => s.deleteRemoteWorkspaceProfile)
   const openTodayDailyNote = useStore((s) => s.openTodayDailyNote)
   const openThisWeekWeeklyNote = useStore((s) => s.openThisWeekWeeklyNote)
   const autoCalendarPanel = useStore((s) => s.autoCalendarPanel)
@@ -308,24 +260,17 @@ export function SettingsModal(): JSX.Element {
   const calendarWeekStart = useStore((s) => s.calendarWeekStart)
   const setCalendarWeekStart = useStore((s) => s.setCalendarWeekStart)
   const calendarShowWeekNumbers = useStore((s) => s.calendarShowWeekNumbers)
-  const setCalendarShowWeekNumbers = useStore(
-    (s) => s.setCalendarShowWeekNumbers
-  )
+  const setCalendarShowWeekNumbers = useStore((s) => s.setCalendarShowWeekNumbers)
   const customTemplates = useStore((s) => s.customTemplates)
   const deleteCustomTemplate = useStore((s) => s.deleteCustomTemplate)
   const hideBuiltinTemplates = useStore((s) => s.hideBuiltinTemplates)
   const setHideBuiltinTemplates = useStore((s) => s.setHideBuiltinTemplates)
   const allTemplates = useMemo(
-    () =>
-      mergeTemplates(
-        hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES,
-        customTemplates
-      ),
+    () => mergeTemplates(hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES, customTemplates),
     [customTemplates, hideBuiltinTemplates]
   )
   const supportsCustomTemplates =
-    zenBridge.getCapabilities().supportsCustomTemplates &&
-    workspaceMode !== 'remote'
+    zenBridge.getCapabilities().supportsCustomTemplates && workspaceMode !== 'remote'
   const [templateEditor, setTemplateEditor] = useState<{
     initialRaw?: string
     sourcePath?: string
@@ -452,8 +397,7 @@ export function SettingsModal(): JSX.Element {
         if (!cancelled) setVaultTextSearchCapabilities(capabilities)
       },
       () => {
-        if (!cancelled)
-          setVaultTextSearchCapabilities({ ripgrep: false, fzf: false })
+        if (!cancelled) setVaultTextSearchCapabilities({ ripgrep: false, fzf: false })
       }
     )
     return () => {
@@ -479,10 +423,7 @@ export function SettingsModal(): JSX.Element {
         }
       },
       (error) => {
-        const message =
-          error instanceof Error
-            ? error.message
-            : 'Could not check for updates.'
+        const message = error instanceof Error ? error.message : 'Could not check for updates.'
         window.alert(message)
       }
     )
@@ -512,21 +453,18 @@ export function SettingsModal(): JSX.Element {
     })
   }, [remoteWorkspaceInfo?.baseUrl, vault?.root, workspaceMode])
 
-  const openEditRemoteProfile = useCallback(
-    (profile: RemoteWorkspaceProfile) => {
-      setEditingRemoteProfile({
-        mode: 'edit',
-        value: {
-          id: profile.id,
-          name: profile.name,
-          baseUrl: profile.baseUrl,
-          vaultPath: profile.vaultPath
-        },
-        hasStoredCredential: profile.hasCredential
-      })
-    },
-    []
-  )
+  const openEditRemoteProfile = useCallback((profile: RemoteWorkspaceProfile) => {
+    setEditingRemoteProfile({
+      mode: 'edit',
+      value: {
+        id: profile.id,
+        name: profile.name,
+        baseUrl: profile.baseUrl,
+        vaultPath: profile.vaultPath
+      },
+      hasStoredCredential: profile.hasCredential
+    })
+  }, [])
 
   const submitRemoteProfile = useCallback(
     async (input: RemoteWorkspaceProfileInput) => {
@@ -609,18 +547,13 @@ export function SettingsModal(): JSX.Element {
    *  mode this is whatever `resolveAuto` produced, since the stored
    *  themeId may not match what's painted on screen. */
   const renderedThemeId = useMemo(
-    () =>
-      themeMode === 'auto'
-        ? resolveAuto(themeFamily, prefersDark, themeId)
-        : themeId,
+    () => (themeMode === 'auto' ? resolveAuto(themeFamily, prefersDark, themeId) : themeId),
     [themeId, themeFamily, themeMode, prefersDark]
   )
 
   const visibleVariants = useMemo(() => {
     if (themeFamily === 'gruvbox') {
-      return THEMES.filter(
-        (t) => t.family === 'gruvbox' && t.mode === effectiveMode
-      )
+      return THEMES.filter((t) => t.family === 'gruvbox' && t.mode === effectiveMode)
     }
     // Families with only a light/dark pair don't need a variant picker —
     // the Mode selector above already handles the toggle.
@@ -665,10 +598,7 @@ export function SettingsModal(): JSX.Element {
     const currentVariant = THEMES.find((t) => t.id === themeId)?.variant
     const candidate =
       THEMES.find(
-        (t) =>
-          t.family === themeFamily &&
-          t.mode === mode &&
-          t.variant === currentVariant
+        (t) => t.family === themeFamily && t.mode === mode && t.variant === currentVariant
       ) ?? THEMES.find((t) => t.family === themeFamily && t.mode === mode)
     if (candidate) setTheme({ id: candidate.id, family: themeFamily, mode })
   }
@@ -687,22 +617,15 @@ export function SettingsModal(): JSX.Element {
 
   const ref = useRef<HTMLDivElement | null>(null)
   const settingsSearchHighlightTimerRef = useRef<number | null>(null)
-  const [activeCategory, setActiveCategory] =
-    useState<SettingsCategoryId>('appearance')
-  const [activeSearchResultId, setActiveSearchResultId] = useState<
-    string | null
-  >(null)
+  const [activeCategory, setActiveCategory] = useState<SettingsCategoryId>('appearance')
+  const [activeSearchResultId, setActiveSearchResultId] = useState<string | null>(null)
   const [navQuery, setNavQuery] = useState('')
   const availableVaultTextSearchTools = [
     vaultTextSearchCapabilities?.ripgrep ? 'ripgrep' : null,
     vaultTextSearchCapabilities?.fzf ? 'fzf' : null
   ].filter((value): value is string => !!value)
   const resolvedVaultTextSearchBackend = useMemo(
-    () =>
-      resolveVaultTextSearchBackend(
-        vaultTextSearchBackend,
-        vaultTextSearchCapabilities
-      ),
+    () => resolveVaultTextSearchBackend(vaultTextSearchBackend, vaultTextSearchCapabilities),
     [vaultTextSearchBackend, vaultTextSearchCapabilities]
   )
   const resolvedVaultTextSearchMessage = useMemo(() => {
@@ -829,17 +752,13 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'sidebar-arrows',
           title: 'Sidebar arrows',
-          description:
-            'Show disclosure arrows for collapsible folders and sidebar sections.',
+          description: 'Show disclosure arrows for collapsible folders and sidebar sections.',
           keywords: ['chevrons', 'disclosure']
         }
       ],
       content: (
         <div className="space-y-6">
-          <Section
-            title="Theme"
-            description="Pick the visual system ZenNotes uses across the app."
-          >
+          <Section title="Theme" description="Pick the visual system ZenNotes uses across the app.">
             <div className="flex flex-col gap-5 px-5 py-5">
               <div {...settingsSearchTargetProps('theme-family')}>
                 <div className="mb-2 text-xs font-medium uppercase tracking-[0.18em] text-ink-500">
@@ -940,8 +859,7 @@ export function SettingsModal(): JSX.Element {
     {
       id: 'editor',
       title: 'Editor',
-      description:
-        'Vim, leader hints, live preview, tabs, and writing behavior.',
+      description: 'Vim, leader hints, live preview, tabs, and writing behavior.',
       keywords: [
         'vim',
         'leader',
@@ -966,8 +884,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'vim-insert-escape',
           title: 'Exit insert mode with',
-          description:
-            'Map a key sequence like jk or jj to Escape in insert mode.',
+          description: 'Map a key sequence like jk or jj to Escape in insert mode.',
           keywords: ['vim', 'jk', 'jj', 'escape', 'insert mode', 'esc']
         },
         {
@@ -1022,8 +939,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'note-tabs',
           title: 'Note tabs',
-          description:
-            'Open notes in tabs and allow split-friendly tab workflows.',
+          description: 'Open notes in tabs and allow split-friendly tab workflows.',
           keywords: ['tabs']
         },
         {
@@ -1043,8 +959,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'smooth-preview-scroll',
           title: 'Smooth preview scroll',
-          description:
-            'Animate Ctrl+D / Ctrl+U half-page jumps in preview mode.',
+          description: 'Animate Ctrl+D / Ctrl+U half-page jumps in preview mode.',
           keywords: ['preview', 'scroll']
         },
         {
@@ -1057,8 +972,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'date-titled-quick-notes',
           title: 'Date-titled Quick Notes',
-          description:
-            'New Quick Notes use YYYY-MM-DD instead of timestamp-style titles.',
+          description: 'New Quick Notes use YYYY-MM-DD instead of timestamp-style titles.',
           keywords: ['quick note', 'date', 'title']
         },
         {
@@ -1070,17 +984,13 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'quick-capture-hotkey',
           title: 'Quick capture hotkey',
-          description:
-            'System-wide shortcut to open the floating capture window.',
+          description: 'System-wide shortcut to open the floating capture window.',
           keywords: ['quick capture', 'hotkey', 'shortcut']
         }
       ],
       content: (
         <div className="space-y-6">
-          <Section
-            title="Vim"
-            description="Keyboard-first editing behavior and leader guidance."
-          >
+          <Section title="Vim" description="Keyboard-first editing behavior and leader guidance.">
             <ToggleRow
               label="Vim mode"
               description="First-class Vim motions in the markdown editor."
@@ -1116,9 +1026,7 @@ export function SettingsModal(): JSX.Element {
                         { value: 'timed', label: 'Timed' },
                         { value: 'sticky', label: 'Sticky' }
                       ]}
-                      onChange={(next) =>
-                        setWhichKeyHintMode(next as WhichKeyHintMode)
-                      }
+                      onChange={(next) => setWhichKeyHintMode(next as WhichKeyHintMode)}
                     />
                     {whichKeyHintMode === 'timed' && (
                       <SliderRow
@@ -1143,10 +1051,7 @@ export function SettingsModal(): JSX.Element {
             )}
           </Section>
 
-          <Section
-            title="Search"
-            description="Choose how vault-wide text search is powered."
-          >
+          <Section title="Search" description="Choose how vault-wide text search is powered.">
             <SegmentedRow
               label="Vault text search backend"
               description="Auto prefers fzf when available, then ripgrep, and falls back to the built-in searcher."
@@ -1159,9 +1064,7 @@ export function SettingsModal(): JSX.Element {
                 { value: 'fzf', label: 'fzf' }
               ]}
               onChange={(next) =>
-                setVaultTextSearchBackend(
-                  next as VaultTextSearchBackendPreference
-                )
+                setVaultTextSearchBackend(next as VaultTextSearchBackendPreference)
               }
             />
             <TextInputRow
@@ -1181,10 +1084,7 @@ export function SettingsModal(): JSX.Element {
               onChange={(next) => setFzfBinaryPath(next)}
             />
             <InlineNote>
-              Runtime backend:{' '}
-              {resolvedVaultTextSearchBackendLabel(
-                resolvedVaultTextSearchBackend
-              )}
+              Runtime backend: {resolvedVaultTextSearchBackendLabel(resolvedVaultTextSearchBackend)}
             </InlineNote>
             <InlineNote>{resolvedVaultTextSearchMessage}</InlineNote>
             <InlineNote>
@@ -1281,23 +1181,12 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'shortcut-editor',
           title: 'Shortcut editor',
-          description:
-            'Record a new key or sequence for the app’s keyboard-first actions.',
-          keywords: [
-            'shortcuts',
-            'bindings',
-            'leader',
-            'vim',
-            'remap',
-            'keyboard'
-          ]
+          description: 'Record a new key or sequence for the app’s keyboard-first actions.',
+          keywords: ['shortcuts', 'bindings', 'leader', 'vim', 'remap', 'keyboard']
         }
       ],
       content: (
-        <div
-          className="h-full"
-          {...settingsSearchTargetProps('shortcut-editor')}
-        >
+        <div className="h-full" {...settingsSearchTargetProps('shortcut-editor')}>
           <KeymapSettings
             vimMode={vimMode}
             overrides={keymapOverrides}
@@ -1310,16 +1199,8 @@ export function SettingsModal(): JSX.Element {
     {
       id: 'typography',
       title: 'Typography',
-      description:
-        'Fonts, line height, reading width, alignment, and line numbers.',
-      keywords: [
-        'font',
-        'size',
-        'line height',
-        'width',
-        'alignment',
-        'numbers'
-      ],
+      description: 'Fonts, line height, reading width, alignment, and line numbers.',
+      keywords: ['font', 'size', 'line height', 'width', 'alignment', 'numbers'],
       searchItems: [
         {
           id: 'interface-font',
@@ -1367,8 +1248,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'content-alignment',
           title: 'Content alignment',
-          description:
-            'Center note content within the column or left-align it to the pane edge.',
+          description: 'Center note content within the column or left-align it to the pane edge.',
           keywords: ['alignment', 'center', 'left']
         },
         {
@@ -1410,10 +1290,7 @@ export function SettingsModal(): JSX.Element {
             />
           </Section>
 
-          <Section
-            title="Layout"
-            description="Tune reading density and how notes sit in the pane."
-          >
+          <Section title="Layout" description="Tune reading density and how notes sit in the pane.">
             <SliderRow
               label="Font size"
               description="Editor and preview text size."
@@ -1494,15 +1371,13 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'vault-location',
           title: 'Vault location',
-          description:
-            'ZenNotes reads markdown directly from the selected vault folder.',
+          description: 'ZenNotes reads markdown directly from the selected vault folder.',
           keywords: ['folder', 'root', 'location', 'open vault', 'change']
         },
         {
           id: 'saved-remote-workspaces',
           title: 'Saved Remote Workspaces',
-          description:
-            'Keep multiple ZenNotes servers and vaults ready to reconnect.',
+          description: 'Keep multiple ZenNotes servers and vaults ready to reconnect.',
           keywords: ['remote', 'server', 'workspace', 'connect'],
           available: supportsRemoteWorkspace
         },
@@ -1541,8 +1416,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'enable-weekly-notes',
           title: 'Enable weekly notes',
-          description:
-            'Adds a dedicated weekly-notes workflow alongside daily notes.',
+          description: 'Adds a dedicated weekly-notes workflow alongside daily notes.',
           keywords: ['weekly notes']
         },
         {
@@ -1560,8 +1434,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'open-this-week-note',
           title: "Open this week's note",
-          description:
-            "Opens this week's note if it exists, otherwise creates it.",
+          description: "Opens this week's note if it exists, otherwise creates it.",
           keywords: ['weekly notes', 'this week']
         },
         {
@@ -1569,13 +1442,7 @@ export function SettingsModal(): JSX.Element {
           title: 'Show calendar in daily & weekly notes',
           description:
             'Auto-open a calendar panel on the right while viewing a daily or weekly note.',
-          keywords: [
-            'calendar',
-            'daily notes',
-            'weekly notes',
-            'date',
-            'navigate'
-          ]
+          keywords: ['calendar', 'daily notes', 'weekly notes', 'date', 'navigate']
         },
         {
           id: 'calendar-week-start',
@@ -1592,8 +1459,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'inbox-label',
           title: 'Inbox label',
-          description:
-            'Shown in the sidebar, breadcrumbs, commands, and note actions.',
+          description: 'Shown in the sidebar, breadcrumbs, commands, and note actions.',
           keywords: ['system folders', 'folder label']
         },
         {
@@ -1627,9 +1493,7 @@ export function SettingsModal(): JSX.Element {
             >
               <div className="min-w-0">
                 <div className="text-sm font-medium text-ink-900">
-                  {workspaceMode === 'remote'
-                    ? 'Remote workspace'
-                    : 'Vault location'}
+                  {workspaceMode === 'remote' ? 'Remote workspace' : 'Vault location'}
                 </div>
                 <div className="mt-1 truncate text-xs text-ink-500">
                   {vault?.root ?? 'No vault selected'}
@@ -1648,9 +1512,7 @@ export function SettingsModal(): JSX.Element {
                 }
                 className="shrink-0 rounded-xl border border-paper-300/70 bg-paper-100/80 px-3.5 py-2 text-xs font-medium text-ink-800 transition-colors hover:bg-paper-200"
               >
-                {workspaceMode === 'remote'
-                  ? 'Change Remote Vault…'
-                  : 'Change…'}
+                {workspaceMode === 'remote' ? 'Change Remote Vault…' : 'Change…'}
               </button>
               {workspaceMode === 'remote' && (
                 <button
@@ -1688,8 +1550,8 @@ export function SettingsModal(): JSX.Element {
               <div className="space-y-3 px-5 py-5">
                 <div className="flex items-center justify-between gap-4">
                   <div className="text-xs text-ink-500">
-                    Saved connections can point at different servers or
-                    different vaults on the same server.
+                    Saved connections can point at different servers or different vaults on the same
+                    server.
                   </div>
                   <button
                     type="button"
@@ -1702,10 +1564,8 @@ export function SettingsModal(): JSX.Element {
                 {remoteWorkspaceProfiles.length === 0 ? (
                   <div className="rounded-xl border border-paper-300/60 bg-paper-50/60 px-4 py-4 text-sm text-ink-500">
                     No saved remote workspaces yet. Use{' '}
-                    <span className="font-medium text-ink-700">
-                      Quick Connect…
-                    </span>{' '}
-                    once and ZenNotes will remember it here.
+                    <span className="font-medium text-ink-700">Quick Connect…</span> once and
+                    ZenNotes will remember it here.
                   </div>
                 ) : (
                   <div className="space-y-3">
@@ -1740,9 +1600,7 @@ export function SettingsModal(): JSX.Element {
                             {!isCurrent && (
                               <button
                                 type="button"
-                                onClick={() =>
-                                  void connectRemoteWorkspaceProfile(profile.id)
-                                }
+                                onClick={() => void connectRemoteWorkspaceProfile(profile.id)}
                                 className="rounded-xl border border-paper-300/70 bg-paper-100/80 px-3 py-2 text-xs font-medium text-ink-800 transition-colors hover:bg-paper-200"
                               >
                                 Connect
@@ -1847,12 +1705,9 @@ export function SettingsModal(): JSX.Element {
               {...settingsSearchTargetProps('open-todays-daily-note')}
             >
               <div className="min-w-0">
-                <div className="text-sm font-medium text-ink-900">
-                  Open today's daily note
-                </div>
+                <div className="text-sm font-medium text-ink-900">Open today's daily note</div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
-                  Opens today's note if it exists, otherwise creates it with a
-                  YYYY-MM-DD title.
+                  Opens today's note if it exists, otherwise creates it with a YYYY-MM-DD title.
                 </div>
               </div>
               <button
@@ -1924,12 +1779,9 @@ export function SettingsModal(): JSX.Element {
               {...settingsSearchTargetProps('open-this-week-note')}
             >
               <div className="min-w-0">
-                <div className="text-sm font-medium text-ink-900">
-                  Open this week's note
-                </div>
+                <div className="text-sm font-medium text-ink-900">Open this week's note</div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
-                  Opens this week's note if it exists, otherwise creates it with
-                  a YYYY-Www title.
+                  Opens this week's note if it exists, otherwise creates it with a YYYY-Www title.
                 </div>
               </div>
               <button
@@ -2011,8 +1863,7 @@ export function SettingsModal(): JSX.Element {
               onChange={(next) => setSystemFolderLabel('trash', next)}
             />
             <InlineNote>
-              Current labels:{' '}
-              {getSystemFolderLabel('quick', systemFolderLabels)},{' '}
+              Current labels: {getSystemFolderLabel('quick', systemFolderLabels)},{' '}
               {getSystemFolderLabel('inbox', systemFolderLabels)},{' '}
               {getSystemFolderLabel('archive', systemFolderLabels)}, and{' '}
               {getSystemFolderLabel('trash', systemFolderLabels)}.
@@ -2067,9 +1918,7 @@ export function SettingsModal(): JSX.Element {
                 {...settingsSearchTargetProps('templates-new')}
               >
                 <div className="min-w-0">
-                  <div className="text-sm font-medium text-ink-900">
-                    Create a custom template
-                  </div>
+                  <div className="text-sm font-medium text-ink-900">Create a custom template</div>
                   <div className="mt-1 text-xs leading-5 text-ink-500">
                     Stored as a markdown file in `.zennotes/templates`.
                   </div>
@@ -2085,16 +1934,13 @@ export function SettingsModal(): JSX.Element {
               </div>
             ) : (
               <InlineNote>
-                Custom templates require a local vault. Built-in templates still
-                work here.
+                Custom templates require a local vault. Built-in templates still work here.
               </InlineNote>
             )}
             <div className="flex items-center justify-between gap-4 border-t border-paper-300/40 px-5 py-4">
               <div className="min-w-0">
                 <div className="text-sm font-medium text-ink-900">
-                  {hideBuiltinTemplates
-                    ? 'Built-in templates are hidden'
-                    : 'Built-in templates'}
+                  {hideBuiltinTemplates ? 'Built-in templates are hidden' : 'Built-in templates'}
                 </div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
                   {hideBuiltinTemplates
@@ -2108,20 +1954,13 @@ export function SettingsModal(): JSX.Element {
                 onClick={() => void toggleBuiltinTemplates()}
                 className="shrink-0"
               >
-                {hideBuiltinTemplates
-                  ? 'Restore built-in templates'
-                  : 'Remove built-in templates'}
+                {hideBuiltinTemplates ? 'Restore built-in templates' : 'Remove built-in templates'}
               </Button>
             </div>
             {allTemplates.map((template) => (
-              <div
-                key={template.id}
-                className="flex items-center justify-between gap-4 px-5 py-3"
-              >
+              <div key={template.id} className="flex items-center justify-between gap-4 px-5 py-3">
                 <div className="min-w-0">
-                  <div className="text-sm font-medium text-ink-900">
-                    {template.name}
-                  </div>
+                  <div className="text-sm font-medium text-ink-900">{template.name}</div>
                   <div className="mt-0.5 truncate text-xs text-ink-500">
                     {template.category}
                     {template.description ? ` — ${template.description}` : ''}
@@ -2194,8 +2033,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'mcp-server',
           title: 'MCP server',
-          description:
-            'ZenNotes bundles a local MCP server that connected clients use.',
+          description: 'ZenNotes bundles a local MCP server that connected clients use.',
           keywords: ['mcp', 'server', 'runtime', 'command']
         },
         {
@@ -2207,8 +2045,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'mcp-instructions',
           title: 'MCP instructions',
-          description:
-            'Edit the system prompt ZenNotes ships to any connected MCP client.',
+          description: 'Edit the system prompt ZenNotes ships to any connected MCP client.',
           keywords: ['mcp', 'prompt', 'instructions', 'system prompt']
         }
       ],
@@ -2237,17 +2074,8 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'zen-command-line-tool',
           title: 'zen command-line tool',
-          description:
-            'Install the `zen` shell command for terminal-based note workflows.',
-          keywords: [
-            'cli',
-            'command line',
-            'terminal',
-            'shell',
-            'zen',
-            'install',
-            'path'
-          ]
+          description: 'Install the `zen` shell command for terminal-based note workflows.',
+          keywords: ['cli', 'command line', 'terminal', 'shell', 'zen', 'install', 'path']
         },
         {
           id: 'cli-quick-reference',
@@ -2258,8 +2086,7 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'raycast-extension',
           title: 'Raycast Extension',
-          description:
-            'Install the ZenNotes Raycast extension locally from this app.',
+          description: 'Install the ZenNotes Raycast extension locally from this app.',
           keywords: ['raycast', 'launcher', 'extension', 'install']
         }
       ],
@@ -2268,8 +2095,7 @@ export function SettingsModal(): JSX.Element {
     {
       id: 'about',
       title: 'About',
-      description:
-        'App identity, version, updater status, and company information.',
+      description: 'App identity, version, updater status, and company information.',
       keywords: ['version', 'company', 'lumary', 'about', 'logo', 'updates'],
       searchItems: [
         {
@@ -2315,9 +2141,7 @@ export function SettingsModal(): JSX.Element {
                           updatePhaseBadgeClass(appUpdateState?.phase ?? 'idle')
                         ].join(' ')}
                       >
-                        {formatUpdatePhaseLabel(
-                          appUpdateState?.phase ?? 'idle'
-                        )}
+                        {formatUpdatePhaseLabel(appUpdateState?.phase ?? 'idle')}
                       </span>
                       {appUpdateState?.availableVersion && (
                         <span className="text-xs text-ink-500">
@@ -2361,8 +2185,7 @@ export function SettingsModal(): JSX.Element {
                     )}
                     <a
                       href={
-                        appInfo.homepage ??
-                        'https://github.com/ZenNotes/zennotes/releases/latest'
+                        appInfo.homepage ?? 'https://github.com/ZenNotes/zennotes/releases/latest'
                       }
                       target="_blank"
                       rel="noreferrer"
@@ -2373,8 +2196,7 @@ export function SettingsModal(): JSX.Element {
                   </div>
                 </div>
                 <p className="mt-3 text-sm leading-6 text-ink-600">
-                  {appUpdateState?.message ??
-                    'Check GitHub releases for a newer ZenNotes build.'}
+                  {appUpdateState?.message ?? 'Check GitHub releases for a newer ZenNotes build.'}
                 </p>
                 {appUpdateState?.phase === 'downloading' && (
                   <div className="mt-3">
@@ -2387,9 +2209,7 @@ export function SettingsModal(): JSX.Element {
                       />
                     </div>
                     <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-500">
-                      <span>
-                        {Math.round(appUpdateState.progressPercent ?? 0)}%
-                      </span>
+                      <span>{Math.round(appUpdateState.progressPercent ?? 0)}%</span>
                       {formatBytes(appUpdateState.transferredBytes) &&
                         formatBytes(appUpdateState.totalBytes) && (
                           <span>
@@ -2398,9 +2218,7 @@ export function SettingsModal(): JSX.Element {
                           </span>
                         )}
                       {formatBytes(appUpdateState.bytesPerSecond) && (
-                        <span>
-                          {formatBytes(appUpdateState.bytesPerSecond)}/s
-                        </span>
+                        <span>{formatBytes(appUpdateState.bytesPerSecond)}/s</span>
                       )}
                     </div>
                   </div>
@@ -2416,8 +2234,8 @@ export function SettingsModal(): JSX.Element {
                   </details>
                 )}
                 <div className="mt-3 text-xs leading-5 text-ink-500">
-                  In-app updates use the published GitHub release feed. For
-                  general users, that feed must be publicly reachable.
+                  In-app updates use the published GitHub release feed. For general users, that feed
+                  must be publicly reachable.
                 </div>
               </div>
               <p className="mx-auto mt-2 max-w-[44rem] text-center">
@@ -2544,9 +2362,7 @@ export function SettingsModal(): JSX.Element {
                       ].join(' ')}
                     >
                       <div className="flex min-w-0 items-center justify-between gap-2">
-                        <div className="truncate text-sm font-medium">
-                          {result.title}
-                        </div>
+                        <div className="truncate text-sm font-medium">{result.title}</div>
                         {result.type === 'setting' && (
                           <span className="shrink-0 rounded-full border border-paper-300/60 bg-paper-100/70 px-2 py-0.5 text-2xs font-medium text-ink-500">
                             {result.category.title}
@@ -2601,8 +2417,8 @@ export function SettingsModal(): JSX.Element {
                 visibleCategory.content
               ) : (
                 <div className="flex h-full min-h-[280px] items-center justify-center rounded-3xl border border-dashed border-paper-300/70 bg-paper-50/35 px-6 text-center text-sm leading-6 text-ink-500">
-                  Try a broader search term, or clear the search field to browse
-                  every settings section.
+                  Try a broader search term, or clear the search field to browse every settings
+                  section.
                 </div>
               )}
             </div>
@@ -2622,10 +2438,7 @@ export function SettingsModal(): JSX.Element {
                 : 'Save a ZenNotes server so you can reconnect without re-entering the details.',
             initialValue: editingRemoteProfile.value,
             hasStoredCredential: editingRemoteProfile.hasStoredCredential,
-            submitLabel:
-              editingRemoteProfile.mode === 'edit'
-                ? 'Save Changes'
-                : 'Save Remote'
+            submitLabel: editingRemoteProfile.mode === 'edit' ? 'Save Changes' : 'Save Remote'
           }}
           onSubmit={submitRemoteProfile}
           onCancel={() => setEditingRemoteProfile(null)}
@@ -2658,15 +2471,10 @@ function KeymapSettings({
   const [query, setQuery] = useState('')
   const [recording, setRecording] = useState<KeymapDefinition | null>(null)
 
-  const keymapDiagnostics = useMemo(
-    () => findConflictingKeymaps(overrides),
-    [overrides]
-  )
+  const keymapDiagnostics = useMemo(() => findConflictingKeymaps(overrides), [overrides])
 
   const vimMappingDiagnostics = useMemo(() => {
-    const leaderKey =
-      toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix')) ??
-      '<Space>'
+    const leaderKey = toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix')) ?? '<Space>'
     const appSeqMap = getAppVimSequenceMap(overrides)
     return diagnoseVimMappings(vimMappings, leaderKey, appSeqMap)
   }, [vimMappings, overrides])
@@ -2675,8 +2483,7 @@ function KeymapSettings({
     () =>
       new Set(
         vimMappingDiagnostics.reduce<KeymapId[]>((acc, d) => {
-          if (d.kind === 'app-conflict' && d.keymapId)
-            acc.push(d.keymapId as KeymapId)
+          if (d.kind === 'app-conflict' && d.keymapId) acc.push(d.keymapId as KeymapId)
           return acc
         }, [])
       ),
@@ -2688,11 +2495,7 @@ function KeymapSettings({
     return getKeymapDefinitionsByGroup()
       .map((group) => {
         const items = group.items.filter((definition) => {
-          if (
-            definition.vimOnly &&
-            !vimMode &&
-            definition.id !== 'global.searchNotesNonVim'
-          ) {
+          if (definition.vimOnly && !vimMode && definition.id !== 'global.searchNotesNonVim') {
             // Keep Vim-only bindings visible so users can prep their layout
             // before turning Vim mode back on, but still let the filter work.
           }
@@ -2705,12 +2508,7 @@ function KeymapSettings({
         })
         return items.length > 0 ? { ...group, items } : null
       })
-      .filter(
-        (
-          group
-        ): group is ReturnType<typeof getKeymapDefinitionsByGroup>[number] =>
-          !!group
-      )
+      .filter((group): group is ReturnType<typeof getKeymapDefinitionsByGroup>[number] => !!group)
   }, [overrides, query, vimMode])
 
   const totalConflicts = keymapDiagnostics.size + vimrcOverriddenIds.size
@@ -2723,9 +2521,8 @@ function KeymapSettings({
         <div className="min-w-0">
           <div className="text-sm font-medium text-ink-900">Vimrc</div>
           <div className="mt-1 text-xs leading-5 text-ink-500">
-            Extend custom key mappings using Vimscript syntax, takes precedence
-            over vim keymaps. Supports noremap, map, and unmap across normal,
-            visual, and insert modes.
+            Extend custom key mappings using Vimscript syntax, takes precedence over vim keymaps.
+            Supports noremap, map, and unmap across normal, visual, and insert modes.
           </div>
         </div>
         <textarea
@@ -2740,9 +2537,7 @@ function KeymapSettings({
             <ul className="space-y-1">
               {vimMappingDiagnostics.map((d, i) => (
                 <li key={i} className="flex gap-2 text-xs text-amber-500">
-                  <span className="shrink-0">
-                    Line {String(d.line).padStart(2, ' ')}:
-                  </span>
+                  <span className="shrink-0">Line {String(d.line).padStart(2, ' ')}:</span>
                   <span>{d.message}</span>
                 </li>
               ))}
@@ -2768,9 +2563,8 @@ function KeymapSettings({
                 )}
               </div>
               <div className="mt-1 text-xs leading-5 text-ink-500">
-                Record a new key or sequence for the app’s keyboard-first
-                actions. Standard accessibility fallbacks like arrows, Enter,
-                and Escape still work.
+                Record a new key or sequence for the app’s keyboard-first actions. Standard
+                accessibility fallbacks like arrows, Enter, and Escape still work.
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -2808,8 +2602,7 @@ function KeymapSettings({
                   const current = getKeymapBinding(overrides, definition.id)
                   const custom = !!overrides[definition.id]
                   const inactive =
-                    (definition.vimOnly && !vimMode) ||
-                    (definition.nonVimOnly && vimMode)
+                    (definition.vimOnly && !vimMode) || (definition.nonVimOnly && vimMode)
                   return (
                     <div
                       key={definition.id}
@@ -2900,10 +2693,7 @@ function KeymapSettings({
           currentBinding={getKeymapBinding(overrides, recording.id)}
           onClose={() => setRecording(null)}
           onSave={(binding) => {
-            onSetBinding(
-              recording.id,
-              binding === recording.defaultBinding ? null : binding
-            )
+            onSetBinding(recording.id, binding === recording.defaultBinding ? null : binding)
             setRecording(null)
           }}
         />
@@ -2929,11 +2719,7 @@ function KeymapRecorderModal({
   useEffect(() => {
     const onKey = (event: KeyboardEvent): void => {
       const target = event.target as HTMLElement | null
-      if (
-        target &&
-        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')
-      )
-        return
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return
       const key = event.key
       if (key === 'Backspace' || key === 'Delete') {
         event.preventDefault()
@@ -2977,29 +2763,21 @@ function KeymapRecorderModal({
     return () => window.removeEventListener('keydown', onKey, true)
   }, [definition])
 
-  const display = binding
-    ? formatKeymapBinding(binding, definition.kind)
-    : 'Press a key…'
+  const display = binding ? formatKeymapBinding(binding, definition.kind) : 'Press a key…'
 
   return createPortal(
     <div className="fixed inset-0 z-toast flex items-center justify-center bg-black/35 px-4 backdrop-blur-sm">
       <div className="w-[min(440px,92vw)] overflow-hidden rounded-2xl border border-paper-300/70 bg-paper-100 shadow-float">
         <div className="border-b border-paper-300/60 px-5 py-4">
-          <div className="text-base font-semibold text-ink-900">
-            {definition.title}
-          </div>
-          <div className="mt-1 text-sm text-ink-500">
-            {definition.description}
-          </div>
+          <div className="text-base font-semibold text-ink-900">{definition.title}</div>
+          <div className="mt-1 text-sm text-ink-500">{definition.description}</div>
         </div>
         <div className="px-5 py-4">
           <div className="rounded-xl border border-paper-300/70 bg-paper-50/80 px-4 py-4">
             <div className="text-xs font-medium uppercase tracking-[0.16em] text-ink-500">
               Recording
             </div>
-            <div className="mt-2 text-2xl font-semibold text-ink-900">
-              {display}
-            </div>
+            <div className="mt-2 text-2xl font-semibold text-ink-900">{display}</div>
             <div className="mt-2 text-xs leading-5 text-ink-500">
               {definition.kind === 'shortcut'
                 ? `Press the shortcut you want. ${mac ? 'Command' : 'Ctrl'}-style chords are saved in the app’s cross-platform format.`
@@ -3010,8 +2788,7 @@ function KeymapRecorderModal({
             Current: {formatKeymapBinding(currentBinding, definition.kind)}
           </div>
           <div className="mt-1 text-xs text-ink-500">
-            Default:{' '}
-            {formatKeymapBinding(definition.defaultBinding, definition.kind)}
+            Default: {formatKeymapBinding(definition.defaultBinding, definition.kind)}
           </div>
         </div>
         <div className="flex items-center justify-between gap-3 border-t border-paper-300/60 px-5 py-3">
@@ -3030,12 +2807,7 @@ function KeymapRecorderModal({
             >
               Cancel
             </button>
-            <Button
-              variant="primary"
-              size="sm"
-              disabled={!binding}
-              onClick={() => onSave(binding)}
-            >
+            <Button variant="primary" size="sm" disabled={!binding} onClick={() => onSave(binding)}>
               Save
             </Button>
           </div>
@@ -3060,13 +2832,9 @@ function Section({
   return (
     <section className="space-y-3" {...settingsSearchTargetProps(settingId)}>
       <div>
-        <div className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">
-          {title}
-        </div>
+        <div className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">{title}</div>
         {description && (
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-ink-500">
-            {description}
-          </p>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-ink-500">{description}</p>
         )}
       </div>
       <div className="overflow-hidden rounded-3xl border border-paper-300/60 bg-paper-50/45 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
@@ -3077,9 +2845,7 @@ function Section({
 }
 
 function InlineNote({ children }: { children: React.ReactNode }): JSX.Element {
-  return (
-    <div className="px-5 py-4 text-xs leading-5 text-ink-500">{children}</div>
-  )
+  return <div className="px-5 py-4 text-xs leading-5 text-ink-500">{children}</div>
 }
 
 const DEFAULT_QUICK_CAPTURE_HOTKEY = 'CommandOrControl+Shift+Space'
@@ -3097,10 +2863,8 @@ function formatAcceleratorForDisplay(accelerator: string): string {
   return accelerator
     .split('+')
     .map((part) => {
-      if (part === 'CommandOrControl' || part === 'CmdOrCtrl')
-        return mac ? '⌘' : 'Ctrl'
-      if (part === 'Command' || part === 'Cmd' || part === 'Meta')
-        return mac ? '⌘' : 'Meta'
+      if (part === 'CommandOrControl' || part === 'CmdOrCtrl') return mac ? '⌘' : 'Ctrl'
+      if (part === 'Command' || part === 'Cmd' || part === 'Meta') return mac ? '⌘' : 'Meta'
       if (part === 'Control' || part === 'Ctrl') return mac ? '⌃' : 'Ctrl'
       if (part === 'Alt' || part === 'Option') return mac ? '⌥' : 'Alt'
       if (part === 'Shift') return mac ? '⇧' : 'Shift'
@@ -3110,9 +2874,7 @@ function formatAcceleratorForDisplay(accelerator: string): string {
     .join(mac ? '' : '+')
 }
 
-function QuickCaptureHotkeyRow({
-  settingId
-}: { settingId?: string } = {}): JSX.Element {
+function QuickCaptureHotkeyRow({ settingId }: { settingId?: string } = {}): JSX.Element {
   const [current, setCurrent] = useState<string>('')
   const [recording, setRecording] = useState(false)
   const [draft, setDraft] = useState<string>('')
@@ -3169,19 +2931,13 @@ function QuickCaptureHotkeyRow({
 
   const display = draft || current
   return (
-    <div
-      className="flex flex-col gap-2 px-5 py-4"
-      {...settingsSearchTargetProps(settingId)}
-    >
+    <div className="flex flex-col gap-2 px-5 py-4" {...settingsSearchTargetProps(settingId)}>
       <div className="flex items-center justify-between gap-5">
         <div className="min-w-0">
-          <div className="text-sm font-medium text-ink-900">
-            Quick capture hotkey
-          </div>
+          <div className="text-sm font-medium text-ink-900">Quick capture hotkey</div>
           <div className="mt-1 text-xs leading-5 text-ink-500">
-            System-wide shortcut to open the floating capture window. Works even
-            when ZenNotes is hidden or another app is focused. Click Record,
-            then press the chord; Esc cancels.
+            System-wide shortcut to open the floating capture window. Works even when ZenNotes is
+            hidden or another app is focused. Click Record, then press the chord; Esc cancels.
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -3275,11 +3031,7 @@ function TextInputRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && (
-          <div className="mt-1 text-xs leading-5 text-ink-500">
-            {description}
-          </div>
-        )}
+        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
       </div>
       <input
         value={value}
@@ -3319,11 +3071,7 @@ function TemplateSelectRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && (
-          <div className="mt-1 text-xs leading-5 text-ink-500">
-            {description}
-          </div>
-        )}
+        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
       </div>
       <select
         value={missing ? '__missing__' : (value ?? '')}
@@ -3427,19 +3175,14 @@ function FontRow({
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
-    const base = q
-      ? options.filter((o) => o.toLowerCase().includes(q))
-      : options
+    const base = q ? options.filter((o) => o.toLowerCase().includes(q)) : options
     return base.slice(0, 120)
   }, [query, options])
 
   // Virtual item list: entry 0 is the "Default" reset, then every filtered
   // font. A single index tracks which row is keyboard-highlighted.
   // `null` represents the default / reset row.
-  const items: Array<string | null> = useMemo(
-    () => [null, ...filtered],
-    [filtered]
-  )
+  const items: Array<string | null> = useMemo(() => [null, ...filtered], [filtered])
 
   // Clamp the active index whenever the filter narrows/widens.
   useEffect(() => {
@@ -3449,9 +3192,7 @@ function FontRow({
   // Scroll the keyboard-selected row into view.
   useEffect(() => {
     if (!open || !listRef.current) return
-    const el = listRef.current.querySelector<HTMLElement>(
-      `[data-idx="${activeIdx}"]`
-    )
+    const el = listRef.current.querySelector<HTMLElement>(`[data-idx="${activeIdx}"]`)
     el?.scrollIntoView({ block: 'nearest' })
   }, [activeIdx, open])
 
@@ -3490,11 +3231,7 @@ function FontRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && (
-          <div className="mt-1 text-xs leading-5 text-ink-500">
-            {description}
-          </div>
-        )}
+        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
       </div>
       <button
         ref={buttonRef}
@@ -3505,9 +3242,7 @@ function FontRow({
         <span
           className="truncate"
           style={{
-            fontFamily: value
-              ? `"${value}", ui-monospace, monospace`
-              : undefined
+            fontFamily: value ? `"${value}", ui-monospace, monospace` : undefined
           }}
         >
           {value ?? 'Default'}
@@ -3565,9 +3300,7 @@ function FontRow({
               </button>
               {filtered.length === 0 ? (
                 <div className="px-3 py-4 text-center text-xs text-ink-400">
-                  {options.length === 0
-                    ? 'No fonts available'
-                    : 'No fonts match your search'}
+                  {options.length === 0 ? 'No fonts available' : 'No fonts match your search'}
                 </div>
               ) : (
                 filtered.map((f, i) => {
@@ -3626,8 +3359,7 @@ function SliderRow({
   settingId?: string
   onChange: (next: number) => void
 }): JSX.Element {
-  const display =
-    (format ? format(value) : String(value)) + (unit && !format ? unit : '')
+  const display = (format ? format(value) : String(value)) + (unit && !format ? unit : '')
   return (
     <div
       className="flex items-center justify-between gap-5 px-5 py-4"
@@ -3635,11 +3367,7 @@ function SliderRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && (
-          <div className="mt-1 text-xs leading-5 text-ink-500">
-            {description}
-          </div>
-        )}
+        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
       </div>
       <div className="flex shrink-0 items-center gap-3">
         <input
@@ -3651,9 +3379,7 @@ function SliderRow({
           onChange={(e) => onChange(Number(e.target.value))}
           className="zen-slider h-1 w-[140px] cursor-pointer appearance-none rounded-full"
         />
-        <div className="min-w-[54px] text-right text-sm tabular-nums text-ink-800">
-          {display}
-        </div>
+        <div className="min-w-[54px] text-right text-sm tabular-nums text-ink-800">{display}</div>
       </div>
     </div>
   )
@@ -3691,9 +3417,7 @@ function NumberRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && (
-          <div className="text-xs text-ink-500">{description}</div>
-        )}
+        {description && <div className="text-xs text-ink-500">{description}</div>}
       </div>
       <div className="flex items-center gap-2">
         <button
@@ -3703,9 +3427,7 @@ function NumberRow({
         >
           −
         </button>
-        <div className="min-w-[56px] text-center text-sm tabular-nums text-ink-800">
-          {display}
-        </div>
+        <div className="min-w-[56px] text-center text-sm tabular-nums text-ink-800">{display}</div>
         <button
           type="button"
           onClick={() => onChange(clamp(+(value + step).toFixed(2)))}
@@ -3738,11 +3460,7 @@ function ToggleRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && (
-          <div className="mt-1 text-xs leading-5 text-ink-500">
-            {description}
-          </div>
-        )}
+        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
       </div>
       <button
         type="button"
@@ -3787,11 +3505,7 @@ function SegmentedRow<T extends string>({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && (
-          <div className="mt-1 text-xs leading-5 text-ink-500">
-            {description}
-          </div>
-        )}
+        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
       </div>
       <div className="inline-flex shrink-0 rounded-xl border border-paper-300/70 bg-paper-100/75 p-1">
         {options.map((option) => (
@@ -3885,9 +3599,7 @@ function CliSettings(): JSX.Element {
           description="Install the `zen` shell command for terminal-based note workflows."
           settingId="zen-command-line-tool"
         >
-          <InlineNote>
-            {status.reason ?? 'Not supported on this platform yet.'}
-          </InlineNote>
+          <InlineNote>{status.reason ?? 'Not supported on this platform yet.'}</InlineNote>
         </Section>
       </div>
     )
@@ -3934,15 +3646,12 @@ function CliSettings(): JSX.Element {
                       : `Symlinks ${status.defaultTarget} to ZenNotes' bundled wrapper.`}
               </div>
               {status.reason && (
-                <div className="mt-1.5 text-xs leading-5 text-amber-500">
-                  {status.reason}
-                </div>
+                <div className="mt-1.5 text-xs leading-5 text-amber-500">{status.reason}</div>
               )}
               {!installed && status.pathHint && (
                 <div className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs leading-5 text-ink-700">
                   <div className="font-medium text-amber-600">
-                    {status.defaultTarget.replace(/\/[^/]+$/, '')} is not on
-                    your PATH.
+                    {status.defaultTarget.replace(/\/[^/]+$/, '')} is not on your PATH.
                   </div>
                   <div className="mt-1 text-ink-500">
                     After install, run this once so your shell can find{' '}
@@ -3999,9 +3708,7 @@ function CliSettings(): JSX.Element {
             </code>
             <button
               type="button"
-              onClick={() =>
-                copyToClipboard(status.installedAt ?? status.defaultTarget)
-              }
+              onClick={() => copyToClipboard(status.installedAt ?? status.defaultTarget)}
               className="shrink-0 rounded-md border border-paper-300/70 bg-paper-100/80 px-2 py-1 text-xs font-medium text-ink-700 hover:bg-paper-200"
             >
               Copy
@@ -4010,10 +3717,7 @@ function CliSettings(): JSX.Element {
         </div>
       </Section>
 
-      <RaycastExtensionSettings
-        cliInstalled={installed}
-        copyToClipboard={copyToClipboard}
-      />
+      <RaycastExtensionSettings cliInstalled={installed} copyToClipboard={copyToClipboard} />
 
       <Section
         title="Quick reference"
@@ -4116,9 +3820,7 @@ function RaycastExtensionSettings({
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-              <span className="text-sm font-medium text-ink-900">
-                ZenNotes for Raycast
-              </span>
+              <span className="text-sm font-medium text-ink-900">ZenNotes for Raycast</span>
               <span
                 className={[
                   'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
@@ -4129,19 +3831,15 @@ function RaycastExtensionSettings({
               </span>
             </div>
             <div className="mt-1 text-xs leading-5 text-ink-500">{detail}</div>
-            <div className="mt-1 text-xs leading-5 text-ink-400">
-              {toolchainDetail}
-            </div>
+            <div className="mt-1 text-xs leading-5 text-ink-400">{toolchainDetail}</div>
             {!cliInstalled && (
               <div className="mt-1.5 text-xs leading-5 text-amber-500">
-                Install the <code className="font-mono">zen</code> CLI above
-                first. The Raycast command calls it to read your local vault.
+                Install the <code className="font-mono">zen</code> CLI above first. The Raycast
+                command calls it to read your local vault.
               </div>
             )}
             {cliInstalled && status.reason && (
-              <div className="mt-1.5 text-xs leading-5 text-amber-500">
-                {status.reason}
-              </div>
+              <div className="mt-1.5 text-xs leading-5 text-amber-500">{status.reason}</div>
             )}
           </div>
           <Button
@@ -4186,18 +3884,13 @@ function raycastStatusChip(
   cliInstalled: boolean
 ): { label: string; tone: 'ok' | 'warn' | 'off' } {
   if (!status.supportedPlatform) return { label: 'Not supported', tone: 'off' }
-  if (status.installed && status.upToDate)
-    return { label: 'Installed', tone: 'ok' }
-  if (status.installed && !status.upToDate)
-    return { label: 'Update available', tone: 'warn' }
+  if (status.installed && status.upToDate) return { label: 'Installed', tone: 'ok' }
+  if (status.installed && !status.upToDate) return { label: 'Update available', tone: 'warn' }
   if (status.available && cliInstalled) return { label: 'Ready', tone: 'off' }
   return { label: 'Not ready', tone: 'off' }
 }
 
-function raycastStatusDetail(
-  status: RaycastExtensionStatus,
-  cliInstalled: boolean
-): string {
+function raycastStatusDetail(status: RaycastExtensionStatus, cliInstalled: boolean): string {
   if (!status.supportedPlatform) {
     return status.reason ?? 'Raycast extensions are available on macOS only.'
   }
@@ -4225,10 +3918,7 @@ function McpSettings(): JSX.Element {
 
   const refresh = useCallback(async (): Promise<void> => {
     try {
-      const [s, r] = await Promise.all([
-        window.zen.mcpGetStatuses(),
-        window.zen.mcpGetRuntime()
-      ])
+      const [s, r] = await Promise.all([window.zen.mcpGetStatuses(), window.zen.mcpGetRuntime()])
       setStatuses(s)
       setRuntime(r)
       setError(null)
@@ -4276,8 +3966,7 @@ function McpSettings(): JSX.Element {
 
   const serverStatusLabel =
     runtime == null ? 'Checking\u2026' : entryMissing ? 'Not built' : 'Ready'
-  const serverStatusTone =
-    runtime == null ? 'off' : entryMissing ? 'warn' : 'ok'
+  const serverStatusTone = runtime == null ? 'off' : entryMissing ? 'warn' : 'ok'
   const serverStatusClass = statusChipClass(serverStatusTone)
 
   return (
@@ -4492,13 +4181,10 @@ function McpInstructionsEditor(): JSX.Element {
         <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-ink-500">
           <span>
             Saved at:{' '}
-            <code className="font-mono text-xs text-ink-600">
-              {payload?.filePath ?? '—'}
-            </code>
+            <code className="font-mono text-xs text-ink-600">{payload?.filePath ?? '—'}</code>
           </span>
           <span>
-            {draft.length.toLocaleString()} chars ·{' '}
-            {draft.split(/\r?\n/).length} lines
+            {draft.length.toLocaleString()} chars · {draft.split(/\r?\n/).length} lines
           </span>
         </div>
         {error && (
@@ -4551,13 +4237,9 @@ function McpClientRow({
               {chip.label}
             </span>
           </div>
-          <div className="mt-1 text-xs leading-5 text-ink-500">
-            {description}
-          </div>
+          <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>
           {status.note && (
-            <div className="mt-1.5 text-xs leading-5 text-ink-500">
-              {status.note}
-            </div>
+            <div className="mt-1.5 text-xs leading-5 text-ink-500">{status.note}</div>
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -4593,12 +4275,7 @@ function McpClientRow({
               </button>
             </>
           ) : (
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={onInstall}
-              disabled={busy || entryMissing}
-            >
+            <Button variant="primary" size="sm" onClick={onInstall} disabled={busy || entryMissing}>
               {busy ? 'Installing…' : 'Install'}
             </Button>
           )}

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -1,6 +1,16 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { createPortal } from 'react-dom'
-import { DEFAULT_DAILY_NOTES_DIRECTORY, DEFAULT_WEEKLY_NOTES_DIRECTORY } from '@shared/ipc'
+import {
+  DEFAULT_DAILY_NOTES_DIRECTORY,
+  DEFAULT_WEEKLY_NOTES_DIRECTORY,
+} from '@shared/ipc'
 import type {
   AppUpdateState,
   CliInstallStatus,
@@ -9,41 +19,56 @@ import type {
   RemoteWorkspaceProfileInput,
   VaultTextSearchBackendPreference,
   VaultTextSearchCapabilities,
-  VaultTextSearchToolPaths
+  VaultTextSearchToolPaths,
 } from '@shared/ipc'
 import {
   MCP_CLIENTS,
   type McpClientId,
   type McpClientStatus,
   type McpInstructionsPayload,
-  type McpServerRuntime
+  type McpServerRuntime,
 } from '@shared/mcp-clients'
 import { useStore } from '../store'
 import type { LineNumberMode, WhichKeyHintMode } from '../store'
-import type { KeymapDefinition, KeymapId, KeymapOverrides } from '../lib/keymaps'
+import type {
+  KeymapDefinition,
+  KeymapId,
+  KeymapOverrides,
+} from '../lib/keymaps'
 import {
+  findConflictingKeymaps,
   formatKeymapBinding,
+  getAppVimSequenceMap,
   getKeymapBinding,
   getKeymapDefinitionsByGroup,
   getKeymapDisplay,
   isMacPlatform,
   sequenceTokenFromEvent,
-  shortcutBindingFromEvent
+  shortcutBindingFromEvent,
 } from '../lib/keymaps'
-import { resolveAuto, THEMES, type ThemeFamily, type ThemeMode } from '../lib/themes'
+import { diagnoseVimMappings, toVimSequence } from '../lib/vim-mappings'
+import {
+  resolveAuto,
+  THEMES,
+  type ThemeFamily,
+  type ThemeMode,
+} from '../lib/themes'
 import { hasSystemFontAccess, listSystemFonts } from '../lib/system-fonts'
 import {
   DEFAULT_SYSTEM_FOLDER_LABELS,
-  getSystemFolderLabel
+  getSystemFolderLabel,
 } from '../lib/system-folder-labels'
-import { normalizeDailyNotesDirectory, normalizeWeeklyNotesDirectory } from '../lib/vault-layout'
+import {
+  normalizeDailyNotesDirectory,
+  normalizeWeeklyNotesDirectory,
+} from '../lib/vault-layout'
 import { BUILTIN_TEMPLATES } from '@shared/builtin-templates'
 import { composeTemplateFile, mergeTemplates } from '@shared/template-files'
 import { TemplateEditorModal } from './TemplateEditorModal'
 import type { NoteTemplate } from '@bridge-contract/templates'
 import {
   getSettingsSearchResults,
-  type SettingsSearchCategory
+  type SettingsSearchCategory,
 } from '../lib/settings-search'
 import { useAppUpdateState } from '../lib/app-update-state'
 import { getZenBridge } from '@zennotes/bridge-contract/bridge'
@@ -73,14 +98,19 @@ interface SettingsCategory extends SettingsSearchCategory<SettingsCategoryId> {
   content: JSX.Element
 }
 
-function settingsSearchTargetProps(
-  settingId: string | undefined
-): { 'data-settings-search-id'?: string } {
+function settingsSearchTargetProps(settingId: string | undefined): {
+  'data-settings-search-id'?: string
+} {
   return settingId ? { 'data-settings-search-id': settingId } : {}
 }
 
-function findSettingsSearchTarget(root: HTMLElement, targetId: string): HTMLElement | null {
-  for (const element of root.querySelectorAll<HTMLElement>('[data-settings-search-id]')) {
+function findSettingsSearchTarget(
+  root: HTMLElement,
+  targetId: string,
+): HTMLElement | null {
+  for (const element of root.querySelectorAll<HTMLElement>(
+    '[data-settings-search-id]',
+  )) {
     if (element.dataset.settingsSearchId === targetId) return element
   }
   return null
@@ -96,11 +126,12 @@ function clearSettingsSearchHighlights(root: HTMLElement): void {
 
 function resolveVaultTextSearchBackend(
   preferred: VaultTextSearchBackendPreference,
-  capabilities: VaultTextSearchCapabilities | null
+  capabilities: VaultTextSearchCapabilities | null,
 ): ResolvedVaultTextSearchBackend | null {
   if (!capabilities) return null
   if (preferred === 'builtin') return 'builtin'
-  if (preferred === 'ripgrep') return capabilities.ripgrep ? 'ripgrep' : 'builtin'
+  if (preferred === 'ripgrep')
+    return capabilities.ripgrep ? 'ripgrep' : 'builtin'
   if (preferred === 'fzf') return capabilities.fzf ? 'fzf' : 'builtin'
   if (capabilities.fzf) return 'fzf'
   if (capabilities.ripgrep) return 'ripgrep'
@@ -108,7 +139,7 @@ function resolveVaultTextSearchBackend(
 }
 
 function resolvedVaultTextSearchBackendLabel(
-  backend: ResolvedVaultTextSearchBackend | null
+  backend: ResolvedVaultTextSearchBackend | null,
 ): string {
   if (backend === 'ripgrep') return 'ripgrep'
   if (backend === 'fzf') return 'fzf'
@@ -167,7 +198,12 @@ function formatBytes(bytes: number | null): string | null {
     value /= 1024
     unit = units[i]
   }
-  const rounded = value >= 100 ? value.toFixed(0) : value >= 10 ? value.toFixed(1) : value.toFixed(2)
+  const rounded =
+    value >= 100
+      ? value.toFixed(0)
+      : value >= 10
+        ? value.toFixed(1)
+        : value.toFixed(2)
   return `${rounded} ${unit}`
 }
 
@@ -191,11 +227,19 @@ function formatReleaseNotesForDisplay(notes: string | null): string | null {
   }
 }
 
+function statusChipClass(tone: 'ok' | 'warn' | 'off'): string {
+  if (tone === 'ok') return 'border-accent/25 bg-accent/10 text-accent'
+  if (tone === 'warn')
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-500'
+  return 'border-paper-300/70 bg-paper-100/85 text-ink-500'
+}
+
 export function SettingsModal(): JSX.Element {
   const zenBridge = getZenBridge()
   const appInfo = zenBridge.getAppInfo()
   const supportsRemoteWorkspace =
-    appInfo.runtime === 'desktop' && zenBridge.getCapabilities().supportsRemoteWorkspace
+    appInfo.runtime === 'desktop' &&
+    zenBridge.getCapabilities().supportsRemoteWorkspace
   const setSettingsOpen = useStore((s) => s.setSettingsOpen)
   const vimMode = useStore((s) => s.vimMode)
   const setVimMode = useStore((s) => s.setVimMode)
@@ -244,11 +288,19 @@ export function SettingsModal(): JSX.Element {
   const persistVaultSettings = useStore((s) => s.setVaultSettings)
   const openVaultPicker = useStore((s) => s.openVaultPicker)
   const connectRemoteWorkspace = useStore((s) => s.connectRemoteWorkspace)
-  const connectRemoteWorkspaceProfile = useStore((s) => s.connectRemoteWorkspaceProfile)
-  const changeRemoteWorkspaceVaultPath = useStore((s) => s.changeRemoteWorkspaceVaultPath)
+  const connectRemoteWorkspaceProfile = useStore(
+    (s) => s.connectRemoteWorkspaceProfile,
+  )
+  const changeRemoteWorkspaceVaultPath = useStore(
+    (s) => s.changeRemoteWorkspaceVaultPath,
+  )
   const disconnectRemoteWorkspace = useStore((s) => s.disconnectRemoteWorkspace)
-  const saveRemoteWorkspaceProfile = useStore((s) => s.saveRemoteWorkspaceProfile)
-  const deleteRemoteWorkspaceProfile = useStore((s) => s.deleteRemoteWorkspaceProfile)
+  const saveRemoteWorkspaceProfile = useStore(
+    (s) => s.saveRemoteWorkspaceProfile,
+  )
+  const deleteRemoteWorkspaceProfile = useStore(
+    (s) => s.deleteRemoteWorkspaceProfile,
+  )
   const openTodayDailyNote = useStore((s) => s.openTodayDailyNote)
   const openThisWeekWeeklyNote = useStore((s) => s.openThisWeekWeeklyNote)
   const autoCalendarPanel = useStore((s) => s.autoCalendarPanel)
@@ -256,17 +308,24 @@ export function SettingsModal(): JSX.Element {
   const calendarWeekStart = useStore((s) => s.calendarWeekStart)
   const setCalendarWeekStart = useStore((s) => s.setCalendarWeekStart)
   const calendarShowWeekNumbers = useStore((s) => s.calendarShowWeekNumbers)
-  const setCalendarShowWeekNumbers = useStore((s) => s.setCalendarShowWeekNumbers)
+  const setCalendarShowWeekNumbers = useStore(
+    (s) => s.setCalendarShowWeekNumbers,
+  )
   const customTemplates = useStore((s) => s.customTemplates)
   const deleteCustomTemplate = useStore((s) => s.deleteCustomTemplate)
   const hideBuiltinTemplates = useStore((s) => s.hideBuiltinTemplates)
   const setHideBuiltinTemplates = useStore((s) => s.setHideBuiltinTemplates)
   const allTemplates = useMemo(
-    () => mergeTemplates(hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES, customTemplates),
-    [customTemplates, hideBuiltinTemplates]
+    () =>
+      mergeTemplates(
+        hideBuiltinTemplates ? [] : BUILTIN_TEMPLATES,
+        customTemplates,
+      ),
+    [customTemplates, hideBuiltinTemplates],
   )
   const supportsCustomTemplates =
-    zenBridge.getCapabilities().supportsCustomTemplates && workspaceMode !== 'remote'
+    zenBridge.getCapabilities().supportsCustomTemplates &&
+    workspaceMode !== 'remote'
   const [templateEditor, setTemplateEditor] = useState<{
     initialRaw?: string
     sourcePath?: string
@@ -292,8 +351,8 @@ export function SettingsModal(): JSX.Element {
         targetFolder: template.targetFolder,
         targetSubpath: template.targetSubpath,
         builtinId: template.id,
-        body: template.body
-      })
+        body: template.body,
+      }),
     })
   }
   const removeTemplate = async (template: NoteTemplate): Promise<void> => {
@@ -307,7 +366,7 @@ export function SettingsModal(): JSX.Element {
         ? 'This removes your customizations and restores the built-in template.'
         : 'This removes the template file. Notes already created from it are unaffected.',
       confirmLabel: isOverride ? 'Reset' : 'Delete',
-      danger: true
+      danger: true,
     })
     if (!confirmed) return
     await deleteCustomTemplate(template.sourcePath)
@@ -322,7 +381,7 @@ export function SettingsModal(): JSX.Element {
       description:
         'The shipped templates will be hidden from the picker and palette. Your custom templates are unaffected, and you can restore the built-ins anytime.',
       confirmLabel: 'Remove',
-      danger: true
+      danger: true,
     })
     if (!confirmed) return
     setHideBuiltinTemplates(true)
@@ -366,9 +425,9 @@ export function SettingsModal(): JSX.Element {
   const searchToolPaths = useMemo<VaultTextSearchToolPaths>(
     () => ({
       ripgrepPath: ripgrepBinaryPath,
-      fzfPath: fzfBinaryPath
+      fzfPath: fzfBinaryPath,
     }),
-    [fzfBinaryPath, ripgrepBinaryPath]
+    [fzfBinaryPath, ripgrepBinaryPath],
   )
   useEffect(() => {
     let cancelled = false
@@ -393,8 +452,9 @@ export function SettingsModal(): JSX.Element {
         if (!cancelled) setVaultTextSearchCapabilities(capabilities)
       },
       () => {
-        if (!cancelled) setVaultTextSearchCapabilities({ ripgrep: false, fzf: false })
-      }
+        if (!cancelled)
+          setVaultTextSearchCapabilities({ ripgrep: false, fzf: false })
+      },
     )
     return () => {
       cancelled = true
@@ -406,7 +466,7 @@ export function SettingsModal(): JSX.Element {
       (state) => {
         if (state.phase === 'available') {
           window.alert(
-            `ZenNotes ${state.availableVersion ?? ''} is available. Use “Download Update” to fetch it.`
+            `ZenNotes ${state.availableVersion ?? ''} is available. Use “Download Update” to fetch it.`,
           )
           return
         }
@@ -420,9 +480,11 @@ export function SettingsModal(): JSX.Element {
       },
       (error) => {
         const message =
-          error instanceof Error ? error.message : 'Could not check for updates.'
+          error instanceof Error
+            ? error.message
+            : 'Could not check for updates.'
         window.alert(message)
-      }
+      },
     )
   }, [])
 
@@ -435,7 +497,7 @@ export function SettingsModal(): JSX.Element {
   }, [])
 
   const currentRemoteProfileId =
-    workspaceMode === 'remote' ? remoteWorkspaceInfo?.profileId ?? null : null
+    workspaceMode === 'remote' ? (remoteWorkspaceInfo?.profileId ?? null) : null
 
   const openCreateRemoteProfile = useCallback(() => {
     setEditingRemoteProfile({
@@ -444,50 +506,54 @@ export function SettingsModal(): JSX.Element {
         name: '',
         baseUrl: remoteWorkspaceInfo?.baseUrl ?? 'http://localhost:7878',
         authToken: null,
-        vaultPath: workspaceMode === 'remote' ? vault?.root ?? null : null
+        vaultPath: workspaceMode === 'remote' ? (vault?.root ?? null) : null,
       },
-      hasStoredCredential: false
+      hasStoredCredential: false,
     })
   }, [remoteWorkspaceInfo?.baseUrl, vault?.root, workspaceMode])
 
-  const openEditRemoteProfile = useCallback((profile: RemoteWorkspaceProfile) => {
-    setEditingRemoteProfile({
-      mode: 'edit',
-      value: {
-        id: profile.id,
-        name: profile.name,
-        baseUrl: profile.baseUrl,
-        vaultPath: profile.vaultPath
-      },
-      hasStoredCredential: profile.hasCredential
-    })
-  }, [])
+  const openEditRemoteProfile = useCallback(
+    (profile: RemoteWorkspaceProfile) => {
+      setEditingRemoteProfile({
+        mode: 'edit',
+        value: {
+          id: profile.id,
+          name: profile.name,
+          baseUrl: profile.baseUrl,
+          vaultPath: profile.vaultPath,
+        },
+        hasStoredCredential: profile.hasCredential,
+      })
+    },
+    [],
+  )
 
   const submitRemoteProfile = useCallback(
     async (input: RemoteWorkspaceProfileInput) => {
       await saveRemoteWorkspaceProfile(input)
       setEditingRemoteProfile(null)
     },
-    [saveRemoteWorkspaceProfile]
+    [saveRemoteWorkspaceProfile],
   )
 
   const removeRemoteProfile = useCallback(
     async (profile: RemoteWorkspaceProfile) => {
       const confirmed = await confirmApp({
         title: `Remove “${profile.name}”?`,
-        description: 'This only removes the saved connection from ZenNotes. It does not delete anything on the server.',
+        description:
+          'This only removes the saved connection from ZenNotes. It does not delete anything on the server.',
         confirmLabel: 'Remove',
-        danger: true
+        danger: true,
       })
       if (!confirmed) return
       await deleteRemoteWorkspaceProfile(profile.id)
     },
-    [deleteRemoteWorkspaceProfile]
+    [deleteRemoteWorkspaceProfile],
   )
 
   const displayedReleaseNotes = useMemo(
     () => formatReleaseNotesForDisplay(appUpdateState?.releaseNotes ?? null),
-    [appUpdateState?.releaseNotes]
+    [appUpdateState?.releaseNotes],
   )
 
   // Family list — Apple is the default, followed by the other families.
@@ -501,9 +567,9 @@ export function SettingsModal(): JSX.Element {
       { id: 'one', label: 'One' },
       { id: 'nord', label: 'Nord' },
       { id: 'tokyo-night', label: 'Tokyo Night' },
-      { id: 'black-metal', label: 'Black Metal' }
+      { id: 'black-metal', label: 'Black Metal' },
     ],
-    []
+    [],
   )
 
   // Variants to show in the variant picker.
@@ -524,7 +590,7 @@ export function SettingsModal(): JSX.Element {
   const [prefersDark, setPrefersDark] = useState(() =>
     typeof window !== 'undefined'
       ? window.matchMedia('(prefers-color-scheme: dark)').matches
-      : false
+      : false,
   )
   useEffect(() => {
     const mql = window.matchMedia('(prefers-color-scheme: dark)')
@@ -544,14 +610,16 @@ export function SettingsModal(): JSX.Element {
    *  themeId may not match what's painted on screen. */
   const renderedThemeId = useMemo(
     () =>
-      themeMode === 'auto' ? resolveAuto(themeFamily, prefersDark, themeId) : themeId,
-    [themeId, themeFamily, themeMode, prefersDark]
+      themeMode === 'auto'
+        ? resolveAuto(themeFamily, prefersDark, themeId)
+        : themeId,
+    [themeId, themeFamily, themeMode, prefersDark],
   )
 
   const visibleVariants = useMemo(() => {
     if (themeFamily === 'gruvbox') {
       return THEMES.filter(
-        (t) => t.family === 'gruvbox' && t.mode === effectiveMode
+        (t) => t.family === 'gruvbox' && t.mode === effectiveMode,
       )
     }
     // Families with only a light/dark pair don't need a variant picker —
@@ -562,7 +630,7 @@ export function SettingsModal(): JSX.Element {
       'one',
       'nord',
       'tokyo-night',
-      'black-metal'
+      'black-metal',
     ]
     if (simpleFamilies.includes(themeFamily)) return []
     return THEMES.filter((t) => t.family === themeFamily)
@@ -581,7 +649,7 @@ export function SettingsModal(): JSX.Element {
       one: { light: 'one-light', dark: 'one-dark' },
       nord: { light: 'nord-light', dark: 'nord-dark' },
       'tokyo-night': { light: 'tokyo-night-day', dark: 'tokyo-night-storm' },
-      'black-metal': { light: 'black-metal-day', dark: 'black-metal' }
+      'black-metal': { light: 'black-metal-day', dark: 'black-metal' },
     }
     const targetId = preferred[family][effectiveMode]
     setTheme({ id: targetId, family, mode: themeMode })
@@ -600,7 +668,7 @@ export function SettingsModal(): JSX.Element {
         (t) =>
           t.family === themeFamily &&
           t.mode === mode &&
-          t.variant === currentVariant
+          t.variant === currentVariant,
       ) ?? THEMES.find((t) => t.family === themeFamily && t.mode === mode)
     if (candidate) setTheme({ id: candidate.id, family: themeFamily, mode })
   }
@@ -619,20 +687,23 @@ export function SettingsModal(): JSX.Element {
 
   const ref = useRef<HTMLDivElement | null>(null)
   const settingsSearchHighlightTimerRef = useRef<number | null>(null)
-  const [activeCategory, setActiveCategory] = useState<SettingsCategoryId>('appearance')
-  const [activeSearchResultId, setActiveSearchResultId] = useState<string | null>(null)
+  const [activeCategory, setActiveCategory] =
+    useState<SettingsCategoryId>('appearance')
+  const [activeSearchResultId, setActiveSearchResultId] = useState<
+    string | null
+  >(null)
   const [navQuery, setNavQuery] = useState('')
   const availableVaultTextSearchTools = [
     vaultTextSearchCapabilities?.ripgrep ? 'ripgrep' : null,
-    vaultTextSearchCapabilities?.fzf ? 'fzf' : null
+    vaultTextSearchCapabilities?.fzf ? 'fzf' : null,
   ].filter((value): value is string => !!value)
   const resolvedVaultTextSearchBackend = useMemo(
     () =>
       resolveVaultTextSearchBackend(
         vaultTextSearchBackend,
-        vaultTextSearchCapabilities
+        vaultTextSearchCapabilities,
       ),
-    [vaultTextSearchBackend, vaultTextSearchCapabilities]
+    [vaultTextSearchBackend, vaultTextSearchCapabilities],
   )
   const resolvedVaultTextSearchMessage = useMemo(() => {
     if (!vaultTextSearchCapabilities) return 'Checking configured search tools…'
@@ -724,32 +795,44 @@ export function SettingsModal(): JSX.Element {
           id: 'theme-family',
           title: 'Theme family',
           description: 'Pick the visual system ZenNotes uses across the app.',
-          keywords: ['theme', 'family', 'apple', 'gruvbox', 'catppuccin', 'github', 'solarized', 'nord', 'tokyo night']
+          keywords: [
+            'theme',
+            'family',
+            'apple',
+            'gruvbox',
+            'catppuccin',
+            'github',
+            'solarized',
+            'nord',
+            'tokyo night',
+          ],
         },
         {
           id: 'theme-mode',
           title: 'Theme mode',
           description: 'Choose light, dark, or automatic theme mode.',
-          keywords: ['light', 'dark', 'auto', 'mode']
+          keywords: ['light', 'dark', 'auto', 'mode'],
         },
         {
           id: 'theme-variant',
           title: 'Theme variant',
           description: 'Choose a family-specific contrast, flavor, or variant.',
           keywords: ['variant', 'contrast', 'flavor'],
-          available: visibleVariants.length > 1
+          available: visibleVariants.length > 1,
         },
         {
           id: 'dark-sidebar',
           title: 'Dark sidebar',
-          description: 'Tint the sidebar one step darker than the canvas so the chrome reads as a separate surface.'
+          description:
+            'Tint the sidebar one step darker than the canvas so the chrome reads as a separate surface.',
         },
         {
           id: 'sidebar-arrows',
           title: 'Sidebar arrows',
-          description: 'Show disclosure arrows for collapsible folders and sidebar sections.',
-          keywords: ['chevrons', 'disclosure']
-        }
+          description:
+            'Show disclosure arrows for collapsible folders and sidebar sections.',
+          keywords: ['chevrons', 'disclosure'],
+        },
       ],
       content: (
         <div className="space-y-6">
@@ -771,7 +854,7 @@ export function SettingsModal(): JSX.Element {
                         'rounded-xl border px-3 py-2.5 text-left text-sm transition-colors',
                         themeFamily === f.id
                           ? 'border-accent/45 bg-accent/10 text-ink-900'
-                          : 'border-paper-300/70 bg-paper-100/70 text-ink-700 hover:bg-paper-200/80'
+                          : 'border-paper-300/70 bg-paper-100/70 text-ink-700 hover:bg-paper-200/80',
                       ].join(' ')}
                     >
                       {f.label}
@@ -793,7 +876,7 @@ export function SettingsModal(): JSX.Element {
                         'rounded-lg px-3 py-1.5 text-xs capitalize transition-colors',
                         themeMode === m
                           ? 'bg-paper-50 text-ink-900 shadow-sm'
-                          : 'text-ink-600 hover:text-ink-900'
+                          : 'text-ink-600 hover:text-ink-900',
                       ].join(' ')}
                     >
                       {m}
@@ -820,7 +903,7 @@ export function SettingsModal(): JSX.Element {
                           'rounded-xl border px-3 py-1.5 text-xs transition-colors',
                           renderedThemeId === v.id
                             ? 'border-accent/45 bg-accent/10 text-ink-900'
-                            : 'border-paper-300/70 bg-paper-100/70 text-ink-700 hover:bg-paper-200/80'
+                            : 'border-paper-300/70 bg-paper-100/70 text-ink-700 hover:bg-paper-200/80',
                         ].join(' ')}
                       >
                         {v.label}
@@ -852,119 +935,145 @@ export function SettingsModal(): JSX.Element {
             />
           </Section>
         </div>
-      )
+      ),
     },
     {
       id: 'editor',
       title: 'Editor',
-      description: 'Vim, leader hints, live preview, tabs, and writing behavior.',
-      keywords: ['vim', 'leader', 'preview', 'tabs', 'wrap', 'pdf', 'quick note', 'quick capture', 'hotkey', 'shortcut', 'task', 'tasks'],
+      description:
+        'Vim, leader hints, live preview, tabs, and writing behavior.',
+      keywords: [
+        'vim',
+        'leader',
+        'preview',
+        'tabs',
+        'wrap',
+        'pdf',
+        'quick note',
+        'quick capture',
+        'hotkey',
+        'shortcut',
+        'task',
+        'tasks',
+      ],
       searchItems: [
         {
           id: 'vim-mode',
           title: 'Vim mode',
           description: 'First-class Vim motions in the markdown editor.',
-          keywords: ['vim', 'motions']
+          keywords: ['vim', 'motions'],
         },
         {
           id: 'vim-insert-escape',
           title: 'Exit insert mode with',
-          description: 'Map a key sequence like jk or jj to Escape in insert mode.',
-          keywords: ['vim', 'jk', 'jj', 'escape', 'insert mode', 'esc']
+          description:
+            'Map a key sequence like jk or jj to Escape in insert mode.',
+          keywords: ['vim', 'jk', 'jj', 'escape', 'insert mode', 'esc'],
         },
         {
           id: 'leader-key-hints',
           title: 'Leader key hints',
-          description: 'Show a which-key style guide after pressing the Leader key so the next available actions stay visible.',
+          description:
+            'Show a which-key style guide after pressing the Leader key so the next available actions stay visible.',
           keywords: ['leader', 'which-key'],
-          targetId: leaderKeyHintsTargetId
+          targetId: leaderKeyHintsTargetId,
         },
         {
           id: 'leader-hint-behavior',
           title: 'Leader hint behavior',
-          description: 'Timed auto-hides after a short delay. Sticky keeps the leader overlay open until you dismiss it.',
+          description:
+            'Timed auto-hides after a short delay. Sticky keeps the leader overlay open until you dismiss it.',
           keywords: ['leader', 'sticky', 'timed'],
-          targetId: leaderHintBehaviorTargetId
+          targetId: leaderHintBehaviorTargetId,
         },
         {
           id: 'leader-hint-duration',
           title: 'Leader hint duration',
-          description: 'How long the leader overlay stays visible, and how long the pending leader sequence remains armed.',
+          description:
+            'How long the leader overlay stays visible, and how long the pending leader sequence remains armed.',
           keywords: ['leader', 'timeout', 'delay'],
-          targetId: leaderHintDurationTargetId
+          targetId: leaderHintDurationTargetId,
         },
         {
           id: 'vault-text-search-backend',
           title: 'Vault text search backend',
-          description: 'Auto prefers fzf when available, then ripgrep, and falls back to the built-in searcher.',
-          keywords: ['search', 'backend', 'ripgrep', 'rg', 'fzf', 'built-in']
+          description:
+            'Auto prefers fzf when available, then ripgrep, and falls back to the built-in searcher.',
+          keywords: ['search', 'backend', 'ripgrep', 'rg', 'fzf', 'built-in'],
         },
         {
           id: 'ripgrep-binary-path',
           title: 'ripgrep binary path',
           description: 'Optional. Leave blank to use `rg` from your PATH.',
-          keywords: ['search', 'rg', 'path']
+          keywords: ['search', 'rg', 'path'],
         },
         {
           id: 'fzf-binary-path',
           title: 'fzf binary path',
           description: 'Optional. Leave blank to use `fzf` from your PATH.',
-          keywords: ['search', 'path']
+          keywords: ['search', 'path'],
         },
         {
           id: 'live-preview',
           title: 'Live preview',
           description: 'Hide markdown syntax on lines you are not editing.',
-          keywords: ['preview', 'markdown']
+          keywords: ['preview', 'markdown'],
         },
         {
           id: 'note-tabs',
           title: 'Note tabs',
-          description: 'Open notes in tabs and allow split-friendly tab workflows.',
-          keywords: ['tabs']
+          description:
+            'Open notes in tabs and allow split-friendly tab workflows.',
+          keywords: ['tabs'],
         },
         {
           id: 'wrap-note-tabs',
           title: 'Wrap note tabs',
-          description: 'Move overflowing tabs onto additional rows instead of horizontal scrolling.',
-          keywords: ['tabs', 'wrap', 'new line', 'overflow']
+          description:
+            'Move overflowing tabs onto additional rows instead of horizontal scrolling.',
+          keywords: ['tabs', 'wrap', 'new line', 'overflow'],
         },
         {
           id: 'word-wrap',
           title: 'Word wrap',
-          description: 'Wrap long lines to the editor width. Turn off to scroll horizontally instead.',
-          keywords: ['wrap', 'line wrap']
+          description:
+            'Wrap long lines to the editor width. Turn off to scroll horizontally instead.',
+          keywords: ['wrap', 'line wrap'],
         },
         {
           id: 'smooth-preview-scroll',
           title: 'Smooth preview scroll',
-          description: 'Animate Ctrl+D / Ctrl+U half-page jumps in preview mode.',
-          keywords: ['preview', 'scroll']
+          description:
+            'Animate Ctrl+D / Ctrl+U half-page jumps in preview mode.',
+          keywords: ['preview', 'scroll'],
         },
         {
           id: 'pdfs-in-edit-mode',
           title: 'PDFs in edit mode',
-          description: 'Compact keeps the editor focused. Full inlines the PDF viewer under your cursor.',
-          keywords: ['pdf', 'embed']
+          description:
+            'Compact keeps the editor focused. Full inlines the PDF viewer under your cursor.',
+          keywords: ['pdf', 'embed'],
         },
         {
           id: 'date-titled-quick-notes',
           title: 'Date-titled Quick Notes',
-          description: 'New Quick Notes use YYYY-MM-DD instead of timestamp-style titles.',
-          keywords: ['quick note', 'date', 'title']
+          description:
+            'New Quick Notes use YYYY-MM-DD instead of timestamp-style titles.',
+          keywords: ['quick note', 'date', 'title'],
         },
         {
           id: 'quick-note-prefix',
           title: 'Quick Note prefix',
           description: 'Used when naming new Quick Notes.',
-          keywords: ['quick note', 'prefix']
+          keywords: ['quick note', 'prefix'],
         },
         {
           id: 'quick-capture-hotkey',
           title: 'Quick capture hotkey',
-          description: 'System-wide shortcut to open the floating capture window.',
-          keywords: ['quick capture', 'hotkey', 'shortcut']
-        }
+          description:
+            'System-wide shortcut to open the floating capture window.',
+          keywords: ['quick capture', 'hotkey', 'shortcut'],
+        },
       ],
       content: (
         <div className="space-y-6">
@@ -1005,9 +1114,11 @@ export function SettingsModal(): JSX.Element {
                       settingId="leader-hint-behavior"
                       options={[
                         { value: 'timed', label: 'Timed' },
-                        { value: 'sticky', label: 'Sticky' }
+                        { value: 'sticky', label: 'Sticky' },
                       ]}
-                      onChange={(next) => setWhichKeyHintMode(next as WhichKeyHintMode)}
+                      onChange={(next) =>
+                        setWhichKeyHintMode(next as WhichKeyHintMode)
+                      }
                     />
                     {whichKeyHintMode === 'timed' && (
                       <SliderRow
@@ -1045,9 +1156,13 @@ export function SettingsModal(): JSX.Element {
                 { value: 'auto', label: 'Auto' },
                 { value: 'builtin', label: 'Built-in' },
                 { value: 'ripgrep', label: 'ripgrep' },
-                { value: 'fzf', label: 'fzf' }
+                { value: 'fzf', label: 'fzf' },
               ]}
-              onChange={(next) => setVaultTextSearchBackend(next as VaultTextSearchBackendPreference)}
+              onChange={(next) =>
+                setVaultTextSearchBackend(
+                  next as VaultTextSearchBackendPreference,
+                )
+              }
             />
             <TextInputRow
               label="ripgrep binary path"
@@ -1066,11 +1181,12 @@ export function SettingsModal(): JSX.Element {
               onChange={(next) => setFzfBinaryPath(next)}
             />
             <InlineNote>
-              Runtime backend: {resolvedVaultTextSearchBackendLabel(resolvedVaultTextSearchBackend)}
+              Runtime backend:{' '}
+              {resolvedVaultTextSearchBackendLabel(
+                resolvedVaultTextSearchBackend,
+              )}
             </InlineNote>
-            <InlineNote>
-              {resolvedVaultTextSearchMessage}
-            </InlineNote>
+            <InlineNote>{resolvedVaultTextSearchMessage}</InlineNote>
             <InlineNote>
               {vaultTextSearchCapabilities == null
                 ? 'Checking configured search tools…'
@@ -1126,7 +1242,7 @@ export function SettingsModal(): JSX.Element {
               settingId="pdfs-in-edit-mode"
               options={[
                 { value: 'compact', label: 'Compact' },
-                { value: 'full', label: 'Full' }
+                { value: 'full', label: 'Full' },
               ]}
               onChange={(next) => setPdfEmbedInEditMode(next)}
             />
@@ -1154,7 +1270,7 @@ export function SettingsModal(): JSX.Element {
             <QuickCaptureHotkeyRow settingId="quick-capture-hotkey" />
           </Section>
         </div>
-      )
+      ),
     },
     {
       id: 'keymaps',
@@ -1165,12 +1281,23 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'shortcut-editor',
           title: 'Shortcut editor',
-          description: 'Record a new key or sequence for the app’s keyboard-first actions.',
-          keywords: ['shortcuts', 'bindings', 'leader', 'vim', 'remap', 'keyboard']
-        }
+          description:
+            'Record a new key or sequence for the app’s keyboard-first actions.',
+          keywords: [
+            'shortcuts',
+            'bindings',
+            'leader',
+            'vim',
+            'remap',
+            'keyboard',
+          ],
+        },
       ],
       content: (
-        <div className="h-full" {...settingsSearchTargetProps('shortcut-editor')}>
+        <div
+          className="h-full"
+          {...settingsSearchTargetProps('shortcut-editor')}
+        >
           <KeymapSettings
             vimMode={vimMode}
             overrides={keymapOverrides}
@@ -1178,68 +1305,78 @@ export function SettingsModal(): JSX.Element {
             onResetAll={resetAllKeymaps}
           />
         </div>
-      )
+      ),
     },
     {
       id: 'typography',
       title: 'Typography',
-      description: 'Fonts, line height, reading width, alignment, and line numbers.',
-      keywords: ['font', 'size', 'line height', 'width', 'alignment', 'numbers'],
+      description:
+        'Fonts, line height, reading width, alignment, and line numbers.',
+      keywords: [
+        'font',
+        'size',
+        'line height',
+        'width',
+        'alignment',
+        'numbers',
+      ],
       searchItems: [
         {
           id: 'interface-font',
           title: 'Interface font',
           description: 'Used for the sidebar, menus, and window chrome.',
-          keywords: ['font']
+          keywords: ['font'],
         },
         {
           id: 'text-font',
           title: 'Text font',
           description: 'Used for editing and reading views.',
-          keywords: ['font']
+          keywords: ['font'],
         },
         {
           id: 'monospace-font',
           title: 'Monospace font',
           description: 'Used for code blocks, inline code, and frontmatter.',
-          keywords: ['font', 'mono', 'code']
+          keywords: ['font', 'mono', 'code'],
         },
         {
           id: 'font-size',
           title: 'Font size',
           description: 'Editor and preview text size.',
-          keywords: ['size']
+          keywords: ['size'],
         },
         {
           id: 'line-height',
           title: 'Line height',
           description: 'Editor and preview line spacing.',
-          keywords: ['spacing']
+          keywords: ['spacing'],
         },
         {
           id: 'reading-width',
           title: 'Reading width',
           description: 'Maximum width for preview and split-preview content.',
-          keywords: ['width', 'preview']
+          keywords: ['width', 'preview'],
         },
         {
           id: 'editor-width',
           title: 'Editor width',
-          description: 'Caps and centers the editor column so lines do not stretch edge-to-edge on large windows.',
-          keywords: ['width']
+          description:
+            'Caps and centers the editor column so lines do not stretch edge-to-edge on large windows.',
+          keywords: ['width'],
         },
         {
           id: 'content-alignment',
           title: 'Content alignment',
-          description: 'Center note content within the column or left-align it to the pane edge.',
-          keywords: ['alignment', 'center', 'left']
+          description:
+            'Center note content within the column or left-align it to the pane edge.',
+          keywords: ['alignment', 'center', 'left'],
         },
         {
           id: 'line-numbers',
           title: 'Line numbers',
           description: 'Show editor gutter numbers.',
-          keywords: ['numbers', 'gutter', 'relative', 'absolute']
-        }
+          keywords: ['numbers', 'gutter', 'relative', 'absolute'],
+        },
       ],
       content: (
         <div className="space-y-6">
@@ -1328,7 +1465,7 @@ export function SettingsModal(): JSX.Element {
               settingId="content-alignment"
               options={[
                 { value: 'center', label: 'Center' },
-                { value: 'left', label: 'Left' }
+                { value: 'left', label: 'Left' },
               ]}
               onChange={(next) => setContentAlign(next)}
             />
@@ -1340,13 +1477,13 @@ export function SettingsModal(): JSX.Element {
               options={[
                 { value: 'off', label: 'Off' },
                 { value: 'absolute', label: 'Absolute' },
-                { value: 'relative', label: 'Relative' }
+                { value: 'relative', label: 'Relative' },
               ]}
               onChange={(next) => setLineNumberMode(next)}
             />
           </Section>
         </div>
-      )
+      ),
     },
     {
       id: 'vault',
@@ -1357,112 +1494,126 @@ export function SettingsModal(): JSX.Element {
         {
           id: 'vault-location',
           title: 'Vault location',
-          description: 'ZenNotes reads markdown directly from the selected vault folder.',
-          keywords: ['folder', 'root', 'location', 'open vault', 'change']
+          description:
+            'ZenNotes reads markdown directly from the selected vault folder.',
+          keywords: ['folder', 'root', 'location', 'open vault', 'change'],
         },
         {
           id: 'saved-remote-workspaces',
           title: 'Saved Remote Workspaces',
-          description: 'Keep multiple ZenNotes servers and vaults ready to reconnect.',
+          description:
+            'Keep multiple ZenNotes servers and vaults ready to reconnect.',
           keywords: ['remote', 'server', 'workspace', 'connect'],
-          available: supportsRemoteWorkspace
+          available: supportsRemoteWorkspace,
         },
         {
           id: 'primary-notes-location',
           title: 'Primary notes location',
-          description: 'Choose whether ZenNotes treats `inbox/` as the main notes area or uses the vault root directly.',
-          keywords: ['primary notes', 'inbox', 'vault root']
+          description:
+            'Choose whether ZenNotes treats `inbox/` as the main notes area or uses the vault root directly.',
+          keywords: ['primary notes', 'inbox', 'vault root'],
         },
         {
           id: 'enable-daily-notes',
           title: 'Enable daily notes',
-          description: 'Adds a dedicated daily-notes workflow without changing ordinary note creation.',
-          keywords: ['daily notes']
+          description:
+            'Adds a dedicated daily-notes workflow without changing ordinary note creation.',
+          keywords: ['daily notes'],
         },
         {
           id: 'daily-notes-directory',
           title: 'Daily notes directory',
           description: 'Stored inside your primary notes area.',
-          keywords: ['daily notes', 'directory', 'folder']
+          keywords: ['daily notes', 'directory', 'folder'],
         },
         {
           id: 'open-todays-daily-note',
           title: "Open today's daily note",
           description: "Opens today's note if it exists, otherwise creates it.",
-          keywords: ['daily notes', 'today']
+          keywords: ['daily notes', 'today'],
         },
         {
           id: 'daily-notes-template',
           title: 'Daily note template',
           description: 'Template applied when a daily note is created.',
-          keywords: ['daily notes', 'template']
+          keywords: ['daily notes', 'template'],
         },
         {
           id: 'enable-weekly-notes',
           title: 'Enable weekly notes',
-          description: 'Adds a dedicated weekly-notes workflow alongside daily notes.',
-          keywords: ['weekly notes']
+          description:
+            'Adds a dedicated weekly-notes workflow alongside daily notes.',
+          keywords: ['weekly notes'],
         },
         {
           id: 'weekly-notes-directory',
           title: 'Weekly notes directory',
           description: 'Stored inside your primary notes area.',
-          keywords: ['weekly notes', 'directory', 'folder']
+          keywords: ['weekly notes', 'directory', 'folder'],
         },
         {
           id: 'weekly-notes-template',
           title: 'Weekly note template',
           description: 'Template applied when a weekly note is created.',
-          keywords: ['weekly notes', 'template']
+          keywords: ['weekly notes', 'template'],
         },
         {
           id: 'open-this-week-note',
           title: "Open this week's note",
-          description: "Opens this week's note if it exists, otherwise creates it.",
-          keywords: ['weekly notes', 'this week']
+          description:
+            "Opens this week's note if it exists, otherwise creates it.",
+          keywords: ['weekly notes', 'this week'],
         },
         {
           id: 'auto-calendar-panel',
           title: 'Show calendar in daily & weekly notes',
-          description: 'Auto-open a calendar panel on the right while viewing a daily or weekly note.',
-          keywords: ['calendar', 'daily notes', 'weekly notes', 'date', 'navigate']
+          description:
+            'Auto-open a calendar panel on the right while viewing a daily or weekly note.',
+          keywords: [
+            'calendar',
+            'daily notes',
+            'weekly notes',
+            'date',
+            'navigate',
+          ],
         },
         {
           id: 'calendar-week-start',
           title: 'Calendar starts week on',
           description: 'Which weekday the calendar grid begins with.',
-          keywords: ['calendar', 'week start', 'monday', 'sunday', 'locale']
+          keywords: ['calendar', 'week start', 'monday', 'sunday', 'locale'],
         },
         {
           id: 'calendar-week-numbers',
           title: 'Show week numbers',
           description: 'Display the ISO week-number column in the calendar.',
-          keywords: ['calendar', 'week numbers', 'iso week', 'weekly notes']
+          keywords: ['calendar', 'week numbers', 'iso week', 'weekly notes'],
         },
         {
           id: 'inbox-label',
           title: 'Inbox label',
-          description: 'Shown in the sidebar, breadcrumbs, commands, and note actions.',
-          keywords: ['system folders', 'folder label']
+          description:
+            'Shown in the sidebar, breadcrumbs, commands, and note actions.',
+          keywords: ['system folders', 'folder label'],
         },
         {
           id: 'quick-notes-label',
           title: 'Quick Notes label',
           description: 'Display name for the quick-capture area.',
-          keywords: ['system folders', 'folder label', 'quick']
+          keywords: ['system folders', 'folder label', 'quick'],
         },
         {
           id: 'archive-label',
           title: 'Archive label',
           description: 'Display name for cold-storage notes.',
-          keywords: ['system folders', 'folder label']
+          keywords: ['system folders', 'folder label'],
         },
         {
           id: 'trash-label',
           title: 'Trash label',
           description: 'Display name for deleted-note recovery.',
-          keywords: ['system folders', 'folder label']
-        }
+          keywords: ['system folders', 'folder label'],
+        },
       ],
       content: (
         <div className="space-y-6">
@@ -1476,7 +1627,9 @@ export function SettingsModal(): JSX.Element {
             >
               <div className="min-w-0">
                 <div className="text-sm font-medium text-ink-900">
-                  {workspaceMode === 'remote' ? 'Remote workspace' : 'Vault location'}
+                  {workspaceMode === 'remote'
+                    ? 'Remote workspace'
+                    : 'Vault location'}
                 </div>
                 <div className="mt-1 truncate text-xs text-ink-500">
                   {vault?.root ?? 'No vault selected'}
@@ -1495,7 +1648,9 @@ export function SettingsModal(): JSX.Element {
                 }
                 className="shrink-0 rounded-xl border border-paper-300/70 bg-paper-100/80 px-3.5 py-2 text-xs font-medium text-ink-800 transition-colors hover:bg-paper-200"
               >
-                {workspaceMode === 'remote' ? 'Change Remote Vault…' : 'Change…'}
+                {workspaceMode === 'remote'
+                  ? 'Change Remote Vault…'
+                  : 'Change…'}
               </button>
               {workspaceMode === 'remote' && (
                 <button
@@ -1533,7 +1688,8 @@ export function SettingsModal(): JSX.Element {
               <div className="space-y-3 px-5 py-5">
                 <div className="flex items-center justify-between gap-4">
                   <div className="text-xs text-ink-500">
-                    Saved connections can point at different servers or different vaults on the same server.
+                    Saved connections can point at different servers or
+                    different vaults on the same server.
                   </div>
                   <button
                     type="button"
@@ -1545,7 +1701,11 @@ export function SettingsModal(): JSX.Element {
                 </div>
                 {remoteWorkspaceProfiles.length === 0 ? (
                   <div className="rounded-xl border border-paper-300/60 bg-paper-50/60 px-4 py-4 text-sm text-ink-500">
-                    No saved remote workspaces yet. Use <span className="font-medium text-ink-700">Quick Connect…</span> once and ZenNotes will remember it here.
+                    No saved remote workspaces yet. Use{' '}
+                    <span className="font-medium text-ink-700">
+                      Quick Connect…
+                    </span>{' '}
+                    once and ZenNotes will remember it here.
                   </div>
                 ) : (
                   <div className="space-y-3">
@@ -1567,16 +1727,22 @@ export function SettingsModal(): JSX.Element {
                                 </span>
                               )}
                             </div>
-                            <div className="mt-1 truncate text-xs text-ink-500">{profile.baseUrl}</div>
+                            <div className="mt-1 truncate text-xs text-ink-500">
+                              {profile.baseUrl}
+                            </div>
                             <div className="mt-1 truncate text-xs text-ink-400">
-                              {profile.vaultPath ? profile.vaultPath : 'Vault picked when connecting'}
+                              {profile.vaultPath
+                                ? profile.vaultPath
+                                : 'Vault picked when connecting'}
                             </div>
                           </div>
                           <div className="flex shrink-0 items-center gap-2">
                             {!isCurrent && (
                               <button
                                 type="button"
-                                onClick={() => void connectRemoteWorkspaceProfile(profile.id)}
+                                onClick={() =>
+                                  void connectRemoteWorkspaceProfile(profile.id)
+                                }
                                 className="rounded-xl border border-paper-300/70 bg-paper-100/80 px-3 py-2 text-xs font-medium text-ink-800 transition-colors hover:bg-paper-200"
                               >
                                 Connect
@@ -1617,12 +1783,12 @@ export function SettingsModal(): JSX.Element {
               settingId="primary-notes-location"
               options={[
                 { value: 'inbox', label: 'Inbox' },
-                { value: 'root', label: 'Vault root' }
+                { value: 'root', label: 'Vault root' },
               ]}
               onChange={(primaryNotesLocation) =>
                 void persistVaultSettings({
                   ...vaultSettings,
-                  primaryNotesLocation
+                  primaryNotesLocation,
                 })
               }
             />
@@ -1642,8 +1808,8 @@ export function SettingsModal(): JSX.Element {
                   ...vaultSettings,
                   dailyNotes: {
                     ...vaultSettings.dailyNotes,
-                    enabled
-                  }
+                    enabled,
+                  },
                 })
               }
             />
@@ -1658,8 +1824,8 @@ export function SettingsModal(): JSX.Element {
                   ...vaultSettings,
                   dailyNotes: {
                     ...vaultSettings.dailyNotes,
-                    directory: normalizeDailyNotesDirectory(next)
-                  }
+                    directory: normalizeDailyNotesDirectory(next),
+                  },
                 })
               }
             />
@@ -1672,7 +1838,7 @@ export function SettingsModal(): JSX.Element {
               onChange={(templateId) =>
                 void persistVaultSettings({
                   ...vaultSettings,
-                  dailyNotes: { ...vaultSettings.dailyNotes, templateId }
+                  dailyNotes: { ...vaultSettings.dailyNotes, templateId },
                 })
               }
             />
@@ -1681,9 +1847,12 @@ export function SettingsModal(): JSX.Element {
               {...settingsSearchTargetProps('open-todays-daily-note')}
             >
               <div className="min-w-0">
-                <div className="text-sm font-medium text-ink-900">Open today's daily note</div>
+                <div className="text-sm font-medium text-ink-900">
+                  Open today's daily note
+                </div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
-                  Opens today's note if it exists, otherwise creates it with a YYYY-MM-DD title.
+                  Opens today's note if it exists, otherwise creates it with a
+                  YYYY-MM-DD title.
                 </div>
               </div>
               <button
@@ -1694,7 +1863,7 @@ export function SettingsModal(): JSX.Element {
                   'shrink-0 rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors',
                   vaultSettings.dailyNotes.enabled
                     ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
+                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
                 ].join(' ')}
               >
                 Open today
@@ -1716,8 +1885,8 @@ export function SettingsModal(): JSX.Element {
                   ...vaultSettings,
                   weeklyNotes: {
                     ...vaultSettings.weeklyNotes,
-                    enabled
-                  }
+                    enabled,
+                  },
                 })
               }
             />
@@ -1732,8 +1901,8 @@ export function SettingsModal(): JSX.Element {
                   ...vaultSettings,
                   weeklyNotes: {
                     ...vaultSettings.weeklyNotes,
-                    directory: normalizeWeeklyNotesDirectory(next)
-                  }
+                    directory: normalizeWeeklyNotesDirectory(next),
+                  },
                 })
               }
             />
@@ -1746,7 +1915,7 @@ export function SettingsModal(): JSX.Element {
               onChange={(templateId) =>
                 void persistVaultSettings({
                   ...vaultSettings,
-                  weeklyNotes: { ...vaultSettings.weeklyNotes, templateId }
+                  weeklyNotes: { ...vaultSettings.weeklyNotes, templateId },
                 })
               }
             />
@@ -1755,9 +1924,12 @@ export function SettingsModal(): JSX.Element {
               {...settingsSearchTargetProps('open-this-week-note')}
             >
               <div className="min-w-0">
-                <div className="text-sm font-medium text-ink-900">Open this week's note</div>
+                <div className="text-sm font-medium text-ink-900">
+                  Open this week's note
+                </div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
-                  Opens this week's note if it exists, otherwise creates it with a YYYY-Www title.
+                  Opens this week's note if it exists, otherwise creates it with
+                  a YYYY-Www title.
                 </div>
               </div>
               <button
@@ -1768,7 +1940,7 @@ export function SettingsModal(): JSX.Element {
                   'shrink-0 rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors',
                   vaultSettings.weeklyNotes.enabled
                     ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
+                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
                 ].join(' ')}
               >
                 Open this week
@@ -1789,7 +1961,7 @@ export function SettingsModal(): JSX.Element {
               options={[
                 { value: 'monday', label: 'Monday' },
                 { value: 'sunday', label: 'Sunday' },
-                { value: 'locale', label: 'Locale' }
+                { value: 'locale', label: 'Locale' },
               ]}
               onChange={setCalendarWeekStart}
             />
@@ -1839,11 +2011,15 @@ export function SettingsModal(): JSX.Element {
               onChange={(next) => setSystemFolderLabel('trash', next)}
             />
             <InlineNote>
-              Current labels: {getSystemFolderLabel('quick', systemFolderLabels)}, {getSystemFolderLabel('inbox', systemFolderLabels)}, {getSystemFolderLabel('archive', systemFolderLabels)}, and {getSystemFolderLabel('trash', systemFolderLabels)}.
+              Current labels:{' '}
+              {getSystemFolderLabel('quick', systemFolderLabels)},{' '}
+              {getSystemFolderLabel('inbox', systemFolderLabels)},{' '}
+              {getSystemFolderLabel('archive', systemFolderLabels)}, and{' '}
+              {getSystemFolderLabel('trash', systemFolderLabels)}.
             </InlineNote>
           </Section>
         </div>
-      )
+      ),
     },
     {
       id: 'templates',
@@ -1861,22 +2037,22 @@ export function SettingsModal(): JSX.Element {
         'journal',
         'custom',
         'scaffold',
-        'boilerplate'
+        'boilerplate',
       ],
       searchItems: [
         {
           id: 'templates-list',
           title: 'Template library',
           description: 'Browse built-in templates and manage your custom ones.',
-          keywords: ['templates', 'library', 'built-in', 'custom']
+          keywords: ['templates', 'library', 'built-in', 'custom'],
         },
         {
           id: 'templates-new',
           title: 'Create a custom template',
           description: 'Author a new template stored in .zennotes/templates.',
           keywords: ['template', 'new', 'create', 'custom'],
-          available: supportsCustomTemplates
-        }
+          available: supportsCustomTemplates,
+        },
       ],
       content: (
         <div className="space-y-6">
@@ -1891,7 +2067,9 @@ export function SettingsModal(): JSX.Element {
                 {...settingsSearchTargetProps('templates-new')}
               >
                 <div className="min-w-0">
-                  <div className="text-sm font-medium text-ink-900">Create a custom template</div>
+                  <div className="text-sm font-medium text-ink-900">
+                    Create a custom template
+                  </div>
                   <div className="mt-1 text-xs leading-5 text-ink-500">
                     Stored as a markdown file in `.zennotes/templates`.
                   </div>
@@ -1907,13 +2085,16 @@ export function SettingsModal(): JSX.Element {
               </div>
             ) : (
               <InlineNote>
-                Custom templates require a local vault. Built-in templates still work here.
+                Custom templates require a local vault. Built-in templates still
+                work here.
               </InlineNote>
             )}
             <div className="flex items-center justify-between gap-4 border-t border-paper-300/40 px-5 py-4">
               <div className="min-w-0">
                 <div className="text-sm font-medium text-ink-900">
-                  {hideBuiltinTemplates ? 'Built-in templates are hidden' : 'Built-in templates'}
+                  {hideBuiltinTemplates
+                    ? 'Built-in templates are hidden'
+                    : 'Built-in templates'}
                 </div>
                 <div className="mt-1 text-xs leading-5 text-ink-500">
                   {hideBuiltinTemplates
@@ -1927,7 +2108,9 @@ export function SettingsModal(): JSX.Element {
                 onClick={() => void toggleBuiltinTemplates()}
                 className="shrink-0"
               >
-                {hideBuiltinTemplates ? 'Restore built-in templates' : 'Remove built-in templates'}
+                {hideBuiltinTemplates
+                  ? 'Restore built-in templates'
+                  : 'Remove built-in templates'}
               </Button>
             </div>
             {allTemplates.map((template) => (
@@ -1936,7 +2119,9 @@ export function SettingsModal(): JSX.Element {
                 className="flex items-center justify-between gap-4 px-5 py-3"
               >
                 <div className="min-w-0">
-                  <div className="text-sm font-medium text-ink-900">{template.name}</div>
+                  <div className="text-sm font-medium text-ink-900">
+                    {template.name}
+                  </div>
                   <div className="mt-0.5 truncate text-xs text-ink-500">
                     {template.category}
                     {template.description ? ` — ${template.description}` : ''}
@@ -1953,40 +2138,40 @@ export function SettingsModal(): JSX.Element {
                       Customized
                     </span>
                   )}
-                  {template.builtin
-                    ? supportsCustomTemplates && (
-                        <button
-                          type="button"
-                          onClick={() => editBuiltinTemplate(template)}
-                          className="rounded-lg border border-paper-300/70 bg-paper-100/80 px-3 py-1.5 text-xs font-medium text-ink-800 hover:bg-paper-200"
-                        >
-                          Edit
-                        </button>
-                      )
-                    : (
-                      <>
-                        <button
-                          type="button"
-                          onClick={() => void openTemplateEditor(template)}
-                          className="rounded-lg border border-paper-300/70 bg-paper-100/80 px-3 py-1.5 text-xs font-medium text-ink-800 hover:bg-paper-200"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => void removeTemplate(template)}
-                          className="rounded-lg border border-red-500/30 bg-paper-100/80 px-3 py-1.5 text-xs font-medium text-[rgb(var(--z-red))] hover:bg-red-500/10"
-                        >
-                          {template.builtinId ? 'Reset' : 'Delete'}
-                        </button>
-                      </>
-                    )}
+                  {template.builtin ? (
+                    supportsCustomTemplates && (
+                      <button
+                        type="button"
+                        onClick={() => editBuiltinTemplate(template)}
+                        className="rounded-lg border border-paper-300/70 bg-paper-100/80 px-3 py-1.5 text-xs font-medium text-ink-800 hover:bg-paper-200"
+                      >
+                        Edit
+                      </button>
+                    )
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => void openTemplateEditor(template)}
+                        className="rounded-lg border border-paper-300/70 bg-paper-100/80 px-3 py-1.5 text-xs font-medium text-ink-800 hover:bg-paper-200"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void removeTemplate(template)}
+                        className="rounded-lg border border-red-500/30 bg-paper-100/80 px-3 py-1.5 text-xs font-medium text-[rgb(var(--z-red))] hover:bg-red-500/10"
+                      >
+                        {template.builtinId ? 'Reset' : 'Delete'}
+                      </button>
+                    </>
+                  )}
                 </div>
               </div>
             ))}
           </Section>
         </div>
-      )
+      ),
     },
     {
       id: 'mcp',
@@ -2003,29 +2188,38 @@ export function SettingsModal(): JSX.Element {
         'openai',
         'integration',
         'agent',
-        'model context protocol'
+        'model context protocol',
       ],
       searchItems: [
         {
           id: 'mcp-server',
           title: 'MCP server',
-          description: 'ZenNotes bundles a local MCP server that connected clients use.',
-          keywords: ['mcp', 'server', 'runtime', 'command']
+          description:
+            'ZenNotes bundles a local MCP server that connected clients use.',
+          keywords: ['mcp', 'server', 'runtime', 'command'],
         },
         {
           id: 'mcp-integrations',
           title: 'MCP integrations',
           description: 'Pick the clients you want connected to this vault.',
-          keywords: ['mcp', 'claude', 'codex', 'client', 'install', 'uninstall']
+          keywords: [
+            'mcp',
+            'claude',
+            'codex',
+            'client',
+            'install',
+            'uninstall',
+          ],
         },
         {
           id: 'mcp-instructions',
           title: 'MCP instructions',
-          description: 'Edit the system prompt ZenNotes ships to any connected MCP client.',
-          keywords: ['mcp', 'prompt', 'instructions', 'system prompt']
-        }
+          description:
+            'Edit the system prompt ZenNotes ships to any connected MCP client.',
+          keywords: ['mcp', 'prompt', 'instructions', 'system prompt'],
+        },
       ],
-      content: <McpSettings />
+      content: <McpSettings />,
     },
     {
       id: 'cli',
@@ -2044,54 +2238,65 @@ export function SettingsModal(): JSX.Element {
         'automation',
         'pipe',
         'capture',
-        'developer'
+        'developer',
       ],
       searchItems: [
         {
           id: 'zen-command-line-tool',
           title: 'zen command-line tool',
-          description: 'Install the `zen` shell command for terminal-based note workflows.',
-          keywords: ['cli', 'command line', 'terminal', 'shell', 'zen', 'install', 'path']
+          description:
+            'Install the `zen` shell command for terminal-based note workflows.',
+          keywords: [
+            'cli',
+            'command line',
+            'terminal',
+            'shell',
+            'zen',
+            'install',
+            'path',
+          ],
         },
         {
           id: 'cli-quick-reference',
           title: 'CLI quick reference',
           description: 'A handful of the most useful `zen` commands.',
-          keywords: ['cli', 'help', 'commands', 'reference']
+          keywords: ['cli', 'help', 'commands', 'reference'],
         },
         {
           id: 'raycast-extension',
           title: 'Raycast Extension',
-          description: 'Install the ZenNotes Raycast extension locally from this app.',
-          keywords: ['raycast', 'launcher', 'extension', 'install']
-        }
+          description:
+            'Install the ZenNotes Raycast extension locally from this app.',
+          keywords: ['raycast', 'launcher', 'extension', 'install'],
+        },
       ],
-      content: <CliSettings />
+      content: <CliSettings />,
     },
     {
       id: 'about',
       title: 'About',
-      description: 'App identity, version, updater status, and company information.',
+      description:
+        'App identity, version, updater status, and company information.',
       keywords: ['version', 'company', 'lumary', 'about', 'logo', 'updates'],
       searchItems: [
         {
           id: 'zen-notes-version',
           title: 'ZenNotes version',
           description: 'App identity, current version, and product details.',
-          keywords: ['about', 'version', 'identity']
+          keywords: ['about', 'version', 'identity'],
         },
         {
           id: 'updates',
           title: 'Updates',
           description: 'Check GitHub releases for a newer ZenNotes build.',
-          keywords: ['release', 'download', 'install', 'updater']
+          keywords: ['release', 'download', 'install', 'updater'],
         },
         {
           id: 'lumary-labs',
           title: 'Lumary Labs',
           description: 'Company and product details.',
-          keywords: ['company', 'lumary', 'logo']
-        }
+          keywords: ['company', 'lumary', 'logo'],
+        },
       ],
       content: (
         <Section title="ZenNotes" settingId="zen-notes-version">
@@ -2114,10 +2319,14 @@ export function SettingsModal(): JSX.Element {
                       <span
                         className={[
                           'rounded-full border px-2.5 py-1 text-xs font-medium',
-                          updatePhaseBadgeClass(appUpdateState?.phase ?? 'idle')
+                          updatePhaseBadgeClass(
+                            appUpdateState?.phase ?? 'idle',
+                          ),
                         ].join(' ')}
                       >
-                        {formatUpdatePhaseLabel(appUpdateState?.phase ?? 'idle')}
+                        {formatUpdatePhaseLabel(
+                          appUpdateState?.phase ?? 'idle',
+                        )}
                       </span>
                       {appUpdateState?.availableVersion && (
                         <span className="text-xs text-ink-500">
@@ -2153,14 +2362,17 @@ export function SettingsModal(): JSX.Element {
                           appUpdateState?.phase === 'checking' ||
                           appUpdateState?.phase === 'downloading'
                             ? 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-                            : 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
+                            : 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200',
                         ].join(' ')}
                       >
                         Check for Updates
                       </button>
                     )}
                     <a
-                      href={appInfo.homepage ?? 'https://github.com/ZenNotes/zennotes/releases/latest'}
+                      href={
+                        appInfo.homepage ??
+                        'https://github.com/ZenNotes/zennotes/releases/latest'
+                      }
                       target="_blank"
                       rel="noreferrer"
                       className="rounded-xl border border-paper-300/70 bg-paper-100/80 px-3.5 py-2 text-xs font-medium text-ink-700 transition-colors hover:bg-paper-200"
@@ -2170,25 +2382,34 @@ export function SettingsModal(): JSX.Element {
                   </div>
                 </div>
                 <p className="mt-3 text-sm leading-6 text-ink-600">
-                  {appUpdateState?.message ?? 'Check GitHub releases for a newer ZenNotes build.'}
+                  {appUpdateState?.message ??
+                    'Check GitHub releases for a newer ZenNotes build.'}
                 </p>
                 {appUpdateState?.phase === 'downloading' && (
                   <div className="mt-3">
                     <div className="h-2 overflow-hidden rounded-full bg-paper-200/90">
                       <div
                         className="h-full rounded-full bg-accent transition-[width] duration-200"
-                        style={{ width: `${Math.max(0, Math.min(100, appUpdateState.progressPercent ?? 0))}%` }}
+                        style={{
+                          width: `${Math.max(0, Math.min(100, appUpdateState.progressPercent ?? 0))}%`,
+                        }}
                       />
                     </div>
                     <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-500">
-                      <span>{Math.round(appUpdateState.progressPercent ?? 0)}%</span>
-                      {formatBytes(appUpdateState.transferredBytes) && formatBytes(appUpdateState.totalBytes) && (
-                        <span>
-                          {formatBytes(appUpdateState.transferredBytes)} / {formatBytes(appUpdateState.totalBytes)}
-                        </span>
-                      )}
+                      <span>
+                        {Math.round(appUpdateState.progressPercent ?? 0)}%
+                      </span>
+                      {formatBytes(appUpdateState.transferredBytes) &&
+                        formatBytes(appUpdateState.totalBytes) && (
+                          <span>
+                            {formatBytes(appUpdateState.transferredBytes)} /{' '}
+                            {formatBytes(appUpdateState.totalBytes)}
+                          </span>
+                        )}
                       {formatBytes(appUpdateState.bytesPerSecond) && (
-                        <span>{formatBytes(appUpdateState.bytesPerSecond)}/s</span>
+                        <span>
+                          {formatBytes(appUpdateState.bytesPerSecond)}/s
+                        </span>
                       )}
                     </div>
                   </div>
@@ -2204,7 +2425,8 @@ export function SettingsModal(): JSX.Element {
                   </details>
                 )}
                 <div className="mt-3 text-xs leading-5 text-ink-500">
-                  In-app updates use the published GitHub release feed. For general users, that feed must be publicly reachable.
+                  In-app updates use the published GitHub release feed. For
+                  general users, that feed must be publicly reachable.
                 </div>
               </div>
               <p className="mx-auto mt-2 max-w-[44rem] text-center">
@@ -2243,7 +2465,7 @@ export function SettingsModal(): JSX.Element {
                       WebkitMaskPosition: 'center',
                       maskPosition: 'center',
                       WebkitMaskSize: 'contain',
-                      maskSize: 'contain'
+                      maskSize: 'contain',
                     }}
                   />
                 </a>
@@ -2251,8 +2473,8 @@ export function SettingsModal(): JSX.Element {
             </div>
           </div>
         </Section>
-      )
-    }
+      ),
+    },
   ]
 
   const query = navQuery.trim().toLowerCase()
@@ -2262,9 +2484,7 @@ export function SettingsModal(): JSX.Element {
     searchResults.find((result) => result.category.id === activeCategory) ??
     searchResults[0] ??
     null
-  const visibleCategory =
-    visibleSearchResult?.category ??
-    null
+  const visibleCategory = visibleSearchResult?.category ?? null
 
   return (
     <>
@@ -2277,121 +2497,124 @@ export function SettingsModal(): JSX.Element {
           className="grid h-[min(92vh,980px)] w-[min(1120px,96vw)] grid-cols-[252px_minmax(0,1fr)] overflow-hidden rounded-3xl border border-paper-300/70 bg-paper-100 shadow-float"
           onClick={(e) => e.stopPropagation()}
         >
-        <aside className="flex min-h-0 flex-col border-r border-paper-300/60 bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.01))]">
-          <div className="border-b border-paper-300/55 px-4 py-4">
-            <div className="text-xs font-medium uppercase tracking-[0.22em] text-ink-500">
-              Settings
+          <aside className="flex min-h-0 flex-col border-r border-paper-300/60 bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.01))]">
+            <div className="border-b border-paper-300/55 px-4 py-4">
+              <div className="text-xs font-medium uppercase tracking-[0.22em] text-ink-500">
+                Settings
+              </div>
+              <div className="mt-3">
+                <label className="relative block">
+                  <input
+                    value={navQuery}
+                    onChange={(e) => setNavQuery(e.target.value)}
+                    placeholder="Search settings…"
+                    className="w-full rounded-xl border border-paper-300/70 bg-paper-50/75 px-3 py-2.5 pl-9 text-sm text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
+                  />
+                  <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-ink-400">
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <circle cx="11" cy="11" r="7" />
+                      <path d="m20 20-3.5-3.5" />
+                    </svg>
+                  </span>
+                </label>
+              </div>
             </div>
-            <div className="mt-3">
-              <label className="relative block">
-                <input
-                  value={navQuery}
-                  onChange={(e) => setNavQuery(e.target.value)}
-                  placeholder="Search settings…"
-                  className="w-full rounded-xl border border-paper-300/70 bg-paper-50/75 px-3 py-2.5 pl-9 text-sm text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
-                />
-                <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-ink-400">
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                  >
-                    <circle cx="11" cy="11" r="7" />
-                    <path d="m20 20-3.5-3.5" />
-                  </svg>
-                </span>
-              </label>
-            </div>
-          </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
-            <nav className="space-y-1">
-              {searchResults.map((result) => {
-                const selected = visibleSearchResult?.id === result.id
-                return (
-                  <button
-                    key={result.id}
-                    type="button"
-                    onClick={() => {
-                      setActiveCategory(result.category.id)
-                      setActiveSearchResultId(result.id)
-                      if (result.type === 'setting') {
-                        jumpToSettingsSearchTarget(result.targetId)
-                      }
-                    }}
-                    className={[
-                      'w-full rounded-xl px-3 py-2.5 text-left transition-colors',
-                      selected
-                        ? 'bg-paper-200/85 text-ink-900 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)]'
-                        : 'text-ink-600 hover:bg-paper-200/45 hover:text-ink-900'
-                    ].join(' ')}
-                  >
-                    <div className="flex min-w-0 items-center justify-between gap-2">
-                      <div className="truncate text-sm font-medium">{result.title}</div>
-                      {result.type === 'setting' && (
-                        <span className="shrink-0 rounded-full border border-paper-300/60 bg-paper-100/70 px-2 py-0.5 text-2xs font-medium text-ink-500">
-                          {result.category.title}
-                        </span>
-                      )}
-                    </div>
-                    <div className="mt-1 line-clamp-2 text-xs leading-5 text-ink-500">
-                      {result.description}
-                    </div>
-                  </button>
-                )
-              })}
-              {searchResults.length === 0 && (
-                <div className="rounded-xl border border-dashed border-paper-300/70 px-3 py-4 text-sm text-ink-500">
-                  No settings match your search.
+            <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+              <nav className="space-y-1">
+                {searchResults.map((result) => {
+                  const selected = visibleSearchResult?.id === result.id
+                  return (
+                    <button
+                      key={result.id}
+                      type="button"
+                      onClick={() => {
+                        setActiveCategory(result.category.id)
+                        setActiveSearchResultId(result.id)
+                        if (result.type === 'setting') {
+                          jumpToSettingsSearchTarget(result.targetId)
+                        }
+                      }}
+                      className={[
+                        'w-full rounded-xl px-3 py-2.5 text-left transition-colors',
+                        selected
+                          ? 'bg-paper-200/85 text-ink-900 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)]'
+                          : 'text-ink-600 hover:bg-paper-200/45 hover:text-ink-900',
+                      ].join(' ')}
+                    >
+                      <div className="flex min-w-0 items-center justify-between gap-2">
+                        <div className="truncate text-sm font-medium">
+                          {result.title}
+                        </div>
+                        {result.type === 'setting' && (
+                          <span className="shrink-0 rounded-full border border-paper-300/60 bg-paper-100/70 px-2 py-0.5 text-2xs font-medium text-ink-500">
+                            {result.category.title}
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1 line-clamp-2 text-xs leading-5 text-ink-500">
+                        {result.description}
+                      </div>
+                    </button>
+                  )
+                })}
+                {searchResults.length === 0 && (
+                  <div className="rounded-xl border border-dashed border-paper-300/70 px-3 py-4 text-sm text-ink-500">
+                    No settings match your search.
+                  </div>
+                )}
+              </nav>
+            </div>
+
+            <div className="border-t border-paper-300/55 px-4 py-3 text-xs leading-5 text-ink-500">
+              Settings save automatically on this device.
+            </div>
+          </aside>
+
+          <div className="flex min-h-0 flex-col">
+            <div className="flex items-start justify-between gap-4 border-b border-paper-300/60 px-7 py-5">
+              <div>
+                <div className="text-xs font-medium uppercase tracking-[0.22em] text-ink-500">
+                  {visibleCategory ? visibleCategory.title : 'Settings'}
+                </div>
+                <h2 className="mt-1 font-serif text-3xl font-semibold leading-tight text-ink-900">
+                  {visibleCategory?.title ?? 'Settings'}
+                </h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-ink-500">
+                  {visibleCategory?.description ??
+                    'Search the navigation on the left to jump to a settings section.'}
+                </p>
+              </div>
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={() => setSettingsOpen(false)}
+                className="shrink-0"
+              >
+                Done
+              </Button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-7 py-6">
+              {visibleCategory ? (
+                visibleCategory.content
+              ) : (
+                <div className="flex h-full min-h-[280px] items-center justify-center rounded-3xl border border-dashed border-paper-300/70 bg-paper-50/35 px-6 text-center text-sm leading-6 text-ink-500">
+                  Try a broader search term, or clear the search field to browse
+                  every settings section.
                 </div>
               )}
-            </nav>
-          </div>
-
-          <div className="border-t border-paper-300/55 px-4 py-3 text-xs leading-5 text-ink-500">
-            Settings save automatically on this device.
-          </div>
-        </aside>
-
-        <div className="flex min-h-0 flex-col">
-          <div className="flex items-start justify-between gap-4 border-b border-paper-300/60 px-7 py-5">
-            <div>
-              <div className="text-xs font-medium uppercase tracking-[0.22em] text-ink-500">
-                {visibleCategory ? visibleCategory.title : 'Settings'}
-              </div>
-              <h2 className="mt-1 font-serif text-3xl font-semibold leading-tight text-ink-900">
-                {visibleCategory?.title ?? 'Settings'}
-              </h2>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-ink-500">
-                {visibleCategory?.description ??
-                  'Search the navigation on the left to jump to a settings section.'}
-              </p>
             </div>
-            <Button
-              variant="secondary"
-              size="md"
-              onClick={() => setSettingsOpen(false)}
-              className="shrink-0"
-            >
-              Done
-            </Button>
-          </div>
-
-          <div className="min-h-0 flex-1 overflow-y-auto px-7 py-6">
-            {visibleCategory ? (
-              visibleCategory.content
-            ) : (
-              <div className="flex h-full min-h-[280px] items-center justify-center rounded-3xl border border-dashed border-paper-300/70 bg-paper-50/35 px-6 text-center text-sm leading-6 text-ink-500">
-                Try a broader search term, or clear the search field to browse every settings section.
-              </div>
-            )}
-          </div>
           </div>
         </div>
       </div>
@@ -2408,7 +2631,10 @@ export function SettingsModal(): JSX.Element {
                 : 'Save a ZenNotes server so you can reconnect without re-entering the details.',
             initialValue: editingRemoteProfile.value,
             hasStoredCredential: editingRemoteProfile.hasStoredCredential,
-            submitLabel: editingRemoteProfile.mode === 'edit' ? 'Save Changes' : 'Save Remote'
+            submitLabel:
+              editingRemoteProfile.mode === 'edit'
+                ? 'Save Changes'
+                : 'Save Remote',
           }}
           onSubmit={submitRemoteProfile}
           onCancel={() => setEditingRemoteProfile(null)}
@@ -2429,7 +2655,7 @@ function KeymapSettings({
   vimMode,
   overrides,
   onSetBinding,
-  onResetAll
+  onResetAll,
 }: {
   vimMode: boolean
   overrides: KeymapOverrides
@@ -2441,12 +2667,41 @@ function KeymapSettings({
   const [query, setQuery] = useState('')
   const [recording, setRecording] = useState<KeymapDefinition | null>(null)
 
+  const keymapDiagnostics = useMemo(
+    () => findConflictingKeymaps(overrides),
+    [overrides],
+  )
+
+  const vimMappingDiagnostics = useMemo(() => {
+    const leaderKey =
+      toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix')) ??
+      '<Space>'
+    const appSeqMap = getAppVimSequenceMap(overrides)
+    return diagnoseVimMappings(vimMappings, leaderKey, appSeqMap)
+  }, [vimMappings, overrides])
+
+  const vimrcOverriddenIds = useMemo(
+    () =>
+      new Set(
+        vimMappingDiagnostics.reduce<KeymapId[]>((acc, d) => {
+          if (d.kind === 'app-conflict' && d.keymapId)
+            acc.push(d.keymapId as KeymapId)
+          return acc
+        }, []),
+      ),
+    [vimMappingDiagnostics],
+  )
+
   const groups = useMemo(() => {
     const q = query.trim().toLowerCase()
     return getKeymapDefinitionsByGroup()
       .map((group) => {
         const items = group.items.filter((definition) => {
-          if (definition.vimOnly && !vimMode && definition.id !== 'global.searchNotesNonVim') {
+          if (
+            definition.vimOnly &&
+            !vimMode &&
+            definition.id !== 'global.searchNotesNonVim'
+          ) {
             // Keep Vim-only bindings visible so users can prep their layout
             // before turning Vim mode back on, but still let the filter work.
           }
@@ -2459,61 +2714,96 @@ function KeymapSettings({
         })
         return items.length > 0 ? { ...group, items } : null
       })
-      .filter((group): group is ReturnType<typeof getKeymapDefinitionsByGroup>[number] => !!group)
+      .filter(
+        (
+          group,
+        ): group is ReturnType<typeof getKeymapDefinitionsByGroup>[number] =>
+          !!group,
+      )
   }, [overrides, query, vimMode])
 
+  const totalConflicts = keymapDiagnostics.size + vimrcOverriddenIds.size
   const hasOverrides = Object.keys(overrides).length > 0
+  const hasConflicts = totalConflicts > 0
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="flex min-h-0 flex-1 flex-col rounded-3xl border border-paper-300/60 bg-paper-50/45 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
-        <div className="z-10 rounded-t-[22px] border-b border-paper-300/55 bg-paper-50/95 px-5 py-4 backdrop-blur flex flex-col gap-3">
-          <div className="min-w-0">
-            <div className="text-sm font-medium text-ink-900">.vimrc</div>
-            <div className="mt-1 text-xs leading-5 text-ink-500">
-              Extend custom key mappings using Vimscript syntax. Supports
-              noremap, map, and unmap across normal, visual, and insert modes.
-            </div>
+    <div className="flex h-full min-h-0 flex-col space-y-6">
+      <div className="z-10 rounded-[22px] border border-paper-300/55 bg-paper-50/95 px-5 py-4 backdrop-blur flex flex-col gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-ink-900">Vimrc</div>
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            Extend custom key mappings using Vimscript syntax, takes precedence
+            over vim keymaps. Supports noremap, map, and unmap across normal,
+            visual, and insert modes.
           </div>
-          <textarea
-            value={vimMappings}
-            onChange={(e) => setVimMappings(e.target.value)}
-            placeholder={'noremap L $\nnoremap H ^\n" comment'}
-            spellCheck={false}
-            className="h-40 w-full resize-none rounded-xl border border-paper-300/70 bg-paper-50/80 px-3.5 py-3 font-mono text-xs leading-5 text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
-          />
         </div>
+        <textarea
+          value={vimMappings}
+          onChange={(e) => setVimMappings(e.target.value)}
+          placeholder={'noremap L $\nnoremap H ^\n" comment'}
+          spellCheck={false}
+          className="h-40 w-full resize-none rounded-xl border border-paper-300/70 bg-paper-100/80 px-3.5 py-3 font-mono text-xs leading-5 text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
+        />
+        {vimMappingDiagnostics.length > 0 && (
+          <div className="flex flex-col">
+            <ul className="space-y-1">
+              {vimMappingDiagnostics.map((d, i) => (
+                <li key={i} className="flex gap-2 text-xs text-amber-500">
+                  <span className="shrink-0">
+                    Line {String(d.line).padStart(2, ' ')}:
+                  </span>
+                  <span>{d.message}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col rounded-3xl border border-paper-300/60 bg-paper-50/45 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
         <div className="sticky top-0 z-10 rounded-t-[22px] border-b border-paper-300/55 bg-paper-50/95 px-5 py-4 backdrop-blur">
           <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="min-w-0">
-            <div className="text-sm font-medium text-ink-900">Shortcut editor</div>
-            <div className="mt-1 text-xs leading-5 text-ink-500">
-              Record a new key or sequence for the app’s keyboard-first actions. Standard
-              accessibility fallbacks like arrows, Enter, and Escape still work.
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-ink-900 flex gap-x-2">
+                Shortcut editor
+                {hasConflicts && (
+                  <span
+                    className={[
+                      'rounded-full px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
+                      statusChipClass('warn'),
+                    ].join(' ')}
+                  >
+                    {totalConflicts} Conflict{totalConflicts > 0 ? 's' : ''}
+                  </span>
+                )}
+              </div>
+              <div className="mt-1 text-xs leading-5 text-ink-500">
+                Record a new key or sequence for the app’s keyboard-first
+                actions. Standard accessibility fallbacks like arrows, Enter,
+                and Escape still work.
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Filter keymaps…"
+                className="w-72 rounded-xl border border-paper-300/70 bg-paper-100/80 px-4 py-2.5 text-sm text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
+              />
+              <button
+                type="button"
+                disabled={!hasOverrides}
+                onClick={onResetAll}
+                className={[
+                  'rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors',
+                  hasOverrides
+                    ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
+                    : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
+                ].join(' ')}
+              >
+                Reset all
+              </button>
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Filter keymaps…"
-              className="w-72 rounded-xl border border-paper-300/70 bg-paper-100/80 px-4 py-2.5 text-sm text-ink-900 outline-none placeholder:text-ink-400 focus:border-accent/45"
-            />
-            <button
-              type="button"
-              disabled={!hasOverrides}
-              onClick={onResetAll}
-              className={[
-                'rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors',
-                hasOverrides
-                  ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-              ].join(' ')}
-            >
-              Reset all
-            </button>
-          </div>
-        </div>
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto divide-y divide-paper-300/45">
@@ -2549,8 +2839,30 @@ function KeymapSettings({
                               Custom
                             </span>
                           )}
+                          {keymapDiagnostics.has(definition.id) && (
+                            <span
+                              className={[
+                                'rounded-full px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
+                                statusChipClass('warn'),
+                              ].join(' ')}
+                            >
+                              Conflict
+                            </span>
+                          )}
+                          {vimrcOverriddenIds.has(definition.id) && (
+                            <span
+                              className={[
+                                'rounded-full px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
+                                statusChipClass('warn'),
+                              ].join(' ')}
+                            >
+                              vimrc
+                            </span>
+                          )}
                         </div>
-                        <div className="mt-1 text-xs leading-5 text-ink-500">{definition.description}</div>
+                        <div className="mt-1 text-xs leading-5 text-ink-500">
+                          {definition.description}
+                        </div>
                       </div>
                       <div className="flex shrink-0 items-center gap-2">
                         <span className="rounded-xl border border-paper-300/70 bg-paper-100/85 px-3 py-1.5 text-xs font-medium text-ink-900">
@@ -2571,7 +2883,7 @@ function KeymapSettings({
                             'rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors',
                             custom
                               ? 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200'
-                              : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
+                              : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
                           ].join(' ')}
                         >
                           Reset
@@ -2597,7 +2909,10 @@ function KeymapSettings({
           currentBinding={getKeymapBinding(overrides, recording.id)}
           onClose={() => setRecording(null)}
           onSave={(binding) => {
-            onSetBinding(recording.id, binding === recording.defaultBinding ? null : binding)
+            onSetBinding(
+              recording.id,
+              binding === recording.defaultBinding ? null : binding,
+            )
             setRecording(null)
           }}
         />
@@ -2610,7 +2925,7 @@ function KeymapRecorderModal({
   definition,
   currentBinding,
   onClose,
-  onSave
+  onSave,
 }: {
   definition: KeymapDefinition
   currentBinding: string
@@ -2623,7 +2938,11 @@ function KeymapRecorderModal({
   useEffect(() => {
     const onKey = (event: KeyboardEvent): void => {
       const target = event.target as HTMLElement | null
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return
+      if (
+        target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')
+      )
+        return
       const key = event.key
       if (key === 'Backspace' || key === 'Delete') {
         event.preventDefault()
@@ -2675,15 +2994,21 @@ function KeymapRecorderModal({
     <div className="fixed inset-0 z-toast flex items-center justify-center bg-black/35 px-4 backdrop-blur-sm">
       <div className="w-[min(440px,92vw)] overflow-hidden rounded-2xl border border-paper-300/70 bg-paper-100 shadow-float">
         <div className="border-b border-paper-300/60 px-5 py-4">
-          <div className="text-base font-semibold text-ink-900">{definition.title}</div>
-          <div className="mt-1 text-sm text-ink-500">{definition.description}</div>
+          <div className="text-base font-semibold text-ink-900">
+            {definition.title}
+          </div>
+          <div className="mt-1 text-sm text-ink-500">
+            {definition.description}
+          </div>
         </div>
         <div className="px-5 py-4">
           <div className="rounded-xl border border-paper-300/70 bg-paper-50/80 px-4 py-4">
             <div className="text-xs font-medium uppercase tracking-[0.16em] text-ink-500">
               Recording
             </div>
-            <div className="mt-2 text-2xl font-semibold text-ink-900">{display}</div>
+            <div className="mt-2 text-2xl font-semibold text-ink-900">
+              {display}
+            </div>
             <div className="mt-2 text-xs leading-5 text-ink-500">
               {definition.kind === 'shortcut'
                 ? `Press the shortcut you want. ${mac ? 'Command' : 'Ctrl'}-style chords are saved in the app’s cross-platform format.`
@@ -2694,7 +3019,8 @@ function KeymapRecorderModal({
             Current: {formatKeymapBinding(currentBinding, definition.kind)}
           </div>
           <div className="mt-1 text-xs text-ink-500">
-            Default: {formatKeymapBinding(definition.defaultBinding, definition.kind)}
+            Default:{' '}
+            {formatKeymapBinding(definition.defaultBinding, definition.kind)}
           </div>
         </div>
         <div className="flex items-center justify-between gap-3 border-t border-paper-300/60 px-5 py-3">
@@ -2725,7 +3051,7 @@ function KeymapRecorderModal({
         </div>
       </div>
     </div>,
-    document.body
+    document.body,
   )
 }
 
@@ -2733,7 +3059,7 @@ function Section({
   title,
   description,
   settingId,
-  children
+  children,
 }: {
   title: string
   description?: string
@@ -2747,7 +3073,9 @@ function Section({
           {title}
         </div>
         {description && (
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-ink-500">{description}</p>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-ink-500">
+            {description}
+          </p>
         )}
       </div>
       <div className="overflow-hidden rounded-3xl border border-paper-300/60 bg-paper-50/45 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
@@ -2758,7 +3086,9 @@ function Section({
 }
 
 function InlineNote({ children }: { children: React.ReactNode }): JSX.Element {
-  return <div className="px-5 py-4 text-xs leading-5 text-ink-500">{children}</div>
+  return (
+    <div className="px-5 py-4 text-xs leading-5 text-ink-500">{children}</div>
+  )
 }
 
 const DEFAULT_QUICK_CAPTURE_HOTKEY = 'CommandOrControl+Shift+Space'
@@ -2776,8 +3106,10 @@ function formatAcceleratorForDisplay(accelerator: string): string {
   return accelerator
     .split('+')
     .map((part) => {
-      if (part === 'CommandOrControl' || part === 'CmdOrCtrl') return mac ? '⌘' : 'Ctrl'
-      if (part === 'Command' || part === 'Cmd' || part === 'Meta') return mac ? '⌘' : 'Meta'
+      if (part === 'CommandOrControl' || part === 'CmdOrCtrl')
+        return mac ? '⌘' : 'Ctrl'
+      if (part === 'Command' || part === 'Cmd' || part === 'Meta')
+        return mac ? '⌘' : 'Meta'
       if (part === 'Control' || part === 'Ctrl') return mac ? '⌃' : 'Ctrl'
       if (part === 'Alt' || part === 'Option') return mac ? '⌥' : 'Alt'
       if (part === 'Shift') return mac ? '⇧' : 'Shift'
@@ -2787,7 +3119,9 @@ function formatAcceleratorForDisplay(accelerator: string): string {
     .join(mac ? '' : '+')
 }
 
-function QuickCaptureHotkeyRow({ settingId }: { settingId?: string } = {}): JSX.Element {
+function QuickCaptureHotkeyRow({
+  settingId,
+}: { settingId?: string } = {}): JSX.Element {
   const [current, setCurrent] = useState<string>('')
   const [recording, setRecording] = useState(false)
   const [draft, setDraft] = useState<string>('')
@@ -2850,11 +3184,13 @@ function QuickCaptureHotkeyRow({ settingId }: { settingId?: string } = {}): JSX.
     >
       <div className="flex items-center justify-between gap-5">
         <div className="min-w-0">
-          <div className="text-sm font-medium text-ink-900">Quick capture hotkey</div>
+          <div className="text-sm font-medium text-ink-900">
+            Quick capture hotkey
+          </div>
           <div className="mt-1 text-xs leading-5 text-ink-500">
-            System-wide shortcut to open the floating capture window. Works even when
-            ZenNotes is hidden or another app is focused. Click Record, then press the
-            chord; Esc cancels.
+            System-wide shortcut to open the floating capture window. Works even
+            when ZenNotes is hidden or another app is focused. Click Record,
+            then press the chord; Esc cancels.
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -2869,7 +3205,7 @@ function QuickCaptureHotkeyRow({ settingId }: { settingId?: string } = {}): JSX.
               'rounded-xl border px-3 py-1.5 text-sm tabular-nums',
               recording
                 ? 'border-accent/60 bg-accent/10 text-accent'
-                : 'border-paper-300/70 bg-paper-100/80 text-ink-900 hover:border-paper-300'
+                : 'border-paper-300/70 bg-paper-100/80 text-ink-900 hover:border-paper-300',
             ].join(' ')}
           >
             {recording
@@ -2921,13 +3257,10 @@ function QuickCaptureHotkeyRow({ settingId }: { settingId?: string } = {}): JSX.
           )}
         </div>
       </div>
-      {error && (
-        <div className="text-xs text-red-500">{error}</div>
-      )}
+      {error && <div className="text-xs text-red-500">{error}</div>}
     </div>
   )
 }
-
 
 function TextInputRow({
   label,
@@ -2935,7 +3268,7 @@ function TextInputRow({
   value,
   placeholder,
   settingId,
-  onChange
+  onChange,
 }: {
   label: string
   description?: string
@@ -2951,7 +3284,11 @@ function TextInputRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <input
         value={value}
@@ -2972,7 +3309,7 @@ function TemplateSelectRow({
   value,
   templates,
   settingId,
-  onChange
+  onChange,
 }: {
   label: string
   description?: string
@@ -2991,10 +3328,14 @@ function TemplateSelectRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <select
-        value={missing ? '__missing__' : value ?? ''}
+        value={missing ? '__missing__' : (value ?? '')}
         onChange={(e) => onChange(e.target.value ? e.target.value : undefined)}
         className="w-[23rem] max-w-[50vw] rounded-xl border border-paper-300/70 bg-paper-100/80 px-3 py-2 text-sm text-ink-900 outline-none focus:border-accent/45"
       >
@@ -3020,7 +3361,7 @@ function FontRow({
   value,
   options,
   settingId,
-  onChange
+  onChange,
 }: {
   label: string
   description?: string
@@ -3035,9 +3376,11 @@ function FontRow({
   const buttonRef = useRef<HTMLButtonElement | null>(null)
   const searchRef = useRef<HTMLInputElement | null>(null)
   const listRef = useRef<HTMLDivElement | null>(null)
-  const [rect, setRect] = useState<{ left: number; top: number; width: number } | null>(
-    null
-  )
+  const [rect, setRect] = useState<{
+    left: number
+    top: number
+    width: number
+  } | null>(null)
 
   // Reset the search box whenever the popover opens.
   useEffect(() => {
@@ -3076,7 +3419,11 @@ function FontRow({
       const el = buttonRef.current
       if (!el) return
       const r = el.getBoundingClientRect()
-      setRect({ left: r.left, top: r.bottom + 4, width: Math.max(260, r.width) })
+      setRect({
+        left: r.left,
+        top: r.bottom + 4,
+        width: Math.max(260, r.width),
+      })
     }
     update()
     window.addEventListener('resize', update)
@@ -3098,7 +3445,10 @@ function FontRow({
   // Virtual item list: entry 0 is the "Default" reset, then every filtered
   // font. A single index tracks which row is keyboard-highlighted.
   // `null` represents the default / reset row.
-  const items: Array<string | null> = useMemo(() => [null, ...filtered], [filtered])
+  const items: Array<string | null> = useMemo(
+    () => [null, ...filtered],
+    [filtered],
+  )
 
   // Clamp the active index whenever the filter narrows/widens.
   useEffect(() => {
@@ -3109,7 +3459,7 @@ function FontRow({
   useEffect(() => {
     if (!open || !listRef.current) return
     const el = listRef.current.querySelector<HTMLElement>(
-      `[data-idx="${activeIdx}"]`
+      `[data-idx="${activeIdx}"]`,
     )
     el?.scrollIntoView({ block: 'nearest' })
   }, [activeIdx, open])
@@ -3149,7 +3499,11 @@ function FontRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <button
         ref={buttonRef}
@@ -3159,7 +3513,11 @@ function FontRow({
       >
         <span
           className="truncate"
-          style={{ fontFamily: value ? `"${value}", ui-monospace, monospace` : undefined }}
+          style={{
+            fontFamily: value
+              ? `"${value}", ui-monospace, monospace`
+              : undefined,
+          }}
         >
           {value ?? 'Default'}
         </span>
@@ -3209,7 +3567,7 @@ function FontRow({
                     ? 'bg-paper-200 text-ink-900'
                     : value === null
                       ? 'text-ink-900'
-                      : 'text-ink-700'
+                      : 'text-ink-700',
                 ].join(' ')}
               >
                 Default
@@ -3237,7 +3595,7 @@ function FontRow({
                           ? 'bg-paper-200 text-ink-900'
                           : value === f
                             ? 'text-ink-900'
-                            : 'text-ink-800'
+                            : 'text-ink-800',
                       ].join(' ')}
                       style={{ fontFamily: `"${f}", ui-monospace, monospace` }}
                     >
@@ -3248,7 +3606,7 @@ function FontRow({
               )}
             </div>
           </div>,
-          document.body
+          document.body,
         )}
     </div>
   )
@@ -3264,7 +3622,7 @@ function SliderRow({
   unit,
   format,
   settingId,
-  onChange
+  onChange,
 }: {
   label: string
   description?: string
@@ -3277,7 +3635,8 @@ function SliderRow({
   settingId?: string
   onChange: (next: number) => void
 }): JSX.Element {
-  const display = (format ? format(value) : String(value)) + (unit && !format ? unit : '')
+  const display =
+    (format ? format(value) : String(value)) + (unit && !format ? unit : '')
   return (
     <div
       className="flex items-center justify-between gap-5 px-5 py-4"
@@ -3285,7 +3644,11 @@ function SliderRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <div className="flex shrink-0 items-center gap-3">
         <input
@@ -3315,7 +3678,7 @@ function NumberRow({
   unit,
   format,
   settingId,
-  onChange
+  onChange,
 }: {
   label: string
   description?: string
@@ -3337,7 +3700,9 @@ function NumberRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="text-xs text-ink-500">{description}</div>}
+        {description && (
+          <div className="text-xs text-ink-500">{description}</div>
+        )}
       </div>
       <div className="flex items-center gap-2">
         <button
@@ -3367,7 +3732,7 @@ function ToggleRow({
   description,
   value,
   settingId,
-  onChange
+  onChange,
 }: {
   label: string
   description?: string
@@ -3382,7 +3747,11 @@ function ToggleRow({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <button
         type="button"
@@ -3391,13 +3760,13 @@ function ToggleRow({
         onClick={() => onChange(!value)}
         className={[
           'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors',
-          value ? 'bg-accent' : 'bg-paper-300'
+          value ? 'bg-accent' : 'bg-paper-300',
         ].join(' ')}
       >
         <span
           className={[
             'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
-            value ? 'translate-x-4' : 'translate-x-0.5'
+            value ? 'translate-x-4' : 'translate-x-0.5',
           ].join(' ')}
         />
       </button>
@@ -3411,7 +3780,7 @@ function SegmentedRow<T extends string>({
   value,
   options,
   settingId,
-  onChange
+  onChange,
 }: {
   label: string
   description?: string
@@ -3427,7 +3796,11 @@ function SegmentedRow<T extends string>({
     >
       <div className="min-w-0">
         <div className="text-sm font-medium text-ink-900">{label}</div>
-        {description && <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>}
+        {description && (
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+        )}
       </div>
       <div className="inline-flex shrink-0 rounded-xl border border-paper-300/70 bg-paper-100/75 p-1">
         {options.map((option) => (
@@ -3439,7 +3812,7 @@ function SegmentedRow<T extends string>({
               'rounded-lg px-3 py-1.5 text-xs transition-colors',
               value === option.value
                 ? 'bg-paper-50 text-ink-900 shadow-sm'
-                : 'text-ink-600 hover:text-ink-900'
+                : 'text-ink-600 hover:text-ink-900',
             ].join(' ')}
           >
             {option.label}
@@ -3521,7 +3894,9 @@ function CliSettings(): JSX.Element {
           description="Install the `zen` shell command for terminal-based note workflows."
           settingId="zen-command-line-tool"
         >
-          <InlineNote>{status.reason ?? 'Not supported on this platform yet.'}</InlineNote>
+          <InlineNote>
+            {status.reason ?? 'Not supported on this platform yet.'}
+          </InlineNote>
         </Section>
       </div>
     )
@@ -3552,7 +3927,7 @@ function CliSettings(): JSX.Element {
                 <span
                   className={[
                     'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                    statusChipClass(chip.tone)
+                    statusChipClass(chip.tone),
                   ].join(' ')}
                 >
                   {chip.label}
@@ -3568,15 +3943,19 @@ function CliSettings(): JSX.Element {
                       : `Symlinks ${status.defaultTarget} to ZenNotes' bundled wrapper.`}
               </div>
               {status.reason && (
-                <div className="mt-1.5 text-xs leading-5 text-amber-500">{status.reason}</div>
+                <div className="mt-1.5 text-xs leading-5 text-amber-500">
+                  {status.reason}
+                </div>
               )}
               {!installed && status.pathHint && (
                 <div className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs leading-5 text-ink-700">
                   <div className="font-medium text-amber-600">
-                    {status.defaultTarget.replace(/\/[^/]+$/, '')} is not on your PATH.
+                    {status.defaultTarget.replace(/\/[^/]+$/, '')} is not on
+                    your PATH.
                   </div>
                   <div className="mt-1 text-ink-500">
-                    After install, run this once so your shell can find <code className="font-mono">zen</code>:
+                    After install, run this once so your shell can find{' '}
+                    <code className="font-mono">zen</code>:
                   </div>
                   <div className="mt-1.5 flex items-center gap-2">
                     <code className="min-w-0 flex-1 break-all rounded-md bg-paper-100/80 px-2 py-1 font-mono text-xs text-ink-900">
@@ -3603,7 +3982,7 @@ function CliSettings(): JSX.Element {
                     'rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors',
                     busy || (installed && !ours)
                       ? 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-                      : 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200'
+                      : 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200',
                   ].join(' ')}
                 >
                   {busy ? 'Working…' : 'Uninstall'}
@@ -3629,7 +4008,9 @@ function CliSettings(): JSX.Element {
             </code>
             <button
               type="button"
-              onClick={() => copyToClipboard(status.installedAt ?? status.defaultTarget)}
+              onClick={() =>
+                copyToClipboard(status.installedAt ?? status.defaultTarget)
+              }
               className="shrink-0 rounded-md border border-paper-300/70 bg-paper-100/80 px-2 py-1 text-xs font-medium text-ink-700 hover:bg-paper-200"
             >
               Copy
@@ -3655,7 +4036,7 @@ function CliSettings(): JSX.Element {
           <div>echo "hello" | zen capture</div>
           <div>zen append daily.md --body "- talked to alice"</div>
           <div>zen search "deadline" --json | jq .</div>
-          <div>zen mcp           # used by Claude Code/Desktop/Codex</div>
+          <div>zen mcp # used by Claude Code/Desktop/Codex</div>
         </div>
       </Section>
 
@@ -3670,7 +4051,7 @@ function CliSettings(): JSX.Element {
 
 function RaycastExtensionSettings({
   cliInstalled,
-  copyToClipboard
+  copyToClipboard,
 }: {
   cliInstalled: boolean
   copyToClipboard: (text: string) => void
@@ -3731,7 +4112,7 @@ function RaycastExtensionSettings({
   const toolchainDetail = [
     `Raycast ${status.raycastInstalled ? 'found' : 'missing'}`,
     `Node ${status.nodeVersion ?? 'missing'}`,
-    `npm ${status.npmVersion ?? 'missing'}`
+    `npm ${status.npmVersion ?? 'missing'}`,
   ].join(' · ')
 
   return (
@@ -3744,26 +4125,32 @@ function RaycastExtensionSettings({
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-              <span className="text-sm font-medium text-ink-900">ZenNotes for Raycast</span>
+              <span className="text-sm font-medium text-ink-900">
+                ZenNotes for Raycast
+              </span>
               <span
                 className={[
                   'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                  statusChipClass(chip.tone)
+                  statusChipClass(chip.tone),
                 ].join(' ')}
               >
                 {chip.label}
               </span>
             </div>
             <div className="mt-1 text-xs leading-5 text-ink-500">{detail}</div>
-            <div className="mt-1 text-xs leading-5 text-ink-400">{toolchainDetail}</div>
+            <div className="mt-1 text-xs leading-5 text-ink-400">
+              {toolchainDetail}
+            </div>
             {!cliInstalled && (
               <div className="mt-1.5 text-xs leading-5 text-amber-500">
-                Install the <code className="font-mono">zen</code> CLI above first. The Raycast
-                command calls it to read your local vault.
+                Install the <code className="font-mono">zen</code> CLI above
+                first. The Raycast command calls it to read your local vault.
               </div>
             )}
             {cliInstalled && status.reason && (
-              <div className="mt-1.5 text-xs leading-5 text-amber-500">{status.reason}</div>
+              <div className="mt-1.5 text-xs leading-5 text-amber-500">
+                {status.reason}
+              </div>
             )}
           </div>
           <Button
@@ -3805,18 +4192,20 @@ function RaycastExtensionSettings({
 
 function raycastStatusChip(
   status: RaycastExtensionStatus,
-  cliInstalled: boolean
+  cliInstalled: boolean,
 ): { label: string; tone: 'ok' | 'warn' | 'off' } {
   if (!status.supportedPlatform) return { label: 'Not supported', tone: 'off' }
-  if (status.installed && status.upToDate) return { label: 'Installed', tone: 'ok' }
-  if (status.installed && !status.upToDate) return { label: 'Update available', tone: 'warn' }
+  if (status.installed && status.upToDate)
+    return { label: 'Installed', tone: 'ok' }
+  if (status.installed && !status.upToDate)
+    return { label: 'Update available', tone: 'warn' }
   if (status.available && cliInstalled) return { label: 'Ready', tone: 'off' }
   return { label: 'Not ready', tone: 'off' }
 }
 
 function raycastStatusDetail(
   status: RaycastExtensionStatus,
-  cliInstalled: boolean
+  cliInstalled: boolean,
 ): string {
   if (!status.supportedPlatform) {
     return status.reason ?? 'Raycast extensions are available on macOS only.'
@@ -3836,7 +4225,6 @@ function raycastStatusDetail(
   return 'Copies the bundled extension into app data, installs dependencies, builds it, and imports it into Raycast.'
 }
 
-
 function McpSettings(): JSX.Element {
   const [statuses, setStatuses] = useState<McpClientStatus[] | null>(null)
   const [runtime, setRuntime] = useState<McpServerRuntime | null>(null)
@@ -3848,7 +4236,7 @@ function McpSettings(): JSX.Element {
     try {
       const [s, r] = await Promise.all([
         window.zen.mcpGetStatuses(),
-        window.zen.mcpGetRuntime()
+        window.zen.mcpGetRuntime(),
       ])
       setStatuses(s)
       setRuntime(r)
@@ -3895,16 +4283,10 @@ function McpSettings(): JSX.Element {
     : '—'
   const entryMissing = runtime !== null && runtime.entryPath == null
 
-  const serverStatusLabel = runtime == null
-    ? 'Checking\u2026'
-    : entryMissing
-      ? 'Not built'
-      : 'Ready'
-  const serverStatusTone = runtime == null
-    ? 'off'
-    : entryMissing
-      ? 'warn'
-      : 'ok'
+  const serverStatusLabel =
+    runtime == null ? 'Checking\u2026' : entryMissing ? 'Not built' : 'Ready'
+  const serverStatusTone =
+    runtime == null ? 'off' : entryMissing ? 'warn' : 'ok'
   const serverStatusClass = statusChipClass(serverStatusTone)
 
   return (
@@ -3920,7 +4302,7 @@ function McpSettings(): JSX.Element {
               <span
                 className={[
                   'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                  serverStatusClass
+                  serverStatusClass,
                 ].join(' ')}
               >
                 {serverStatusLabel}
@@ -3960,7 +4342,9 @@ function McpSettings(): JSX.Element {
 
       <Section
         title="Integrations"
-        description={"Pick the clients you want connected to this vault. Install writes a managed ZenNotes entry into that client\u2019s config; Uninstall removes just that entry."}
+        description={
+          'Pick the clients you want connected to this vault. Install writes a managed ZenNotes entry into that client\u2019s config; Uninstall removes just that entry.'
+        }
         settingId="mcp-integrations"
       >
         {statuses == null ? (
@@ -4079,7 +4463,7 @@ function McpInstructionsEditor(): JSX.Element {
                 'rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors',
                 payload != null && draft !== payload.defaultValue
                   ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
+                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
               ].join(' ')}
             >
               Reset to default
@@ -4092,7 +4476,7 @@ function McpInstructionsEditor(): JSX.Element {
                 'rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors',
                 dirty
                   ? 'border-paper-300/70 bg-paper-100/80 text-ink-800 hover:bg-paper-200'
-                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
+                  : 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400',
               ].join(' ')}
             >
               Revert
@@ -4122,7 +4506,8 @@ function McpInstructionsEditor(): JSX.Element {
             </code>
           </span>
           <span>
-            {draft.length.toLocaleString()} chars · {draft.split(/\r?\n/).length} lines
+            {draft.length.toLocaleString()} chars ·{' '}
+            {draft.split(/\r?\n/).length} lines
           </span>
         </div>
         {error && (
@@ -4135,12 +4520,6 @@ function McpInstructionsEditor(): JSX.Element {
   )
 }
 
-function statusChipClass(tone: 'ok' | 'warn' | 'off'): string {
-  if (tone === 'ok') return 'border-accent/25 bg-accent/10 text-accent'
-  if (tone === 'warn') return 'border-amber-500/30 bg-amber-500/10 text-amber-500'
-  return 'border-paper-300/70 bg-paper-100/85 text-ink-500'
-}
-
 function McpClientRow({
   title,
   description,
@@ -4149,7 +4528,7 @@ function McpClientRow({
   entryMissing,
   onInstall,
   onUninstall,
-  onCopyConfigPath
+  onCopyConfigPath,
 }: {
   title: string
   description: string
@@ -4175,14 +4554,20 @@ function McpClientRow({
             <span
               className={[
                 'rounded-full border px-2 py-0.5 text-2xs font-medium uppercase tracking-[0.14em]',
-                statusChipClass(chip.tone)
+                statusChipClass(chip.tone),
               ].join(' ')}
             >
               {chip.label}
             </span>
           </div>
-          <div className="mt-1 text-xs leading-5 text-ink-500">{description}</div>
-          {status.note && <div className="mt-1.5 text-xs leading-5 text-ink-500">{status.note}</div>}
+          <div className="mt-1 text-xs leading-5 text-ink-500">
+            {description}
+          </div>
+          {status.note && (
+            <div className="mt-1.5 text-xs leading-5 text-ink-500">
+              {status.note}
+            </div>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {status.installed ? (
@@ -4196,7 +4581,7 @@ function McpClientRow({
                     'rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors',
                     busy || entryMissing
                       ? 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-                      : 'border-accent/30 bg-accent/15 text-accent hover:bg-accent/25'
+                      : 'border-accent/30 bg-accent/15 text-accent hover:bg-accent/25',
                   ].join(' ')}
                 >
                   Update
@@ -4210,7 +4595,7 @@ function McpClientRow({
                   'rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors',
                   busy
                     ? 'cursor-not-allowed border-paper-300/60 bg-paper-100/45 text-ink-400'
-                    : 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200'
+                    : 'border-paper-300/70 bg-paper-100/80 text-ink-700 hover:bg-paper-200',
                 ].join(' ')}
               >
                 Uninstall

--- a/packages/app-core/src/lib/keymaps.ts
+++ b/packages/app-core/src/lib/keymaps.ts
@@ -113,7 +113,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Search notes',
     description: 'Open the vault-wide note search palette.',
-    defaultBinding: 'Mod+P',
+    defaultBinding: 'Mod+P'
   },
   {
     id: 'global.searchNotesNonVim',
@@ -123,7 +123,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Search notes in non-Vim mode',
     description: 'Extra direct search shortcut when Vim mode is off.',
     defaultBinding: 'Mod+F',
-    nonVimOnly: true,
+    nonVimOnly: true
   },
   {
     id: 'global.commandPalette',
@@ -132,7 +132,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Open command palette',
     description: 'Open the command palette.',
-    defaultBinding: 'Shift+Mod+P',
+    defaultBinding: 'Shift+Mod+P'
   },
   {
     id: 'global.newQuickNote',
@@ -141,7 +141,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'New quick note',
     description: 'Create a quick capture note and focus its title.',
-    defaultBinding: 'Shift+Mod+N',
+    defaultBinding: 'Shift+Mod+N'
   },
   {
     id: 'global.openSettings',
@@ -150,7 +150,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Open settings',
     description: 'Open the Settings modal.',
-    defaultBinding: 'Mod+,',
+    defaultBinding: 'Mod+,'
   },
   {
     id: 'global.toggleSidebar',
@@ -159,7 +159,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Toggle sidebar',
     description: 'Hide or show the left sidebar.',
-    defaultBinding: 'Mod+1',
+    defaultBinding: 'Mod+1'
   },
   {
     id: 'global.toggleConnections',
@@ -168,7 +168,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Toggle connections panel',
     description: 'Toggle the connections panel in the active pane.',
-    defaultBinding: 'Mod+2',
+    defaultBinding: 'Mod+2'
   },
   {
     id: 'global.toggleOutlinePanel',
@@ -177,7 +177,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Toggle outline panel',
     description: 'Toggle the outline panel in the active pane.',
-    defaultBinding: 'Mod+3',
+    defaultBinding: 'Mod+3'
   },
   {
     id: 'global.toggleCommentsPanel',
@@ -186,7 +186,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Toggle comments panel',
     description: 'Toggle the comments panel in the active pane.',
-    defaultBinding: 'Mod+Shift+C',
+    defaultBinding: 'Mod+Shift+C'
   },
   {
     id: 'global.addComment',
@@ -195,7 +195,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Add comment to selection',
     description: 'Start a comment on the selected text (or current line).',
-    defaultBinding: 'Mod+Alt+M',
+    defaultBinding: 'Mod+Alt+M'
   },
   {
     id: 'global.focusPaneLeft',
@@ -205,7 +205,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Focus pane left',
     description:
       'Move focus to the pane/panel on the left. Works without vim mode.',
-    defaultBinding: 'Alt+H',
+    defaultBinding: 'Alt+H'
   },
   {
     id: 'global.focusPaneDown',
@@ -214,7 +214,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Focus pane down',
     description: 'Move focus to the pane/panel below. Works without vim mode.',
-    defaultBinding: 'Alt+J',
+    defaultBinding: 'Alt+J'
   },
   {
     id: 'global.focusPaneUp',
@@ -223,7 +223,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Focus pane up',
     description: 'Move focus to the pane/panel above. Works without vim mode.',
-    defaultBinding: 'Alt+K',
+    defaultBinding: 'Alt+K'
   },
   {
     id: 'global.focusPaneRight',
@@ -233,7 +233,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Focus pane right',
     description:
       'Move focus to the pane/panel on the right. Works without vim mode.',
-    defaultBinding: 'Alt+L',
+    defaultBinding: 'Alt+L'
   },
   {
     id: 'global.modeEdit',
@@ -242,7 +242,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Switch to editor mode',
     description: 'Show only the markdown editor for the active note.',
-    defaultBinding: 'Mod+4',
+    defaultBinding: 'Mod+4'
   },
   {
     id: 'global.modeSplit',
@@ -251,7 +251,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Switch to split mode',
     description: 'Show the editor and rendered preview side by side.',
-    defaultBinding: 'Mod+5',
+    defaultBinding: 'Mod+5'
   },
   {
     id: 'global.modePreview',
@@ -260,7 +260,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Switch to preview mode',
     description: 'Show only the rendered preview for the active note.',
-    defaultBinding: 'Mod+6',
+    defaultBinding: 'Mod+6'
   },
   {
     id: 'global.toggleZenMode',
@@ -269,7 +269,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Toggle Zen mode',
     description: 'Hide or restore the app chrome.',
-    defaultBinding: 'Mod+.',
+    defaultBinding: 'Mod+.'
   },
   {
     id: 'global.closeActiveTab',
@@ -278,7 +278,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Close active tab',
     description: 'Close the current note or virtual tab.',
-    defaultBinding: 'Mod+W',
+    defaultBinding: 'Mod+W'
   },
   {
     id: 'global.toggleWordWrap',
@@ -287,7 +287,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Toggle word wrap',
     description: 'Switch between wrapped lines and horizontal scrolling.',
-    defaultBinding: 'Alt+Z',
+    defaultBinding: 'Alt+Z'
   },
   {
     id: 'global.exportNotePdf',
@@ -296,7 +296,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Export note as PDF',
     description: 'Export the active note as a PDF file.',
-    defaultBinding: 'Shift+Mod+E',
+    defaultBinding: 'Shift+Mod+E'
   },
   {
     id: 'global.zoomIn',
@@ -305,7 +305,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Zoom in',
     description: 'Increase the app zoom factor.',
-    defaultBinding: 'Mod+=',
+    defaultBinding: 'Mod+='
   },
   {
     id: 'global.zoomOut',
@@ -314,7 +314,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Zoom out',
     description: 'Decrease the app zoom factor.',
-    defaultBinding: 'Mod+-',
+    defaultBinding: 'Mod+-'
   },
   {
     id: 'global.zoomReset',
@@ -323,7 +323,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     group: 'global',
     title: 'Reset zoom',
     description: 'Restore the app zoom factor to its default size.',
-    defaultBinding: 'Mod+0',
+    defaultBinding: 'Mod+0'
   },
   {
     id: 'vim.leaderPrefix',
@@ -334,7 +334,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Start leader mode and leader hints.',
     defaultBinding: 'Space',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderOpenBuffers',
@@ -345,7 +345,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open the buffer switcher.',
     defaultBinding: 'o',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderSearchNotes',
@@ -356,7 +356,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open note search from any panel.',
     defaultBinding: 'f',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderSearchGroup',
@@ -367,7 +367,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open the search leader group (text search, etc.).',
     defaultBinding: 's',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderSearchVaultText',
@@ -379,7 +379,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
       'Open fuzzy vault text search across note contents (under the search group).',
     defaultBinding: 't',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderToggleSidebar',
@@ -390,7 +390,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Show or hide the left sidebar.',
     defaultBinding: 'e',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderNoteOutline',
@@ -401,7 +401,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open the note outline palette.',
     defaultBinding: 'p',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderSwitchVault',
@@ -412,7 +412,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open the command palette vault switcher.',
     defaultBinding: 'v',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderNoteActions',
@@ -423,7 +423,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open the note-local leader group.',
     defaultBinding: 'l',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderFormatNote',
@@ -434,7 +434,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Format the active note from the editor.',
     defaultBinding: 'f',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderQuickCapture',
@@ -445,7 +445,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open the floating quick capture window.',
     defaultBinding: 'q',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderTemplatePicker',
@@ -456,7 +456,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open the template picker to create a note.',
     defaultBinding: 't',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderInsertTemplate',
@@ -467,7 +467,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Render a template into the current note.',
     defaultBinding: 'i',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderDailyNote',
@@ -478,7 +478,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: "Open or create today's daily note.",
     defaultBinding: 'd',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderWeeklyNote',
@@ -489,7 +489,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: "Open or create this week's weekly note.",
     defaultBinding: 'w',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.leaderCalendar',
@@ -501,7 +501,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
       'Toggle the calendar panel for the active daily or weekly note.',
     defaultBinding: 'c',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.panePrefix',
@@ -512,7 +512,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Start pane focus and split commands.',
     defaultBinding: 'Ctrl+W',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.paneFocusLeft',
@@ -523,7 +523,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Move focus to the panel or pane on the left.',
     defaultBinding: 'h',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.paneFocusDown',
@@ -534,7 +534,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Move focus to the panel or pane below.',
     defaultBinding: 'j',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.paneFocusUp',
@@ -545,7 +545,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Move focus to the panel or pane above.',
     defaultBinding: 'k',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.paneFocusRight',
@@ -556,7 +556,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Move focus to the panel or pane on the right.',
     defaultBinding: 'l',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.paneSplitRight',
@@ -567,7 +567,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Clone the current tab into a pane on the right.',
     defaultBinding: 'v',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.paneSplitDown',
@@ -578,7 +578,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Clone the current tab into a pane below.',
     defaultBinding: 's',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.historyBack',
@@ -589,7 +589,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Jump to the previous note location in history.',
     defaultBinding: 'Ctrl+O',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.historyForward',
@@ -600,7 +600,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Jump forward in note history.',
     defaultBinding: 'Ctrl+I',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.bufferPrevious',
@@ -612,7 +612,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
       'Move to the previous open buffer, or a recent note when only one buffer is open.',
     defaultBinding: '[ b',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'vim.bufferNext',
@@ -624,7 +624,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
       'Move to the next open buffer, or a recent note when only one buffer is open.',
     defaultBinding: '] b',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'vim.tabPrevious',
@@ -635,7 +635,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Go to the previous tab in the active pane (Vim-style gT).',
     defaultBinding: 'g T',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'vim.tabNext',
@@ -646,7 +646,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Go to the next tab in the active pane (Vim-style gt).',
     defaultBinding: 'g t',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'vim.hintMode',
@@ -658,7 +658,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
       'Show jump labels for clickable targets (jump to any button or link).',
     defaultBinding: 'h',
     vimOnly: true,
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'vim.goToDefinition',
@@ -669,7 +669,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Open the note, URL, or asset under the cursor.',
     defaultBinding: 'g d',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'vim.foldCurrent',
@@ -680,7 +680,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Collapse the heading section at the cursor.',
     defaultBinding: 'z c',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'vim.unfoldCurrent',
@@ -691,7 +691,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Expand the heading section at the cursor.',
     defaultBinding: 'z o',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'vim.foldAll',
@@ -702,7 +702,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Collapse every heading section in the note.',
     defaultBinding: 'z M',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'vim.unfoldAll',
@@ -713,7 +713,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description: 'Expand every heading section in the note.',
     defaultBinding: 'z R',
     vimOnly: true,
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'nav.moveDown',
@@ -723,7 +723,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Move selection down',
     description: 'Move the current row cursor or panel selection down.',
     defaultBinding: 'j',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.moveUp',
@@ -733,7 +733,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Move selection up',
     description: 'Move the current row cursor or panel selection up.',
     defaultBinding: 'k',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.jumpTop',
@@ -744,7 +744,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description:
       'Jump to the first visible row or to the top of preview content.',
     defaultBinding: 'g g',
-    maxTokens: 2,
+    maxTokens: 2
   },
   {
     id: 'nav.jumpBottom',
@@ -755,7 +755,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description:
       'Jump to the last visible row or to the bottom of preview content.',
     defaultBinding: 'G',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.halfPageDown',
@@ -765,7 +765,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Half-page down',
     description: 'Scroll preview content down by half a viewport.',
     defaultBinding: 'Ctrl+d',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.halfPageUp',
@@ -775,7 +775,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Half-page up',
     description: 'Scroll preview content up by half a viewport.',
     defaultBinding: 'Ctrl+u',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.openSideItem',
@@ -785,7 +785,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Open sidebar or note-list item',
     description: 'Open the current sidebar or note-list selection.',
     defaultBinding: 'l',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.openResult',
@@ -795,7 +795,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Open result',
     description: 'Open the selected note or result in a view.',
     defaultBinding: 'o',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.back',
@@ -805,7 +805,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Back out',
     description: 'Collapse, move left, or return focus toward the editor.',
     defaultBinding: 'h',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.toggleFolder',
@@ -815,7 +815,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Toggle folder',
     description: 'Expand or collapse the current sidebar folder.',
     defaultBinding: 'o',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.filter',
@@ -826,7 +826,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description:
       'Focus the local filter or open note search from panel navigation.',
     defaultBinding: '/',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.contextMenu',
@@ -836,7 +836,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Open context menu',
     description: 'Open the contextual actions menu for the current row.',
     defaultBinding: 'm',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.peekPreview',
@@ -846,7 +846,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Peek preview',
     description: 'Open the hover preview for the selected connection.',
     defaultBinding: 'p',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.restore',
@@ -856,7 +856,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Restore trashed note',
     description: 'Restore the selected trashed note.',
     defaultBinding: 'r',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.delete',
@@ -867,7 +867,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     description:
       'Permanently delete or move the selected item to trash, depending on the view.',
     defaultBinding: 'x',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.toggleTask',
@@ -877,7 +877,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Toggle task',
     description: 'Check or uncheck the selected task.',
     defaultBinding: 'x',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.localEx',
@@ -887,7 +887,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Open local ex prompt',
     description: 'Open the view-specific ex prompt in Tasks or Tags.',
     defaultBinding: ':',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.newQuickNote',
@@ -897,7 +897,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'New quick note from Quick Notes view',
     description: 'Create a new quick note from the Quick Notes list tab.',
     defaultBinding: 'n',
-    maxTokens: 1,
+    maxTokens: 1
   },
   {
     id: 'nav.unarchive',
@@ -907,8 +907,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     title: 'Unarchive selected note',
     description: 'Move the selected archived note back to Inbox.',
     defaultBinding: 'u',
-    maxTokens: 1,
-  },
+    maxTokens: 1
+  }
 ]
 
 for (const definition of KEYMAP_DEFINITIONS) {
@@ -920,14 +920,14 @@ for (const definition of KEYMAP_DEFINITIONS) {
 }
 
 const KEYMAP_INDEX = new Map<KeymapId, KeymapDefinition>(
-  KEYMAP_DEFINITIONS.map((definition) => [definition.id, definition] as const),
+  KEYMAP_DEFINITIONS.map((definition) => [definition.id, definition] as const)
 )
 
 const KEYMAP_GROUP_LABELS: Record<KeymapGroup, string> = {
   global: 'Global shortcuts',
   vim: 'Vim-specific shortcuts',
   navigation: 'Navigation',
-  'view-actions': 'View-specific actions',
+  'view-actions': 'View-specific actions'
 }
 
 export function getKeymapDefinitions(): KeymapDefinition[] {
@@ -950,7 +950,7 @@ export function getDefaultKeymapBinding(id: KeymapId): string {
 
 export function getKeymapBinding(
   overrides: KeymapOverrides | null | undefined,
-  id: KeymapId,
+  id: KeymapId
 ): string {
   const override = overrides?.[id]
   return override || getDefaultKeymapBinding(id)
@@ -958,7 +958,7 @@ export function getKeymapBinding(
 
 export function getSequenceTokens(
   overrides: KeymapOverrides | null | undefined,
-  id: KeymapId,
+  id: KeymapId
 ): string[] {
   return getKeymapBinding(overrides, id)
     .split(/\s+/)
@@ -1104,7 +1104,7 @@ function normalizeSequenceBaseToken(key: string): string | null {
 }
 
 function normalizeModifierToken(
-  modifier: string,
+  modifier: string
 ): 'Ctrl' | 'Alt' | 'Shift' | 'Meta' | 'Mod' | null {
   if (/^(cmd|command|meta)$/i.test(modifier)) return 'Meta'
   if (/^(ctrl|control)$/i.test(modifier)) return 'Ctrl'
@@ -1141,7 +1141,7 @@ export function normalizeShortcutBinding(input: string): string | null {
       if (normalized === 'Meta') return [mac ? 'Mod' : 'Meta']
       if (normalized === 'Ctrl') return [mac ? 'Ctrl' : 'Mod']
       return [normalized]
-    }),
+    })
   )
   return [...modifiers, key].join('+')
 }
@@ -1160,7 +1160,7 @@ export function normalizeSequenceToken(input: string): string | null {
     parts
       .map((part) => normalizeModifierToken(part))
       .filter((part): part is NonNullable<typeof part> => !!part)
-      .filter((part) => part !== 'Mod'),
+      .filter((part) => part !== 'Mod')
   )
   // When a non-Shift modifier (Ctrl/Alt/Meta) is combined with a single
   // ASCII letter, canonicalize to uppercase. Event-produced tokens come
@@ -1188,7 +1188,7 @@ export function normalizeSequenceBinding(input: string): string | null {
 
 export function normalizeKeymapBinding(
   id: KeymapId,
-  input: string,
+  input: string
 ): string | null {
   const definition = getKeymapDefinition(id)
   const normalized =
@@ -1257,13 +1257,13 @@ export function sequenceTokenFromEvent(event: KeyboardEvent): string | null {
   if (event.metaKey) modifiers.push('Meta')
   if (event.shiftKey && base.length !== 1) modifiers.push('Shift')
   return normalizeSequenceToken(
-    modifiers.length > 0 ? `${modifiers.join('+')}+${base}` : base,
+    modifiers.length > 0 ? `${modifiers.join('+')}+${base}` : base
   )
 }
 
 export function matchesShortcutBinding(
   event: KeyboardEvent,
-  binding: string,
+  binding: string
 ): boolean {
   const normalized = shortcutBindingFromEvent(event)
   return !!normalized && normalized === binding
@@ -1272,7 +1272,7 @@ export function matchesShortcutBinding(
 export function matchesShortcut(
   event: KeyboardEvent,
   overrides: KeymapOverrides | null | undefined,
-  id: KeymapId,
+  id: KeymapId
 ): boolean {
   return matchesShortcutBinding(event, getKeymapBinding(overrides, id))
 }
@@ -1280,7 +1280,7 @@ export function matchesShortcut(
 export function matchesSequenceToken(
   event: KeyboardEvent,
   overrides: KeymapOverrides | null | undefined,
-  id: KeymapId,
+  id: KeymapId
 ): boolean {
   const tokens = getSequenceTokens(overrides, id)
   if (tokens.length !== 1) return false
@@ -1325,7 +1325,7 @@ export function formatKeymapBinding(binding: string, kind: KeymapKind): string {
 
 export function getKeymapDisplay(
   overrides: KeymapOverrides | null | undefined,
-  id: KeymapId,
+  id: KeymapId
 ): string {
   const definition = getKeymapDefinition(id)
   return formatKeymapBinding(getKeymapBinding(overrides, id), definition.kind)
@@ -1333,7 +1333,7 @@ export function getKeymapDisplay(
 
 export function describeCurrentBinding(
   overrides: KeymapOverrides | null | undefined,
-  id: KeymapId,
+  id: KeymapId
 ): string {
   return getKeymapDisplay(overrides, id)
 }
@@ -1347,14 +1347,12 @@ export function getKeymapDefinitionsByGroup(): Array<{
   return groups.map((group) => ({
     group,
     label: getKeymapGroupLabel(group),
-    items: KEYMAP_DEFINITIONS.filter(
-      (definition) => definition.group === group,
-    ),
+    items: KEYMAP_DEFINITIONS.filter((definition) => definition.group === group)
   }))
 }
 
 export function findConflictingKeymaps(
-  overrides: KeymapOverrides,
+  overrides: KeymapOverrides
 ): Map<KeymapId, KeymapId[]> {
   const byKey = new Map<string, KeymapDefinition[]>()
   for (const def of KEYMAP_DEFINITIONS) {
@@ -1388,11 +1386,11 @@ export function findConflictingKeymaps(
  * @returns
  */
 export function getAppVimSequenceMap(
-  overrides: KeymapOverrides,
+  overrides: KeymapOverrides
 ): Map<string, KeymapDefinition> {
   const map = new Map<string, KeymapDefinition>()
   const leaderKey = toVimSequence(
-    getKeymapBinding(overrides, 'vim.leaderPrefix'),
+    getKeymapBinding(overrides, 'vim.leaderPrefix')
   )!
   const paneKey = toVimSequence(getKeymapBinding(overrides, 'vim.panePrefix'))!
 
@@ -1423,7 +1421,7 @@ export function advanceSequence(
   timerRef: { current?: ReturnType<typeof setTimeout> },
   onMatch: () => void,
   consume: () => void,
-  timeoutMs = 500,
+  timeoutMs = 500
 ): boolean {
   const tokens = binding
     .split(/\s+/)

--- a/packages/app-core/src/lib/keymaps.ts
+++ b/packages/app-core/src/lib/keymaps.ts
@@ -1,7 +1,13 @@
 import { toVimSequence } from './vim-mappings'
 
 export type KeymapKind = 'shortcut' | 'sequence'
-export type KeymapScope = 'app' | 'leader' | 'pane' | 'vim-editor' | 'lists' | 'views'
+export type KeymapScope =
+  | 'app'
+  | 'leader'
+  | 'pane'
+  | 'vim-editor'
+  | 'lists'
+  | 'views'
 export type KeymapGroup = 'global' | 'vim' | 'navigation' | 'view-actions'
 
 export type KeymapId =
@@ -197,7 +203,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'app',
     group: 'global',
     title: 'Focus pane left',
-    description: 'Move focus to the pane/panel on the left. Works without vim mode.',
+    description:
+      'Move focus to the pane/panel on the left. Works without vim mode.',
     defaultBinding: 'Alt+H'
   },
   {
@@ -224,7 +231,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'app',
     group: 'global',
     title: 'Focus pane right',
-    description: 'Move focus to the pane/panel on the right. Works without vim mode.',
+    description:
+      'Move focus to the pane/panel on the right. Works without vim mode.',
     defaultBinding: 'Alt+L'
   },
   {
@@ -367,7 +375,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'leader',
     group: 'vim',
     title: 'Leader search: vault text',
-    description: 'Open fuzzy vault text search across note contents (under the search group).',
+    description:
+      'Open fuzzy vault text search across note contents (under the search group).',
     defaultBinding: 't',
     vimOnly: true,
     maxTokens: 1
@@ -488,7 +497,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'leader',
     group: 'vim',
     title: 'Leader: toggle calendar',
-    description: 'Toggle the calendar panel for the active daily or weekly note.',
+    description:
+      'Toggle the calendar panel for the active daily or weekly note.',
     defaultBinding: 'c',
     vimOnly: true,
     maxTokens: 1
@@ -598,7 +608,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'vim-editor',
     group: 'vim',
     title: 'Previous buffer',
-    description: 'Move to the previous open buffer, or a recent note when only one buffer is open.',
+    description:
+      'Move to the previous open buffer, or a recent note when only one buffer is open.',
     defaultBinding: '[ b',
     vimOnly: true,
     maxTokens: 2
@@ -609,7 +620,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'vim-editor',
     group: 'vim',
     title: 'Next buffer',
-    description: 'Move to the next open buffer, or a recent note when only one buffer is open.',
+    description:
+      'Move to the next open buffer, or a recent note when only one buffer is open.',
     defaultBinding: '] b',
     vimOnly: true,
     maxTokens: 2
@@ -642,7 +654,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'leader',
     group: 'vim',
     title: 'Leader: hint mode',
-    description: 'Show jump labels for clickable targets (jump to any button or link).',
+    description:
+      'Show jump labels for clickable targets (jump to any button or link).',
     defaultBinding: 'h',
     vimOnly: true,
     maxTokens: 1
@@ -728,7 +741,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'lists',
     group: 'navigation',
     title: 'Jump to top',
-    description: 'Jump to the first visible row or to the top of preview content.',
+    description:
+      'Jump to the first visible row or to the top of preview content.',
     defaultBinding: 'g g',
     maxTokens: 2
   },
@@ -738,7 +752,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'lists',
     group: 'navigation',
     title: 'Jump to bottom',
-    description: 'Jump to the last visible row or to the bottom of preview content.',
+    description:
+      'Jump to the last visible row or to the bottom of preview content.',
     defaultBinding: 'G',
     maxTokens: 1
   },
@@ -808,7 +823,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'lists',
     group: 'navigation',
     title: 'Focus filter or search',
-    description: 'Focus the local filter or open note search from panel navigation.',
+    description:
+      'Focus the local filter or open note search from panel navigation.',
     defaultBinding: '/',
     maxTokens: 1
   },
@@ -848,7 +864,8 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'views',
     group: 'view-actions',
     title: 'Delete selected result',
-    description: 'Permanently delete or move the selected item to trash, depending on the view.',
+    description:
+      'Permanently delete or move the selected item to trash, depending on the view.',
     defaultBinding: 'x',
     maxTokens: 1
   },
@@ -1169,7 +1186,10 @@ export function normalizeSequenceBinding(input: string): string | null {
   return tokens.join(' ')
 }
 
-export function normalizeKeymapBinding(id: KeymapId, input: string): string | null {
+export function normalizeKeymapBinding(
+  id: KeymapId,
+  input: string
+): string | null {
   const definition = getKeymapDefinition(id)
   const normalized =
     definition.kind === 'shortcut'
@@ -1179,7 +1199,11 @@ export function normalizeKeymapBinding(id: KeymapId, input: string): string | nu
   if (definition.kind === 'sequence' && definition.maxTokens) {
     const tokenCount = normalized.split(/\s+/).filter(Boolean).length
     if (tokenCount > definition.maxTokens) {
-      return normalized.split(/\s+/).filter(Boolean).slice(0, definition.maxTokens).join(' ')
+      return normalized
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, definition.maxTokens)
+        .join(' ')
     }
   }
   return normalized
@@ -1232,10 +1256,15 @@ export function sequenceTokenFromEvent(event: KeyboardEvent): string | null {
   if (event.altKey) modifiers.push('Alt')
   if (event.metaKey) modifiers.push('Meta')
   if (event.shiftKey && base.length !== 1) modifiers.push('Shift')
-  return normalizeSequenceToken(modifiers.length > 0 ? `${modifiers.join('+')}+${base}` : base)
+  return normalizeSequenceToken(
+    modifiers.length > 0 ? `${modifiers.join('+')}+${base}` : base
+  )
 }
 
-export function matchesShortcutBinding(event: KeyboardEvent, binding: string): boolean {
+export function matchesShortcutBinding(
+  event: KeyboardEvent,
+  binding: string
+): boolean {
   const normalized = shortcutBindingFromEvent(event)
   return !!normalized && normalized === binding
 }
@@ -1263,7 +1292,9 @@ export function formatKeyToken(token: string, mac = isMacPlatform()): string {
   if (token.includes('+')) {
     const parts = token.split('+')
     const base = parts.pop() ?? token
-    const prefix = parts.map((part) => formatKeyToken(part, mac)).join(mac ? '' : '+')
+    const prefix = parts
+      .map((part) => formatKeyToken(part, mac))
+      .join(mac ? '' : '+')
     return `${prefix}${mac ? '' : prefix ? '+' : ''}${formatKeyToken(base, mac)}`
   }
   if (token === 'Mod') return mac ? '⌘' : 'Ctrl'
@@ -1320,7 +1351,9 @@ export function getKeymapDefinitionsByGroup(): Array<{
   }))
 }
 
-export function findConflictingKeymaps(overrides: KeymapOverrides): Map<KeymapId, KeymapId[]> {
+export function findConflictingKeymaps(
+  overrides: KeymapOverrides
+): Map<KeymapId, KeymapId[]> {
   const byKey = new Map<string, KeymapDefinition[]>()
   for (const def of KEYMAP_DEFINITIONS) {
     const key = `${def.kind}:${def.scope}:${getKeymapBinding(overrides, def.id)}`
@@ -1352,9 +1385,13 @@ export function findConflictingKeymaps(overrides: KeymapOverrides): Map<KeymapId
  *
  * @returns
  */
-export function getAppVimSequenceMap(overrides: KeymapOverrides): Map<string, KeymapDefinition> {
+export function getAppVimSequenceMap(
+  overrides: KeymapOverrides
+): Map<string, KeymapDefinition> {
   const map = new Map<string, KeymapDefinition>()
-  const leaderKey = toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix'))!
+  const leaderKey = toVimSequence(
+    getKeymapBinding(overrides, 'vim.leaderPrefix')
+  )!
   const paneKey = toVimSequence(getKeymapBinding(overrides, 'vim.panePrefix'))!
 
   for (const def of KEYMAP_DEFINITIONS) {

--- a/packages/app-core/src/lib/keymaps.ts
+++ b/packages/app-core/src/lib/keymaps.ts
@@ -1,13 +1,7 @@
 import { toVimSequence } from './vim-mappings'
 
 export type KeymapKind = 'shortcut' | 'sequence'
-export type KeymapScope =
-  | 'app'
-  | 'leader'
-  | 'pane'
-  | 'vim-editor'
-  | 'lists'
-  | 'views'
+export type KeymapScope = 'app' | 'leader' | 'pane' | 'vim-editor' | 'lists' | 'views'
 export type KeymapGroup = 'global' | 'vim' | 'navigation' | 'view-actions'
 
 export type KeymapId =
@@ -203,8 +197,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'app',
     group: 'global',
     title: 'Focus pane left',
-    description:
-      'Move focus to the pane/panel on the left. Works without vim mode.',
+    description: 'Move focus to the pane/panel on the left. Works without vim mode.',
     defaultBinding: 'Alt+H'
   },
   {
@@ -231,8 +224,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'app',
     group: 'global',
     title: 'Focus pane right',
-    description:
-      'Move focus to the pane/panel on the right. Works without vim mode.',
+    description: 'Move focus to the pane/panel on the right. Works without vim mode.',
     defaultBinding: 'Alt+L'
   },
   {
@@ -375,8 +367,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'leader',
     group: 'vim',
     title: 'Leader search: vault text',
-    description:
-      'Open fuzzy vault text search across note contents (under the search group).',
+    description: 'Open fuzzy vault text search across note contents (under the search group).',
     defaultBinding: 't',
     vimOnly: true,
     maxTokens: 1
@@ -497,8 +488,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'leader',
     group: 'vim',
     title: 'Leader: toggle calendar',
-    description:
-      'Toggle the calendar panel for the active daily or weekly note.',
+    description: 'Toggle the calendar panel for the active daily or weekly note.',
     defaultBinding: 'c',
     vimOnly: true,
     maxTokens: 1
@@ -608,8 +598,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'vim-editor',
     group: 'vim',
     title: 'Previous buffer',
-    description:
-      'Move to the previous open buffer, or a recent note when only one buffer is open.',
+    description: 'Move to the previous open buffer, or a recent note when only one buffer is open.',
     defaultBinding: '[ b',
     vimOnly: true,
     maxTokens: 2
@@ -620,8 +609,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'vim-editor',
     group: 'vim',
     title: 'Next buffer',
-    description:
-      'Move to the next open buffer, or a recent note when only one buffer is open.',
+    description: 'Move to the next open buffer, or a recent note when only one buffer is open.',
     defaultBinding: '] b',
     vimOnly: true,
     maxTokens: 2
@@ -654,8 +642,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'leader',
     group: 'vim',
     title: 'Leader: hint mode',
-    description:
-      'Show jump labels for clickable targets (jump to any button or link).',
+    description: 'Show jump labels for clickable targets (jump to any button or link).',
     defaultBinding: 'h',
     vimOnly: true,
     maxTokens: 1
@@ -741,8 +728,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'lists',
     group: 'navigation',
     title: 'Jump to top',
-    description:
-      'Jump to the first visible row or to the top of preview content.',
+    description: 'Jump to the first visible row or to the top of preview content.',
     defaultBinding: 'g g',
     maxTokens: 2
   },
@@ -752,8 +738,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'lists',
     group: 'navigation',
     title: 'Jump to bottom',
-    description:
-      'Jump to the last visible row or to the bottom of preview content.',
+    description: 'Jump to the last visible row or to the bottom of preview content.',
     defaultBinding: 'G',
     maxTokens: 1
   },
@@ -823,8 +808,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'lists',
     group: 'navigation',
     title: 'Focus filter or search',
-    description:
-      'Focus the local filter or open note search from panel navigation.',
+    description: 'Focus the local filter or open note search from panel navigation.',
     defaultBinding: '/',
     maxTokens: 1
   },
@@ -864,8 +848,7 @@ const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
     scope: 'views',
     group: 'view-actions',
     title: 'Delete selected result',
-    description:
-      'Permanently delete or move the selected item to trash, depending on the view.',
+    description: 'Permanently delete or move the selected item to trash, depending on the view.',
     defaultBinding: 'x',
     maxTokens: 1
   },
@@ -1186,10 +1169,7 @@ export function normalizeSequenceBinding(input: string): string | null {
   return tokens.join(' ')
 }
 
-export function normalizeKeymapBinding(
-  id: KeymapId,
-  input: string
-): string | null {
+export function normalizeKeymapBinding(id: KeymapId, input: string): string | null {
   const definition = getKeymapDefinition(id)
   const normalized =
     definition.kind === 'shortcut'
@@ -1199,11 +1179,7 @@ export function normalizeKeymapBinding(
   if (definition.kind === 'sequence' && definition.maxTokens) {
     const tokenCount = normalized.split(/\s+/).filter(Boolean).length
     if (tokenCount > definition.maxTokens) {
-      return normalized
-        .split(/\s+/)
-        .filter(Boolean)
-        .slice(0, definition.maxTokens)
-        .join(' ')
+      return normalized.split(/\s+/).filter(Boolean).slice(0, definition.maxTokens).join(' ')
     }
   }
   return normalized
@@ -1256,15 +1232,10 @@ export function sequenceTokenFromEvent(event: KeyboardEvent): string | null {
   if (event.altKey) modifiers.push('Alt')
   if (event.metaKey) modifiers.push('Meta')
   if (event.shiftKey && base.length !== 1) modifiers.push('Shift')
-  return normalizeSequenceToken(
-    modifiers.length > 0 ? `${modifiers.join('+')}+${base}` : base
-  )
+  return normalizeSequenceToken(modifiers.length > 0 ? `${modifiers.join('+')}+${base}` : base)
 }
 
-export function matchesShortcutBinding(
-  event: KeyboardEvent,
-  binding: string
-): boolean {
+export function matchesShortcutBinding(event: KeyboardEvent, binding: string): boolean {
   const normalized = shortcutBindingFromEvent(event)
   return !!normalized && normalized === binding
 }
@@ -1292,9 +1263,7 @@ export function formatKeyToken(token: string, mac = isMacPlatform()): string {
   if (token.includes('+')) {
     const parts = token.split('+')
     const base = parts.pop() ?? token
-    const prefix = parts
-      .map((part) => formatKeyToken(part, mac))
-      .join(mac ? '' : '+')
+    const prefix = parts.map((part) => formatKeyToken(part, mac)).join(mac ? '' : '+')
     return `${prefix}${mac ? '' : prefix ? '+' : ''}${formatKeyToken(base, mac)}`
   }
   if (token === 'Mod') return mac ? '⌘' : 'Ctrl'
@@ -1351,9 +1320,7 @@ export function getKeymapDefinitionsByGroup(): Array<{
   }))
 }
 
-export function findConflictingKeymaps(
-  overrides: KeymapOverrides
-): Map<KeymapId, KeymapId[]> {
+export function findConflictingKeymaps(overrides: KeymapOverrides): Map<KeymapId, KeymapId[]> {
   const byKey = new Map<string, KeymapDefinition[]>()
   for (const def of KEYMAP_DEFINITIONS) {
     const key = `${def.kind}:${def.scope}:${getKeymapBinding(overrides, def.id)}`
@@ -1385,13 +1352,9 @@ export function findConflictingKeymaps(
  *
  * @returns
  */
-export function getAppVimSequenceMap(
-  overrides: KeymapOverrides
-): Map<string, KeymapDefinition> {
+export function getAppVimSequenceMap(overrides: KeymapOverrides): Map<string, KeymapDefinition> {
   const map = new Map<string, KeymapDefinition>()
-  const leaderKey = toVimSequence(
-    getKeymapBinding(overrides, 'vim.leaderPrefix')
-  )!
+  const leaderKey = toVimSequence(getKeymapBinding(overrides, 'vim.leaderPrefix'))!
   const paneKey = toVimSequence(getKeymapBinding(overrides, 'vim.panePrefix'))!
 
   for (const def of KEYMAP_DEFINITIONS) {

--- a/packages/app-core/src/lib/keymaps.ts
+++ b/packages/app-core/src/lib/keymaps.ts
@@ -1,950 +1,959 @@
-export type KeymapKind = "shortcut" | "sequence";
+import { toVimSequence } from './vim-mappings'
+
+export type KeymapKind = 'shortcut' | 'sequence'
 export type KeymapScope =
-  | "app"
-  | "leader"
-  | "pane"
-  | "vim-editor"
-  | "lists"
-  | "views";
-export type KeymapGroup = "global" | "vim" | "navigation" | "view-actions";
+  | 'app'
+  | 'leader'
+  | 'pane'
+  | 'vim-editor'
+  | 'lists'
+  | 'views'
+export type KeymapGroup = 'global' | 'vim' | 'navigation' | 'view-actions'
 
 export type KeymapId =
-  | "global.searchNotes"
-  | "global.searchNotesNonVim"
-  | "global.commandPalette"
-  | "global.newQuickNote"
-  | "global.openSettings"
-  | "global.toggleSidebar"
-  | "global.toggleConnections"
-  | "global.toggleOutlinePanel"
-  | "global.toggleCommentsPanel"
-  | "global.addComment"
-  | "global.focusPaneLeft"
-  | "global.focusPaneRight"
-  | "global.focusPaneUp"
-  | "global.focusPaneDown"
-  | "global.modeEdit"
-  | "global.modeSplit"
-  | "global.modePreview"
-  | "global.toggleZenMode"
-  | "global.closeActiveTab"
-  | "global.toggleWordWrap"
-  | "global.exportNotePdf"
-  | "global.zoomIn"
-  | "global.zoomOut"
-  | "global.zoomReset"
-  | "vim.leaderPrefix"
-  | "vim.leaderOpenBuffers"
-  | "vim.leaderSearchNotes"
-  | "vim.leaderSearchGroup"
-  | "vim.leaderSearchVaultText"
-  | "vim.leaderToggleSidebar"
-  | "vim.leaderNoteOutline"
-  | "vim.leaderSwitchVault"
-  | "vim.leaderNoteActions"
-  | "vim.leaderFormatNote"
-  | "vim.leaderQuickCapture"
-  | "vim.leaderTemplatePicker"
-  | "vim.leaderInsertTemplate"
-  | "vim.leaderDailyNote"
-  | "vim.leaderWeeklyNote"
-  | "vim.leaderCalendar"
-  | "vim.panePrefix"
-  | "vim.paneFocusLeft"
-  | "vim.paneFocusDown"
-  | "vim.paneFocusUp"
-  | "vim.paneFocusRight"
-  | "vim.paneSplitRight"
-  | "vim.paneSplitDown"
-  | "vim.historyBack"
-  | "vim.historyForward"
-  | "vim.bufferPrevious"
-  | "vim.bufferNext"
-  | "vim.tabPrevious"
-  | "vim.tabNext"
-  | "vim.hintMode"
-  | "vim.goToDefinition"
-  | "vim.foldCurrent"
-  | "vim.unfoldCurrent"
-  | "vim.foldAll"
-  | "vim.unfoldAll"
-  | "nav.moveDown"
-  | "nav.moveUp"
-  | "nav.jumpTop"
-  | "nav.jumpBottom"
-  | "nav.halfPageDown"
-  | "nav.halfPageUp"
-  | "nav.openSideItem"
-  | "nav.openResult"
-  | "nav.back"
-  | "nav.toggleFolder"
-  | "nav.filter"
-  | "nav.contextMenu"
-  | "nav.peekPreview"
-  | "nav.restore"
-  | "nav.delete"
-  | "nav.toggleTask"
-  | "nav.localEx"
-  | "nav.newQuickNote"
-  | "nav.unarchive";
+  | 'global.searchNotes'
+  | 'global.searchNotesNonVim'
+  | 'global.commandPalette'
+  | 'global.newQuickNote'
+  | 'global.openSettings'
+  | 'global.toggleSidebar'
+  | 'global.toggleConnections'
+  | 'global.toggleOutlinePanel'
+  | 'global.toggleCommentsPanel'
+  | 'global.addComment'
+  | 'global.focusPaneLeft'
+  | 'global.focusPaneRight'
+  | 'global.focusPaneUp'
+  | 'global.focusPaneDown'
+  | 'global.modeEdit'
+  | 'global.modeSplit'
+  | 'global.modePreview'
+  | 'global.toggleZenMode'
+  | 'global.closeActiveTab'
+  | 'global.toggleWordWrap'
+  | 'global.exportNotePdf'
+  | 'global.zoomIn'
+  | 'global.zoomOut'
+  | 'global.zoomReset'
+  | 'vim.leaderPrefix'
+  | 'vim.leaderOpenBuffers'
+  | 'vim.leaderSearchNotes'
+  | 'vim.leaderSearchGroup'
+  | 'vim.leaderSearchVaultText'
+  | 'vim.leaderToggleSidebar'
+  | 'vim.leaderNoteOutline'
+  | 'vim.leaderSwitchVault'
+  | 'vim.leaderNoteActions'
+  | 'vim.leaderFormatNote'
+  | 'vim.leaderQuickCapture'
+  | 'vim.leaderTemplatePicker'
+  | 'vim.leaderInsertTemplate'
+  | 'vim.leaderDailyNote'
+  | 'vim.leaderWeeklyNote'
+  | 'vim.leaderCalendar'
+  | 'vim.panePrefix'
+  | 'vim.paneFocusLeft'
+  | 'vim.paneFocusDown'
+  | 'vim.paneFocusUp'
+  | 'vim.paneFocusRight'
+  | 'vim.paneSplitRight'
+  | 'vim.paneSplitDown'
+  | 'vim.historyBack'
+  | 'vim.historyForward'
+  | 'vim.bufferPrevious'
+  | 'vim.bufferNext'
+  | 'vim.tabPrevious'
+  | 'vim.tabNext'
+  | 'vim.hintMode'
+  | 'vim.goToDefinition'
+  | 'vim.foldCurrent'
+  | 'vim.unfoldCurrent'
+  | 'vim.foldAll'
+  | 'vim.unfoldAll'
+  | 'nav.moveDown'
+  | 'nav.moveUp'
+  | 'nav.jumpTop'
+  | 'nav.jumpBottom'
+  | 'nav.halfPageDown'
+  | 'nav.halfPageUp'
+  | 'nav.openSideItem'
+  | 'nav.openResult'
+  | 'nav.back'
+  | 'nav.toggleFolder'
+  | 'nav.filter'
+  | 'nav.contextMenu'
+  | 'nav.peekPreview'
+  | 'nav.restore'
+  | 'nav.delete'
+  | 'nav.toggleTask'
+  | 'nav.localEx'
+  | 'nav.newQuickNote'
+  | 'nav.unarchive'
 
-export type KeymapOverrides = Partial<Record<KeymapId, string>>;
+export type KeymapOverrides = Partial<Record<KeymapId, string>>
 
 export interface KeymapDefinition {
-  id: KeymapId;
-  kind: KeymapKind;
-  scope: KeymapScope;
-  group: KeymapGroup;
-  title: string;
-  description: string;
-  defaultBinding: string;
-  vimOnly?: boolean;
-  nonVimOnly?: boolean;
-  maxTokens?: number;
+  id: KeymapId
+  kind: KeymapKind
+  scope: KeymapScope
+  group: KeymapGroup
+  title: string
+  description: string
+  defaultBinding: string
+  vimOnly?: boolean
+  nonVimOnly?: boolean
+  maxTokens?: number
 }
 
 const KEYMAP_DEFINITIONS: KeymapDefinition[] = [
   {
-    id: "global.searchNotes",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Search notes",
-    description: "Open the vault-wide note search palette.",
-    defaultBinding: "Mod+P",
+    id: 'global.searchNotes',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Search notes',
+    description: 'Open the vault-wide note search palette.',
+    defaultBinding: 'Mod+P',
   },
   {
-    id: "global.searchNotesNonVim",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Search notes in non-Vim mode",
-    description: "Extra direct search shortcut when Vim mode is off.",
-    defaultBinding: "Mod+F",
+    id: 'global.searchNotesNonVim',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Search notes in non-Vim mode',
+    description: 'Extra direct search shortcut when Vim mode is off.',
+    defaultBinding: 'Mod+F',
     nonVimOnly: true,
   },
   {
-    id: "global.commandPalette",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Open command palette",
-    description: "Open the command palette.",
-    defaultBinding: "Shift+Mod+P",
+    id: 'global.commandPalette',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Open command palette',
+    description: 'Open the command palette.',
+    defaultBinding: 'Shift+Mod+P',
   },
   {
-    id: "global.newQuickNote",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "New quick note",
-    description: "Create a quick capture note and focus its title.",
-    defaultBinding: "Shift+Mod+N",
+    id: 'global.newQuickNote',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'New quick note',
+    description: 'Create a quick capture note and focus its title.',
+    defaultBinding: 'Shift+Mod+N',
   },
   {
-    id: "global.openSettings",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Open settings",
-    description: "Open the Settings modal.",
-    defaultBinding: "Mod+,",
+    id: 'global.openSettings',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Open settings',
+    description: 'Open the Settings modal.',
+    defaultBinding: 'Mod+,',
   },
   {
-    id: "global.toggleSidebar",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Toggle sidebar",
-    description: "Hide or show the left sidebar.",
-    defaultBinding: "Mod+1",
+    id: 'global.toggleSidebar',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Toggle sidebar',
+    description: 'Hide or show the left sidebar.',
+    defaultBinding: 'Mod+1',
   },
   {
-    id: "global.toggleConnections",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Toggle connections panel",
-    description: "Toggle the connections panel in the active pane.",
-    defaultBinding: "Mod+2",
+    id: 'global.toggleConnections',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Toggle connections panel',
+    description: 'Toggle the connections panel in the active pane.',
+    defaultBinding: 'Mod+2',
   },
   {
-    id: "global.toggleOutlinePanel",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Toggle outline panel",
-    description: "Toggle the outline panel in the active pane.",
-    defaultBinding: "Mod+3",
+    id: 'global.toggleOutlinePanel',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Toggle outline panel',
+    description: 'Toggle the outline panel in the active pane.',
+    defaultBinding: 'Mod+3',
   },
   {
-    id: "global.toggleCommentsPanel",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Toggle comments panel",
-    description: "Toggle the comments panel in the active pane.",
-    defaultBinding: "Mod+Shift+C",
+    id: 'global.toggleCommentsPanel',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Toggle comments panel',
+    description: 'Toggle the comments panel in the active pane.',
+    defaultBinding: 'Mod+Shift+C',
   },
   {
-    id: "global.addComment",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Add comment to selection",
-    description: "Start a comment on the selected text (or current line).",
-    defaultBinding: "Mod+Alt+M",
+    id: 'global.addComment',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Add comment to selection',
+    description: 'Start a comment on the selected text (or current line).',
+    defaultBinding: 'Mod+Alt+M',
   },
   {
-    id: "global.focusPaneLeft",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Focus pane left",
-    description: "Move focus to the pane/panel on the left. Works without vim mode.",
-    defaultBinding: "Alt+H",
+    id: 'global.focusPaneLeft',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Focus pane left',
+    description:
+      'Move focus to the pane/panel on the left. Works without vim mode.',
+    defaultBinding: 'Alt+H',
   },
   {
-    id: "global.focusPaneDown",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Focus pane down",
-    description: "Move focus to the pane/panel below. Works without vim mode.",
-    defaultBinding: "Alt+J",
+    id: 'global.focusPaneDown',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Focus pane down',
+    description: 'Move focus to the pane/panel below. Works without vim mode.',
+    defaultBinding: 'Alt+J',
   },
   {
-    id: "global.focusPaneUp",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Focus pane up",
-    description: "Move focus to the pane/panel above. Works without vim mode.",
-    defaultBinding: "Alt+K",
+    id: 'global.focusPaneUp',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Focus pane up',
+    description: 'Move focus to the pane/panel above. Works without vim mode.',
+    defaultBinding: 'Alt+K',
   },
   {
-    id: "global.focusPaneRight",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Focus pane right",
-    description: "Move focus to the pane/panel on the right. Works without vim mode.",
-    defaultBinding: "Alt+L",
+    id: 'global.focusPaneRight',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Focus pane right',
+    description:
+      'Move focus to the pane/panel on the right. Works without vim mode.',
+    defaultBinding: 'Alt+L',
   },
   {
-    id: "global.modeEdit",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Switch to editor mode",
-    description: "Show only the markdown editor for the active note.",
-    defaultBinding: "Mod+4",
+    id: 'global.modeEdit',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Switch to editor mode',
+    description: 'Show only the markdown editor for the active note.',
+    defaultBinding: 'Mod+4',
   },
   {
-    id: "global.modeSplit",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Switch to split mode",
-    description: "Show the editor and rendered preview side by side.",
-    defaultBinding: "Mod+5",
+    id: 'global.modeSplit',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Switch to split mode',
+    description: 'Show the editor and rendered preview side by side.',
+    defaultBinding: 'Mod+5',
   },
   {
-    id: "global.modePreview",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Switch to preview mode",
-    description: "Show only the rendered preview for the active note.",
-    defaultBinding: "Mod+6",
+    id: 'global.modePreview',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Switch to preview mode',
+    description: 'Show only the rendered preview for the active note.',
+    defaultBinding: 'Mod+6',
   },
   {
-    id: "global.toggleZenMode",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Toggle Zen mode",
-    description: "Hide or restore the app chrome.",
-    defaultBinding: "Mod+.",
+    id: 'global.toggleZenMode',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Toggle Zen mode',
+    description: 'Hide or restore the app chrome.',
+    defaultBinding: 'Mod+.',
   },
   {
-    id: "global.closeActiveTab",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Close active tab",
-    description: "Close the current note or virtual tab.",
-    defaultBinding: "Mod+W",
+    id: 'global.closeActiveTab',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Close active tab',
+    description: 'Close the current note or virtual tab.',
+    defaultBinding: 'Mod+W',
   },
   {
-    id: "global.toggleWordWrap",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Toggle word wrap",
-    description: "Switch between wrapped lines and horizontal scrolling.",
-    defaultBinding: "Alt+Z",
+    id: 'global.toggleWordWrap',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Toggle word wrap',
+    description: 'Switch between wrapped lines and horizontal scrolling.',
+    defaultBinding: 'Alt+Z',
   },
   {
-    id: "global.exportNotePdf",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Export note as PDF",
-    description: "Export the active note as a PDF file.",
-    defaultBinding: "Shift+Mod+E",
+    id: 'global.exportNotePdf',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Export note as PDF',
+    description: 'Export the active note as a PDF file.',
+    defaultBinding: 'Shift+Mod+E',
   },
   {
-    id: "global.zoomIn",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Zoom in",
-    description: "Increase the app zoom factor.",
-    defaultBinding: "Mod+=",
+    id: 'global.zoomIn',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Zoom in',
+    description: 'Increase the app zoom factor.',
+    defaultBinding: 'Mod+=',
   },
   {
-    id: "global.zoomOut",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Zoom out",
-    description: "Decrease the app zoom factor.",
-    defaultBinding: "Mod+-",
+    id: 'global.zoomOut',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Zoom out',
+    description: 'Decrease the app zoom factor.',
+    defaultBinding: 'Mod+-',
   },
   {
-    id: "global.zoomReset",
-    kind: "shortcut",
-    scope: "app",
-    group: "global",
-    title: "Reset zoom",
-    description: "Restore the app zoom factor to its default size.",
-    defaultBinding: "Mod+0",
+    id: 'global.zoomReset',
+    kind: 'shortcut',
+    scope: 'app',
+    group: 'global',
+    title: 'Reset zoom',
+    description: 'Restore the app zoom factor to its default size.',
+    defaultBinding: 'Mod+0',
   },
   {
-    id: "vim.leaderPrefix",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader key",
-    description: "Start leader mode and leader hints.",
-    defaultBinding: "Space",
+    id: 'vim.leaderPrefix',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader key',
+    description: 'Start leader mode and leader hints.',
+    defaultBinding: 'Space',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderOpenBuffers",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: open buffers",
-    description: "Open the buffer switcher.",
-    defaultBinding: "o",
+    id: 'vim.leaderOpenBuffers',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: open buffers',
+    description: 'Open the buffer switcher.',
+    defaultBinding: 'o',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderSearchNotes",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: search notes",
-    description: "Open note search from any panel.",
-    defaultBinding: "f",
+    id: 'vim.leaderSearchNotes',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: search notes',
+    description: 'Open note search from any panel.',
+    defaultBinding: 'f',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderSearchGroup",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: search…",
-    description: "Open the search leader group (text search, etc.).",
-    defaultBinding: "s",
+    id: 'vim.leaderSearchGroup',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: search…',
+    description: 'Open the search leader group (text search, etc.).',
+    defaultBinding: 's',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderSearchVaultText",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader search: vault text",
-    description: "Open fuzzy vault text search across note contents (under the search group).",
-    defaultBinding: "t",
+    id: 'vim.leaderSearchVaultText',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader search: vault text',
+    description:
+      'Open fuzzy vault text search across note contents (under the search group).',
+    defaultBinding: 't',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderToggleSidebar",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: toggle sidebar",
-    description: "Show or hide the left sidebar.",
-    defaultBinding: "e",
+    id: 'vim.leaderToggleSidebar',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: toggle sidebar',
+    description: 'Show or hide the left sidebar.',
+    defaultBinding: 'e',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderNoteOutline",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: note outline",
-    description: "Open the note outline palette.",
-    defaultBinding: "p",
+    id: 'vim.leaderNoteOutline',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: note outline',
+    description: 'Open the note outline palette.',
+    defaultBinding: 'p',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderSwitchVault",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: switch vault",
-    description: "Open the command palette vault switcher.",
-    defaultBinding: "v",
+    id: 'vim.leaderSwitchVault',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: switch vault',
+    description: 'Open the command palette vault switcher.',
+    defaultBinding: 'v',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderNoteActions",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: note actions",
-    description: "Open the note-local leader group.",
-    defaultBinding: "l",
+    id: 'vim.leaderNoteActions',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: note actions',
+    description: 'Open the note-local leader group.',
+    defaultBinding: 'l',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderFormatNote",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader note action: format note",
-    description: "Format the active note from the editor.",
-    defaultBinding: "f",
+    id: 'vim.leaderFormatNote',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader note action: format note',
+    description: 'Format the active note from the editor.',
+    defaultBinding: 'f',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderQuickCapture",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: open quick capture",
-    description: "Open the floating quick capture window.",
-    defaultBinding: "q",
+    id: 'vim.leaderQuickCapture',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: open quick capture',
+    description: 'Open the floating quick capture window.',
+    defaultBinding: 'q',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderTemplatePicker",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: new from template",
-    description: "Open the template picker to create a note.",
-    defaultBinding: "t",
+    id: 'vim.leaderTemplatePicker',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: new from template',
+    description: 'Open the template picker to create a note.',
+    defaultBinding: 't',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderInsertTemplate",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: insert template into note",
-    description: "Render a template into the current note.",
-    defaultBinding: "i",
+    id: 'vim.leaderInsertTemplate',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: insert template into note',
+    description: 'Render a template into the current note.',
+    defaultBinding: 'i',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderDailyNote",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
+    id: 'vim.leaderDailyNote',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
     title: "Leader: today's daily note",
     description: "Open or create today's daily note.",
-    defaultBinding: "d",
+    defaultBinding: 'd',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderWeeklyNote",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
+    id: 'vim.leaderWeeklyNote',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
     title: "Leader: this week's note",
     description: "Open or create this week's weekly note.",
-    defaultBinding: "w",
+    defaultBinding: 'w',
     vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "vim.leaderCalendar",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: toggle calendar",
-    description: "Toggle the calendar panel for the active daily or weekly note.",
-    defaultBinding: "c",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.panePrefix",
-    kind: "sequence",
-    scope: "pane",
-    group: "vim",
-    title: "Pane command prefix",
-    description: "Start pane focus and split commands.",
-    defaultBinding: "Ctrl+W",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.paneFocusLeft",
-    kind: "sequence",
-    scope: "pane",
-    group: "vim",
-    title: "Pane: focus left",
-    description: "Move focus to the panel or pane on the left.",
-    defaultBinding: "h",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.paneFocusDown",
-    kind: "sequence",
-    scope: "pane",
-    group: "vim",
-    title: "Pane: focus down",
-    description: "Move focus to the panel or pane below.",
-    defaultBinding: "j",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.paneFocusUp",
-    kind: "sequence",
-    scope: "pane",
-    group: "vim",
-    title: "Pane: focus up",
-    description: "Move focus to the panel or pane above.",
-    defaultBinding: "k",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.paneFocusRight",
-    kind: "sequence",
-    scope: "pane",
-    group: "vim",
-    title: "Pane: focus right",
-    description: "Move focus to the panel or pane on the right.",
-    defaultBinding: "l",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.paneSplitRight",
-    kind: "sequence",
-    scope: "pane",
-    group: "vim",
-    title: "Pane: split right",
-    description: "Clone the current tab into a pane on the right.",
-    defaultBinding: "v",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.paneSplitDown",
-    kind: "sequence",
-    scope: "pane",
-    group: "vim",
-    title: "Pane: split down",
-    description: "Clone the current tab into a pane below.",
-    defaultBinding: "s",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.historyBack",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Go back in note history",
-    description: "Jump to the previous note location in history.",
-    defaultBinding: "Ctrl+O",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.historyForward",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Go forward in note history",
-    description: "Jump forward in note history.",
-    defaultBinding: "Ctrl+I",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.bufferPrevious",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Previous buffer",
-    description: "Move to the previous open buffer, or a recent note when only one buffer is open.",
-    defaultBinding: "[ b",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "vim.bufferNext",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Next buffer",
-    description: "Move to the next open buffer, or a recent note when only one buffer is open.",
-    defaultBinding: "] b",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "vim.tabPrevious",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Previous tab",
-    description: "Go to the previous tab in the active pane (Vim-style gT).",
-    defaultBinding: "g T",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "vim.tabNext",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Next tab",
-    description: "Go to the next tab in the active pane (Vim-style gt).",
-    defaultBinding: "g t",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "vim.hintMode",
-    kind: "sequence",
-    scope: "leader",
-    group: "vim",
-    title: "Leader: hint mode",
-    description: "Show jump labels for clickable targets (jump to any button or link).",
-    defaultBinding: "h",
-    vimOnly: true,
-    maxTokens: 1,
-  },
-  {
-    id: "vim.goToDefinition",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Follow link at cursor",
-    description: "Open the note, URL, or asset under the cursor.",
-    defaultBinding: "g d",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "vim.foldCurrent",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Fold heading at cursor",
-    description: "Collapse the heading section at the cursor.",
-    defaultBinding: "z c",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "vim.unfoldCurrent",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Unfold heading at cursor",
-    description: "Expand the heading section at the cursor.",
-    defaultBinding: "z o",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "vim.foldAll",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Fold all headings",
-    description: "Collapse every heading section in the note.",
-    defaultBinding: "z M",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "vim.unfoldAll",
-    kind: "sequence",
-    scope: "vim-editor",
-    group: "vim",
-    title: "Unfold all headings",
-    description: "Expand every heading section in the note.",
-    defaultBinding: "z R",
-    vimOnly: true,
-    maxTokens: 2,
-  },
-  {
-    id: "nav.moveDown",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Move selection down",
-    description: "Move the current row cursor or panel selection down.",
-    defaultBinding: "j",
-    maxTokens: 1,
-  },
-  {
-    id: "nav.moveUp",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Move selection up",
-    description: "Move the current row cursor or panel selection up.",
-    defaultBinding: "k",
-    maxTokens: 1,
-  },
-  {
-    id: "nav.jumpTop",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Jump to top",
+    id: 'vim.leaderCalendar',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: toggle calendar',
     description:
-      "Jump to the first visible row or to the top of preview content.",
-    defaultBinding: "g g",
+      'Toggle the calendar panel for the active daily or weekly note.',
+    defaultBinding: 'c',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.panePrefix',
+    kind: 'sequence',
+    scope: 'pane',
+    group: 'vim',
+    title: 'Pane command prefix',
+    description: 'Start pane focus and split commands.',
+    defaultBinding: 'Ctrl+W',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.paneFocusLeft',
+    kind: 'sequence',
+    scope: 'pane',
+    group: 'vim',
+    title: 'Pane: focus left',
+    description: 'Move focus to the panel or pane on the left.',
+    defaultBinding: 'h',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.paneFocusDown',
+    kind: 'sequence',
+    scope: 'pane',
+    group: 'vim',
+    title: 'Pane: focus down',
+    description: 'Move focus to the panel or pane below.',
+    defaultBinding: 'j',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.paneFocusUp',
+    kind: 'sequence',
+    scope: 'pane',
+    group: 'vim',
+    title: 'Pane: focus up',
+    description: 'Move focus to the panel or pane above.',
+    defaultBinding: 'k',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.paneFocusRight',
+    kind: 'sequence',
+    scope: 'pane',
+    group: 'vim',
+    title: 'Pane: focus right',
+    description: 'Move focus to the panel or pane on the right.',
+    defaultBinding: 'l',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.paneSplitRight',
+    kind: 'sequence',
+    scope: 'pane',
+    group: 'vim',
+    title: 'Pane: split right',
+    description: 'Clone the current tab into a pane on the right.',
+    defaultBinding: 'v',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.paneSplitDown',
+    kind: 'sequence',
+    scope: 'pane',
+    group: 'vim',
+    title: 'Pane: split down',
+    description: 'Clone the current tab into a pane below.',
+    defaultBinding: 's',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.historyBack',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Go back in note history',
+    description: 'Jump to the previous note location in history.',
+    defaultBinding: 'Ctrl+O',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.historyForward',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Go forward in note history',
+    description: 'Jump forward in note history.',
+    defaultBinding: 'Ctrl+I',
+    vimOnly: true,
+    maxTokens: 1,
+  },
+  {
+    id: 'vim.bufferPrevious',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Previous buffer',
+    description:
+      'Move to the previous open buffer, or a recent note when only one buffer is open.',
+    defaultBinding: '[ b',
+    vimOnly: true,
     maxTokens: 2,
   },
   {
-    id: "nav.jumpBottom",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Jump to bottom",
+    id: 'vim.bufferNext',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Next buffer',
     description:
-      "Jump to the last visible row or to the bottom of preview content.",
-    defaultBinding: "G",
-    maxTokens: 1,
+      'Move to the next open buffer, or a recent note when only one buffer is open.',
+    defaultBinding: '] b',
+    vimOnly: true,
+    maxTokens: 2,
   },
   {
-    id: "nav.halfPageDown",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Half-page down",
-    description: "Scroll preview content down by half a viewport.",
-    defaultBinding: "Ctrl+d",
-    maxTokens: 1,
+    id: 'vim.tabPrevious',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Previous tab',
+    description: 'Go to the previous tab in the active pane (Vim-style gT).',
+    defaultBinding: 'g T',
+    vimOnly: true,
+    maxTokens: 2,
   },
   {
-    id: "nav.halfPageUp",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Half-page up",
-    description: "Scroll preview content up by half a viewport.",
-    defaultBinding: "Ctrl+u",
-    maxTokens: 1,
+    id: 'vim.tabNext',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Next tab',
+    description: 'Go to the next tab in the active pane (Vim-style gt).',
+    defaultBinding: 'g t',
+    vimOnly: true,
+    maxTokens: 2,
   },
   {
-    id: "nav.openSideItem",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Open sidebar or note-list item",
-    description: "Open the current sidebar or note-list selection.",
-    defaultBinding: "l",
-    maxTokens: 1,
-  },
-  {
-    id: "nav.openResult",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Open result",
-    description: "Open the selected note or result in a view.",
-    defaultBinding: "o",
-    maxTokens: 1,
-  },
-  {
-    id: "nav.back",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Back out",
-    description: "Collapse, move left, or return focus toward the editor.",
-    defaultBinding: "h",
-    maxTokens: 1,
-  },
-  {
-    id: "nav.toggleFolder",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Toggle folder",
-    description: "Expand or collapse the current sidebar folder.",
-    defaultBinding: "o",
-    maxTokens: 1,
-  },
-  {
-    id: "nav.filter",
-    kind: "sequence",
-    scope: "lists",
-    group: "navigation",
-    title: "Focus filter or search",
+    id: 'vim.hintMode',
+    kind: 'sequence',
+    scope: 'leader',
+    group: 'vim',
+    title: 'Leader: hint mode',
     description:
-      "Focus the local filter or open note search from panel navigation.",
-    defaultBinding: "/",
+      'Show jump labels for clickable targets (jump to any button or link).',
+    defaultBinding: 'h',
+    vimOnly: true,
     maxTokens: 1,
   },
   {
-    id: "nav.contextMenu",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Open context menu",
-    description: "Open the contextual actions menu for the current row.",
-    defaultBinding: "m",
+    id: 'vim.goToDefinition',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Follow link at cursor',
+    description: 'Open the note, URL, or asset under the cursor.',
+    defaultBinding: 'g d',
+    vimOnly: true,
+    maxTokens: 2,
+  },
+  {
+    id: 'vim.foldCurrent',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Fold heading at cursor',
+    description: 'Collapse the heading section at the cursor.',
+    defaultBinding: 'z c',
+    vimOnly: true,
+    maxTokens: 2,
+  },
+  {
+    id: 'vim.unfoldCurrent',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Unfold heading at cursor',
+    description: 'Expand the heading section at the cursor.',
+    defaultBinding: 'z o',
+    vimOnly: true,
+    maxTokens: 2,
+  },
+  {
+    id: 'vim.foldAll',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Fold all headings',
+    description: 'Collapse every heading section in the note.',
+    defaultBinding: 'z M',
+    vimOnly: true,
+    maxTokens: 2,
+  },
+  {
+    id: 'vim.unfoldAll',
+    kind: 'sequence',
+    scope: 'vim-editor',
+    group: 'vim',
+    title: 'Unfold all headings',
+    description: 'Expand every heading section in the note.',
+    defaultBinding: 'z R',
+    vimOnly: true,
+    maxTokens: 2,
+  },
+  {
+    id: 'nav.moveDown',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Move selection down',
+    description: 'Move the current row cursor or panel selection down.',
+    defaultBinding: 'j',
     maxTokens: 1,
   },
   {
-    id: "nav.peekPreview",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Peek preview",
-    description: "Open the hover preview for the selected connection.",
-    defaultBinding: "p",
+    id: 'nav.moveUp',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Move selection up',
+    description: 'Move the current row cursor or panel selection up.',
+    defaultBinding: 'k',
     maxTokens: 1,
   },
   {
-    id: "nav.restore",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Restore trashed note",
-    description: "Restore the selected trashed note.",
-    defaultBinding: "r",
-    maxTokens: 1,
-  },
-  {
-    id: "nav.delete",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Delete selected result",
+    id: 'nav.jumpTop',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Jump to top',
     description:
-      "Permanently delete or move the selected item to trash, depending on the view.",
-    defaultBinding: "x",
+      'Jump to the first visible row or to the top of preview content.',
+    defaultBinding: 'g g',
+    maxTokens: 2,
+  },
+  {
+    id: 'nav.jumpBottom',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Jump to bottom',
+    description:
+      'Jump to the last visible row or to the bottom of preview content.',
+    defaultBinding: 'G',
     maxTokens: 1,
   },
   {
-    id: "nav.toggleTask",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Toggle task",
-    description: "Check or uncheck the selected task.",
-    defaultBinding: "x",
+    id: 'nav.halfPageDown',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Half-page down',
+    description: 'Scroll preview content down by half a viewport.',
+    defaultBinding: 'Ctrl+d',
     maxTokens: 1,
   },
   {
-    id: "nav.localEx",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Open local ex prompt",
-    description: "Open the view-specific ex prompt in Tasks or Tags.",
-    defaultBinding: ":",
+    id: 'nav.halfPageUp',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Half-page up',
+    description: 'Scroll preview content up by half a viewport.',
+    defaultBinding: 'Ctrl+u',
     maxTokens: 1,
   },
   {
-    id: "nav.newQuickNote",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "New quick note from Quick Notes view",
-    description: "Create a new quick note from the Quick Notes list tab.",
-    defaultBinding: "n",
+    id: 'nav.openSideItem',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Open sidebar or note-list item',
+    description: 'Open the current sidebar or note-list selection.',
+    defaultBinding: 'l',
     maxTokens: 1,
   },
   {
-    id: "nav.unarchive",
-    kind: "sequence",
-    scope: "views",
-    group: "view-actions",
-    title: "Unarchive selected note",
-    description: "Move the selected archived note back to Inbox.",
-    defaultBinding: "u",
+    id: 'nav.openResult',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Open result',
+    description: 'Open the selected note or result in a view.',
+    defaultBinding: 'o',
     maxTokens: 1,
   },
-];
+  {
+    id: 'nav.back',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Back out',
+    description: 'Collapse, move left, or return focus toward the editor.',
+    defaultBinding: 'h',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.toggleFolder',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Toggle folder',
+    description: 'Expand or collapse the current sidebar folder.',
+    defaultBinding: 'o',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.filter',
+    kind: 'sequence',
+    scope: 'lists',
+    group: 'navigation',
+    title: 'Focus filter or search',
+    description:
+      'Focus the local filter or open note search from panel navigation.',
+    defaultBinding: '/',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.contextMenu',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Open context menu',
+    description: 'Open the contextual actions menu for the current row.',
+    defaultBinding: 'm',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.peekPreview',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Peek preview',
+    description: 'Open the hover preview for the selected connection.',
+    defaultBinding: 'p',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.restore',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Restore trashed note',
+    description: 'Restore the selected trashed note.',
+    defaultBinding: 'r',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.delete',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Delete selected result',
+    description:
+      'Permanently delete or move the selected item to trash, depending on the view.',
+    defaultBinding: 'x',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.toggleTask',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Toggle task',
+    description: 'Check or uncheck the selected task.',
+    defaultBinding: 'x',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.localEx',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Open local ex prompt',
+    description: 'Open the view-specific ex prompt in Tasks or Tags.',
+    defaultBinding: ':',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.newQuickNote',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'New quick note from Quick Notes view',
+    description: 'Create a new quick note from the Quick Notes list tab.',
+    defaultBinding: 'n',
+    maxTokens: 1,
+  },
+  {
+    id: 'nav.unarchive',
+    kind: 'sequence',
+    scope: 'views',
+    group: 'view-actions',
+    title: 'Unarchive selected note',
+    description: 'Move the selected archived note back to Inbox.',
+    defaultBinding: 'u',
+    maxTokens: 1,
+  },
+]
 
 for (const definition of KEYMAP_DEFINITIONS) {
   const normalized =
-    definition.kind === "shortcut"
+    definition.kind === 'shortcut'
       ? normalizeShortcutBinding(definition.defaultBinding)
-      : normalizeSequenceBinding(definition.defaultBinding);
-  if (normalized) definition.defaultBinding = normalized;
+      : normalizeSequenceBinding(definition.defaultBinding)
+  if (normalized) definition.defaultBinding = normalized
 }
 
 const KEYMAP_INDEX = new Map<KeymapId, KeymapDefinition>(
   KEYMAP_DEFINITIONS.map((definition) => [definition.id, definition] as const),
-);
+)
 
 const KEYMAP_GROUP_LABELS: Record<KeymapGroup, string> = {
-  global: "Global shortcuts",
-  vim: "Vim-specific shortcuts",
-  navigation: "Navigation",
-  "view-actions": "View-specific actions",
-};
+  global: 'Global shortcuts',
+  vim: 'Vim-specific shortcuts',
+  navigation: 'Navigation',
+  'view-actions': 'View-specific actions',
+}
 
 export function getKeymapDefinitions(): KeymapDefinition[] {
-  return KEYMAP_DEFINITIONS.slice();
+  return KEYMAP_DEFINITIONS.slice()
 }
 
 export function getKeymapDefinition(id: KeymapId): KeymapDefinition {
-  const definition = KEYMAP_INDEX.get(id);
-  if (!definition) throw new Error(`Unknown keymap id: ${id}`);
-  return definition;
+  const definition = KEYMAP_INDEX.get(id)
+  if (!definition) throw new Error(`Unknown keymap id: ${id}`)
+  return definition
 }
 
 export function getKeymapGroupLabel(group: KeymapGroup): string {
-  return KEYMAP_GROUP_LABELS[group];
+  return KEYMAP_GROUP_LABELS[group]
 }
 
 export function getDefaultKeymapBinding(id: KeymapId): string {
-  return getKeymapDefinition(id).defaultBinding;
+  return getKeymapDefinition(id).defaultBinding
 }
 
 export function getKeymapBinding(
   overrides: KeymapOverrides | null | undefined,
   id: KeymapId,
 ): string {
-  const override = overrides?.[id];
-  return override || getDefaultKeymapBinding(id);
+  const override = overrides?.[id]
+  return override || getDefaultKeymapBinding(id)
 }
 
 export function getSequenceTokens(
@@ -954,76 +963,74 @@ export function getSequenceTokens(
   return getKeymapBinding(overrides, id)
     .split(/\s+/)
     .map((token) => token.trim())
-    .filter(Boolean);
+    .filter(Boolean)
 }
 
-type RuntimeZenApi = { platformSync?: () => NodeJS.Platform };
+type RuntimeZenApi = { platformSync?: () => NodeJS.Platform }
 
 function getRuntimePlatform(): NodeJS.Platform | null {
-  if (typeof window !== "undefined") {
-    const zen = (window as Window & { zen?: RuntimeZenApi }).zen;
-    if (typeof zen?.platformSync === "function") {
-      return zen.platformSync();
+  if (typeof window !== 'undefined') {
+    const zen = (window as Window & { zen?: RuntimeZenApi }).zen
+    if (typeof zen?.platformSync === 'function') {
+      return zen.platformSync()
     }
   }
-  if (typeof process !== "undefined" && typeof process.platform === "string") {
-    return process.platform as NodeJS.Platform;
+  if (typeof process !== 'undefined' && typeof process.platform === 'string') {
+    return process.platform as NodeJS.Platform
   }
-  return null;
+  return null
 }
 
 export function isMacPlatform(): boolean {
-  const runtimePlatform = getRuntimePlatform();
-  if (runtimePlatform) return runtimePlatform === "darwin";
-  if (typeof navigator === "undefined") return true;
-  return /Mac|iPhone|iPad|iPod/i.test(navigator.platform);
+  const runtimePlatform = getRuntimePlatform()
+  if (runtimePlatform) return runtimePlatform === 'darwin'
+  if (typeof navigator === 'undefined') return true
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.platform)
 }
 
 function isModifierKey(key: string): boolean {
-  return (
-    key === "Shift" || key === "Control" || key === "Alt" || key === "Meta"
-  );
+  return key === 'Shift' || key === 'Control' || key === 'Alt' || key === 'Meta'
 }
 
 function physicalKeyFromCode(code: string): string | null {
-  if (/^Key[A-Z]$/.test(code)) return code.slice(3);
-  if (/^Digit\d$/.test(code)) return code.slice(5);
-  if (/^Numpad\d$/.test(code)) return code.slice(6);
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3)
+  if (/^Digit\d$/.test(code)) return code.slice(5)
+  if (/^Numpad\d$/.test(code)) return code.slice(6)
   switch (code) {
-    case "Minus":
-      return "-";
-    case "Equal":
-      return "=";
-    case "BracketLeft":
-      return "[";
-    case "BracketRight":
-      return "]";
-    case "Backslash":
-      return "\\";
-    case "Semicolon":
-      return ";";
-    case "Quote":
-      return "'";
-    case "Comma":
-      return ",";
-    case "Period":
-      return ".";
-    case "Slash":
-      return "/";
-    case "Backquote":
-      return "`";
-    case "NumpadAdd":
-      return "+";
-    case "NumpadSubtract":
-      return "-";
-    case "NumpadMultiply":
-      return "*";
-    case "NumpadDivide":
-      return "/";
-    case "NumpadDecimal":
-      return ".";
+    case 'Minus':
+      return '-'
+    case 'Equal':
+      return '='
+    case 'BracketLeft':
+      return '['
+    case 'BracketRight':
+      return ']'
+    case 'Backslash':
+      return '\\'
+    case 'Semicolon':
+      return ';'
+    case 'Quote':
+      return "'"
+    case 'Comma':
+      return ','
+    case 'Period':
+      return '.'
+    case 'Slash':
+      return '/'
+    case 'Backquote':
+      return '`'
+    case 'NumpadAdd':
+      return '+'
+    case 'NumpadSubtract':
+      return '-'
+    case 'NumpadMultiply':
+      return '*'
+    case 'NumpadDivide':
+      return '/'
+    case 'NumpadDecimal':
+      return '.'
     default:
-      return null;
+      return null
   }
 }
 
@@ -1048,111 +1055,113 @@ function physicalKeyFromCode(code: string): string | null {
  * `normalizeKeyName(event.key)`.
  */
 function resolveKeyFromEvent(event: KeyboardEvent): string | null {
-  if (isModifierKey(event.key)) return null;
-  const k = event.key;
+  if (isModifierKey(event.key)) return null
+  const k = event.key
   // Skip the typed-char fast path for '+': it is the binding-string
   // separator, so emitting it would produce unparsable strings like
   // "Mod+Shift++". Fall through to physicalKeyFromCode (event.code
   // = "Equal" -> "=" for Shift+Cmd+=).
-  if (k.length === 1 && k !== "+") {
-    const cp = k.charCodeAt(0);
+  if (k.length === 1 && k !== '+') {
+    const cp = k.charCodeAt(0)
     if (cp > 0x20 && cp < 0x7f) {
-      return k.toUpperCase();
+      return k.toUpperCase()
     }
   }
-  return physicalKeyFromCode(event.code);
+  return physicalKeyFromCode(event.code)
 }
 
 function normalizeKeyName(key: string): string | null {
-  if (!key) return null;
-  if (isModifierKey(key)) return null;
-  if (key === " ") return "Space";
-  if (/^esc(?:ape)?$/i.test(key)) return "Escape";
-  if (/^(return|enter)$/i.test(key)) return "Enter";
-  if (/^tab$/i.test(key)) return "Tab";
-  if (/^arrowup$/i.test(key)) return "ArrowUp";
-  if (/^arrowdown$/i.test(key)) return "ArrowDown";
-  if (/^arrowleft$/i.test(key)) return "ArrowLeft";
-  if (/^arrowright$/i.test(key)) return "ArrowRight";
+  if (!key) return null
+  if (isModifierKey(key)) return null
+  if (key === ' ') return 'Space'
+  if (/^esc(?:ape)?$/i.test(key)) return 'Escape'
+  if (/^(return|enter)$/i.test(key)) return 'Enter'
+  if (/^tab$/i.test(key)) return 'Tab'
+  if (/^arrowup$/i.test(key)) return 'ArrowUp'
+  if (/^arrowdown$/i.test(key)) return 'ArrowDown'
+  if (/^arrowleft$/i.test(key)) return 'ArrowLeft'
+  if (/^arrowright$/i.test(key)) return 'ArrowRight'
   if (key.length === 1) {
-    if (/[A-Za-z]/.test(key)) return key.toUpperCase();
-    return key;
+    if (/[A-Za-z]/.test(key)) return key.toUpperCase()
+    return key
   }
-  return key;
+  return key
 }
 
 function normalizeSequenceBaseToken(key: string): string | null {
-  if (!key) return null;
-  if (isModifierKey(key)) return null;
-  if (key === " ") return "Space";
-  if (/^esc(?:ape)?$/i.test(key)) return "Esc";
-  if (/^(return|enter)$/i.test(key)) return "Enter";
-  if (/^tab$/i.test(key)) return "Tab";
-  if (/^arrowup$/i.test(key)) return "ArrowUp";
-  if (/^arrowdown$/i.test(key)) return "ArrowDown";
-  if (/^arrowleft$/i.test(key)) return "ArrowLeft";
-  if (/^arrowright$/i.test(key)) return "ArrowRight";
-  if (key.length === 1) return key;
-  return key;
+  if (!key) return null
+  if (isModifierKey(key)) return null
+  if (key === ' ') return 'Space'
+  if (/^esc(?:ape)?$/i.test(key)) return 'Esc'
+  if (/^(return|enter)$/i.test(key)) return 'Enter'
+  if (/^tab$/i.test(key)) return 'Tab'
+  if (/^arrowup$/i.test(key)) return 'ArrowUp'
+  if (/^arrowdown$/i.test(key)) return 'ArrowDown'
+  if (/^arrowleft$/i.test(key)) return 'ArrowLeft'
+  if (/^arrowright$/i.test(key)) return 'ArrowRight'
+  if (key.length === 1) return key
+  return key
 }
 
 function normalizeModifierToken(
   modifier: string,
-): "Ctrl" | "Alt" | "Shift" | "Meta" | "Mod" | null {
-  if (/^(cmd|command|meta)$/i.test(modifier)) return "Meta";
-  if (/^(ctrl|control)$/i.test(modifier)) return "Ctrl";
-  if (/^(alt|option|opt)$/i.test(modifier)) return "Alt";
-  if (/^shift$/i.test(modifier)) return "Shift";
-  if (/^mod$/i.test(modifier)) return "Mod";
-  return null;
+): 'Ctrl' | 'Alt' | 'Shift' | 'Meta' | 'Mod' | null {
+  if (/^(cmd|command|meta)$/i.test(modifier)) return 'Meta'
+  if (/^(ctrl|control)$/i.test(modifier)) return 'Ctrl'
+  if (/^(alt|option|opt)$/i.test(modifier)) return 'Alt'
+  if (/^shift$/i.test(modifier)) return 'Shift'
+  if (/^mod$/i.test(modifier)) return 'Mod'
+  return null
 }
 
 function normalizeModifiers(parts: string[]): string[] {
-  const order = ["Ctrl", "Alt", "Shift", "Mod", "Meta"];
-  const unique = [...new Set(parts)];
-  return unique.sort((a, b) => order.indexOf(a) - order.indexOf(b));
+  const order = ['Ctrl', 'Alt', 'Shift', 'Mod', 'Meta']
+  const unique = [...new Set(parts)]
+  return unique.sort((a, b) => order.indexOf(a) - order.indexOf(b))
 }
 
 export function normalizeShortcutBinding(input: string): string | null {
-  const mac = isMacPlatform();
+  const mac = isMacPlatform()
   const parts = input
-    .split("+")
+    .split('+')
     .map((part) => part.trim())
-    .filter(Boolean);
-  if (parts.length === 0) return null;
-  const rawKey = parts.pop();
-  if (!rawKey) return null;
-  const key = normalizeKeyName(rawKey);
-  if (!key) return null;
-  const modifiers = normalizeModifiers(parts.flatMap((part) => {
-    const normalized = normalizeModifierToken(part);
-    if (!normalized) return [];
-    // Canonicalize the platform-primary modifier to `Mod` so stored
-    // shortcut bindings remain portable across the renderer and the
-    // key recorder. Keep the non-primary modifier explicit.
-    if (normalized === "Meta") return [mac ? "Mod" : "Meta"];
-    if (normalized === "Ctrl") return [mac ? "Ctrl" : "Mod"];
-    return [normalized];
-  }));
-  return [...modifiers, key].join("+");
+    .filter(Boolean)
+  if (parts.length === 0) return null
+  const rawKey = parts.pop()
+  if (!rawKey) return null
+  const key = normalizeKeyName(rawKey)
+  if (!key) return null
+  const modifiers = normalizeModifiers(
+    parts.flatMap((part) => {
+      const normalized = normalizeModifierToken(part)
+      if (!normalized) return []
+      // Canonicalize the platform-primary modifier to `Mod` so stored
+      // shortcut bindings remain portable across the renderer and the
+      // key recorder. Keep the non-primary modifier explicit.
+      if (normalized === 'Meta') return [mac ? 'Mod' : 'Meta']
+      if (normalized === 'Ctrl') return [mac ? 'Ctrl' : 'Mod']
+      return [normalized]
+    }),
+  )
+  return [...modifiers, key].join('+')
 }
 
 export function normalizeSequenceToken(input: string): string | null {
   const parts = input
-    .split("+")
+    .split('+')
     .map((part) => part.trim())
-    .filter(Boolean);
-  if (parts.length === 0) return null;
-  const rawKey = parts.pop();
-  if (!rawKey) return null;
-  let base = normalizeSequenceBaseToken(rawKey);
-  if (!base) return null;
+    .filter(Boolean)
+  if (parts.length === 0) return null
+  const rawKey = parts.pop()
+  if (!rawKey) return null
+  let base = normalizeSequenceBaseToken(rawKey)
+  if (!base) return null
   const modifiers = normalizeModifiers(
     parts
       .map((part) => normalizeModifierToken(part))
       .filter((part): part is NonNullable<typeof part> => !!part)
-      .filter((part) => part !== "Mod"),
-  );
+      .filter((part) => part !== 'Mod'),
+  )
   // When a non-Shift modifier (Ctrl/Alt/Meta) is combined with a single
   // ASCII letter, canonicalize to uppercase. Event-produced tokens come
   // out lowercase (e.g. Ctrl+w → `'w'` since Shift isn't held), but the
@@ -1161,74 +1170,74 @@ export function normalizeSequenceToken(input: string): string | null {
   if (
     base.length === 1 &&
     /[a-zA-Z]/.test(base) &&
-    modifiers.some((m) => m === "Ctrl" || m === "Alt" || m === "Meta")
+    modifiers.some((m) => m === 'Ctrl' || m === 'Alt' || m === 'Meta')
   ) {
-    base = base.toUpperCase();
+    base = base.toUpperCase()
   }
-  return modifiers.length > 0 ? `${modifiers.join("+")}+${base}` : base;
+  return modifiers.length > 0 ? `${modifiers.join('+')}+${base}` : base
 }
 
 export function normalizeSequenceBinding(input: string): string | null {
   const tokens = input
     .split(/\s+/)
     .map((token) => normalizeSequenceToken(token))
-    .filter((token): token is string => !!token);
-  if (tokens.length === 0) return null;
-  return tokens.join(" ");
+    .filter((token): token is string => !!token)
+  if (tokens.length === 0) return null
+  return tokens.join(' ')
 }
 
 export function normalizeKeymapBinding(
   id: KeymapId,
   input: string,
 ): string | null {
-  const definition = getKeymapDefinition(id);
+  const definition = getKeymapDefinition(id)
   const normalized =
-    definition.kind === "shortcut"
+    definition.kind === 'shortcut'
       ? normalizeShortcutBinding(input)
-      : normalizeSequenceBinding(input);
-  if (!normalized) return null;
-  if (definition.kind === "sequence" && definition.maxTokens) {
-    const tokenCount = normalized.split(/\s+/).filter(Boolean).length;
+      : normalizeSequenceBinding(input)
+  if (!normalized) return null
+  if (definition.kind === 'sequence' && definition.maxTokens) {
+    const tokenCount = normalized.split(/\s+/).filter(Boolean).length
     if (tokenCount > definition.maxTokens) {
       return normalized
         .split(/\s+/)
         .filter(Boolean)
         .slice(0, definition.maxTokens)
-        .join(" ");
+        .join(' ')
     }
   }
-  return normalized;
+  return normalized
 }
 
 export function normalizeKeymapOverrides(input: unknown): KeymapOverrides {
-  if (!input || typeof input !== "object") return {};
-  const overrides: KeymapOverrides = {};
+  if (!input || typeof input !== 'object') return {}
+  const overrides: KeymapOverrides = {}
   for (const definition of KEYMAP_DEFINITIONS) {
-    const raw = (input as Record<string, unknown>)[definition.id];
-    if (typeof raw !== "string") continue;
-    const normalized = normalizeKeymapBinding(definition.id, raw);
+    const raw = (input as Record<string, unknown>)[definition.id]
+    if (typeof raw !== 'string') continue
+    const normalized = normalizeKeymapBinding(definition.id, raw)
     if (normalized && normalized !== definition.defaultBinding) {
-      overrides[definition.id] = normalized;
+      overrides[definition.id] = normalized
     }
   }
-  return overrides;
+  return overrides
 }
 
 export function shortcutBindingFromEvent(event: KeyboardEvent): string | null {
-  const mac = isMacPlatform();
-  const resolved = resolveKeyFromEvent(event);
-  const key = resolved ?? normalizeKeyName(event.key);
-  if (!key) return null;
-  const modifiers: string[] = [];
-  if (event.ctrlKey) modifiers.push(mac ? "Ctrl" : "Mod");
-  if (event.metaKey) modifiers.push(mac ? "Mod" : "Meta");
-  if (event.altKey) modifiers.push("Alt");
-  if (event.shiftKey) modifiers.push("Shift");
-  return normalizeShortcutBinding([...modifiers, key].join("+"));
+  const mac = isMacPlatform()
+  const resolved = resolveKeyFromEvent(event)
+  const key = resolved ?? normalizeKeyName(event.key)
+  if (!key) return null
+  const modifiers: string[] = []
+  if (event.ctrlKey) modifiers.push(mac ? 'Ctrl' : 'Mod')
+  if (event.metaKey) modifiers.push(mac ? 'Mod' : 'Meta')
+  if (event.altKey) modifiers.push('Alt')
+  if (event.shiftKey) modifiers.push('Shift')
+  return normalizeShortcutBinding([...modifiers, key].join('+'))
 }
 
 export function sequenceTokenFromEvent(event: KeyboardEvent): string | null {
-  const resolved = resolveKeyFromEvent(event);
+  const resolved = resolveKeyFromEvent(event)
   // Sequence tokens are case-sensitive for letters (`<leader>q` vs
   // `<leader>Q` are different bindings). resolveKeyFromEvent returns
   // uppercase letters — fold them down so unmodified letters still
@@ -1239,25 +1248,25 @@ export function sequenceTokenFromEvent(event: KeyboardEvent): string | null {
   } else if (resolved) {
     base = resolved
   } else {
-    base = normalizeSequenceBaseToken(event.key);
+    base = normalizeSequenceBaseToken(event.key)
   }
-  if (!base) return null;
-  const modifiers: string[] = [];
-  if (event.ctrlKey) modifiers.push("Ctrl");
-  if (event.altKey) modifiers.push("Alt");
-  if (event.metaKey) modifiers.push("Meta");
-  if (event.shiftKey && base.length !== 1) modifiers.push("Shift");
+  if (!base) return null
+  const modifiers: string[] = []
+  if (event.ctrlKey) modifiers.push('Ctrl')
+  if (event.altKey) modifiers.push('Alt')
+  if (event.metaKey) modifiers.push('Meta')
+  if (event.shiftKey && base.length !== 1) modifiers.push('Shift')
   return normalizeSequenceToken(
-    modifiers.length > 0 ? `${modifiers.join("+")}+${base}` : base,
-  );
+    modifiers.length > 0 ? `${modifiers.join('+')}+${base}` : base,
+  )
 }
 
 export function matchesShortcutBinding(
   event: KeyboardEvent,
   binding: string,
 ): boolean {
-  const normalized = shortcutBindingFromEvent(event);
-  return !!normalized && normalized === binding;
+  const normalized = shortcutBindingFromEvent(event)
+  return !!normalized && normalized === binding
 }
 
 export function matchesShortcut(
@@ -1265,7 +1274,7 @@ export function matchesShortcut(
   overrides: KeymapOverrides | null | undefined,
   id: KeymapId,
 ): boolean {
-  return matchesShortcutBinding(event, getKeymapBinding(overrides, id));
+  return matchesShortcutBinding(event, getKeymapBinding(overrides, id))
 }
 
 export function matchesSequenceToken(
@@ -1273,75 +1282,138 @@ export function matchesSequenceToken(
   overrides: KeymapOverrides | null | undefined,
   id: KeymapId,
 ): boolean {
-  const tokens = getSequenceTokens(overrides, id);
-  if (tokens.length !== 1) return false;
-  const token = sequenceTokenFromEvent(event);
-  return !!token && token === tokens[0];
+  const tokens = getSequenceTokens(overrides, id)
+  if (tokens.length !== 1) return false
+  const token = sequenceTokenFromEvent(event)
+  return !!token && token === tokens[0]
 }
 
 export function formatKeyToken(token: string, mac = isMacPlatform()): string {
-  if (token.includes("+")) {
-    const parts = token.split("+");
-    const base = parts.pop() ?? token;
+  if (token.includes('+')) {
+    const parts = token.split('+')
+    const base = parts.pop() ?? token
     const prefix = parts
       .map((part) => formatKeyToken(part, mac))
-      .join(mac ? "" : "+");
-    return `${prefix}${mac ? "" : prefix ? "+" : ""}${formatKeyToken(base, mac)}`;
+      .join(mac ? '' : '+')
+    return `${prefix}${mac ? '' : prefix ? '+' : ''}${formatKeyToken(base, mac)}`
   }
-  if (token === "Mod") return mac ? "⌘" : "Ctrl";
-  if (token === "Meta") return mac ? "⌘" : "Meta";
-  if (token === "Ctrl") return mac ? "⌃" : "Ctrl";
-  if (token === "Alt") return mac ? "⌥" : "Alt";
-  if (token === "Shift") return mac ? "⇧" : "Shift";
-  if (token === "Escape" || token === "Esc") return "Esc";
-  if (token === "Enter") return mac ? "↵" : "Enter";
-  if (token === "Tab") return "Tab";
-  if (token === "Space") return "Space";
-  if (token === "ArrowUp") return "↑";
-  if (token === "ArrowDown") return "↓";
-  if (token === "ArrowLeft") return "←";
-  if (token === "ArrowRight") return "→";
-  return token;
+  if (token === 'Mod') return mac ? '⌘' : 'Ctrl'
+  if (token === 'Meta') return mac ? '⌘' : 'Meta'
+  if (token === 'Ctrl') return mac ? '⌃' : 'Ctrl'
+  if (token === 'Alt') return mac ? '⌥' : 'Alt'
+  if (token === 'Shift') return mac ? '⇧' : 'Shift'
+  if (token === 'Escape' || token === 'Esc') return 'Esc'
+  if (token === 'Enter') return mac ? '↵' : 'Enter'
+  if (token === 'Tab') return 'Tab'
+  if (token === 'Space') return 'Space'
+  if (token === 'ArrowUp') return '↑'
+  if (token === 'ArrowDown') return '↓'
+  if (token === 'ArrowLeft') return '←'
+  if (token === 'ArrowRight') return '→'
+  return token
 }
 
 export function formatKeymapBinding(binding: string, kind: KeymapKind): string {
-  if (kind === "shortcut") {
-    return formatKeyToken(binding);
+  if (kind === 'shortcut') {
+    return formatKeyToken(binding)
   }
   return binding
     .split(/\s+/)
     .map((token) => formatKeyToken(token))
-    .join(" ");
+    .join(' ')
 }
 
 export function getKeymapDisplay(
   overrides: KeymapOverrides | null | undefined,
   id: KeymapId,
 ): string {
-  const definition = getKeymapDefinition(id);
-  return formatKeymapBinding(getKeymapBinding(overrides, id), definition.kind);
+  const definition = getKeymapDefinition(id)
+  return formatKeymapBinding(getKeymapBinding(overrides, id), definition.kind)
 }
 
 export function describeCurrentBinding(
   overrides: KeymapOverrides | null | undefined,
   id: KeymapId,
 ): string {
-  return getKeymapDisplay(overrides, id);
+  return getKeymapDisplay(overrides, id)
 }
 
 export function getKeymapDefinitionsByGroup(): Array<{
-  group: KeymapGroup;
-  label: string;
-  items: KeymapDefinition[];
+  group: KeymapGroup
+  label: string
+  items: KeymapDefinition[]
 }> {
-  const groups: KeymapGroup[] = ["global", "vim", "navigation", "view-actions"];
+  const groups: KeymapGroup[] = ['global', 'vim', 'navigation', 'view-actions']
   return groups.map((group) => ({
     group,
     label: getKeymapGroupLabel(group),
     items: KEYMAP_DEFINITIONS.filter(
       (definition) => definition.group === group,
     ),
-  }));
+  }))
+}
+
+export function findConflictingKeymaps(
+  overrides: KeymapOverrides,
+): Map<KeymapId, KeymapId[]> {
+  const byKey = new Map<string, KeymapDefinition[]>()
+  for (const def of KEYMAP_DEFINITIONS) {
+    const key = `${def.kind}:${def.scope}:${getKeymapBinding(overrides, def.id)}`
+    const group = byKey.get(key)
+    if (group) group.push(def)
+    else byKey.set(key, [def])
+  }
+  const result = new Map<KeymapId, KeymapId[]>()
+  for (const defs of byKey.values()) {
+    if (defs.length < 2) continue
+    for (const defA of defs) {
+      const conflicts = defs.reduce<KeymapId[]>((acc, defB) => {
+        if (defB === defA) return acc
+        const mutuallyExclusive =
+          (defA.vimOnly === true && defB.nonVimOnly === true) ||
+          (defA.nonVimOnly === true && defB.vimOnly === true)
+        if (!mutuallyExclusive) acc.push(defB.id)
+        return acc
+      }, [])
+      if (conflicts.length > 0) result.set(defA.id, conflicts)
+    }
+  }
+  return result
+}
+
+/**
+ * get all in-app vim motion keybindings
+ * excludes `pane` and `leader` because
+ *
+ * @returns
+ */
+export function getAppVimSequenceMap(
+  overrides: KeymapOverrides,
+): Map<string, KeymapDefinition> {
+  const map = new Map<string, KeymapDefinition>()
+  const leaderKey = toVimSequence(
+    getKeymapBinding(overrides, 'vim.leaderPrefix'),
+  )!
+  const paneKey = toVimSequence(getKeymapBinding(overrides, 'vim.panePrefix'))!
+
+  for (const def of KEYMAP_DEFINITIONS) {
+    if (def.group !== 'vim') continue
+    if (def.scope === 'pane') {
+      const actionSeq = toVimSequence(getKeymapBinding(overrides, def.id))
+      if (def.id === 'vim.panePrefix') {
+        map.set(paneKey, def)
+      } else if (actionSeq) map.set(`${paneKey}${actionSeq}`, def)
+    } else if (def.scope === 'leader') {
+      const actionSeq = toVimSequence(getKeymapBinding(overrides, def.id))
+      if (def.id === 'vim.leaderPrefix') {
+        map.set(leaderKey, def)
+      } else if (actionSeq) map.set(`${leaderKey}${actionSeq}`, def)
+    } else {
+      const seq = toVimSequence(getKeymapBinding(overrides, def.id))
+      if (seq) map.set(seq, def)
+    }
+  }
+  return map
 }
 
 export function advanceSequence(
@@ -1356,41 +1428,41 @@ export function advanceSequence(
   const tokens = binding
     .split(/\s+/)
     .map((token) => token.trim())
-    .filter(Boolean);
-  if (tokens.length === 0) return false;
-  const token = sequenceTokenFromEvent(event);
-  if (!token) return false;
+    .filter(Boolean)
+  if (tokens.length === 0) return false
+  const token = sequenceTokenFromEvent(event)
+  if (!token) return false
 
   const reset = (): void => {
-    pendingRef.current = 0;
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = undefined;
-  };
+    pendingRef.current = 0
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = undefined
+  }
 
   if (pendingRef.current > 0) {
     if (token === tokens[pendingRef.current]) {
-      consume();
-      pendingRef.current += 1;
+      consume()
+      pendingRef.current += 1
       if (pendingRef.current >= tokens.length) {
-        reset();
-        onMatch();
+        reset()
+        onMatch()
       } else {
-        if (timerRef.current) clearTimeout(timerRef.current);
-        timerRef.current = setTimeout(reset, timeoutMs);
+        if (timerRef.current) clearTimeout(timerRef.current)
+        timerRef.current = setTimeout(reset, timeoutMs)
       }
-      return true;
+      return true
     }
-    reset();
+    reset()
   }
 
-  if (token !== tokens[0]) return false;
-  consume();
+  if (token !== tokens[0]) return false
+  consume()
   if (tokens.length === 1) {
-    onMatch();
-    return true;
+    onMatch()
+    return true
   }
-  pendingRef.current = 1;
-  if (timerRef.current) clearTimeout(timerRef.current);
-  timerRef.current = setTimeout(reset, timeoutMs);
-  return true;
+  pendingRef.current = 1
+  if (timerRef.current) clearTimeout(timerRef.current)
+  timerRef.current = setTimeout(reset, timeoutMs)
+  return true
 }

--- a/packages/app-core/src/lib/vim-mappings.ts
+++ b/packages/app-core/src/lib/vim-mappings.ts
@@ -55,7 +55,10 @@ export const VIM_UNMAP_CMDS = new Set<VimUnmapCmd>([
   'iunmap'
 ])
 
-export type VimMappingDiagnosticKind = 'unknown-command' | 'missing-rhs' | 'app-conflict'
+export type VimMappingDiagnosticKind =
+  | 'unknown-command'
+  | 'missing-rhs'
+  | 'app-conflict'
 
 export interface VimMappingDiagnostic {
   kind: VimMappingDiagnosticKind
@@ -117,7 +120,8 @@ export function diagnoseVimMappings(
   leaderKey: string,
   seqMap: Map<string, KeymapDefinition>
 ): VimMappingDiagnostic[] {
-  const resolve = (token: string): string => token.replace(/<leader>/gi, leaderKey)
+  const resolve = (token: string): string =>
+    token.replace(/<leader>/gi, leaderKey)
 
   const diagnostics: VimMappingDiagnostic[] = []
 

--- a/packages/app-core/src/lib/vim-mappings.ts
+++ b/packages/app-core/src/lib/vim-mappings.ts
@@ -55,10 +55,7 @@ export const VIM_UNMAP_CMDS = new Set<VimUnmapCmd>([
   'iunmap'
 ])
 
-export type VimMappingDiagnosticKind =
-  | 'unknown-command'
-  | 'missing-rhs'
-  | 'app-conflict'
+export type VimMappingDiagnosticKind = 'unknown-command' | 'missing-rhs' | 'app-conflict'
 
 export interface VimMappingDiagnostic {
   kind: VimMappingDiagnosticKind
@@ -120,8 +117,7 @@ export function diagnoseVimMappings(
   leaderKey: string,
   seqMap: Map<string, KeymapDefinition>
 ): VimMappingDiagnostic[] {
-  const resolve = (token: string): string =>
-    token.replace(/<leader>/gi, leaderKey)
+  const resolve = (token: string): string => token.replace(/<leader>/gi, leaderKey)
 
   const diagnostics: VimMappingDiagnostic[] = []
 

--- a/packages/app-core/src/lib/vim-mappings.ts
+++ b/packages/app-core/src/lib/vim-mappings.ts
@@ -1,0 +1,34 @@
+export type VimMode = 'normal' | 'visual' | 'insert'
+
+export type VimMapCmd =
+  | 'noremap' | 'map'
+  | 'nnoremap' | 'nmap'
+  | 'vnoremap' | 'vmap'
+  | 'xnoremap' | 'xmap'
+  | 'inoremap' | 'imap'
+
+export type VimUnmapCmd = 'unmap' | 'nunmap' | 'vunmap' | 'xunmap' | 'iunmap'
+
+export type AppliedVimMapping = { lhs: string; mode: VimMode }
+
+export const VIM_MAP_CMD_MODES: Record<VimMapCmd, VimMode> = {
+  noremap: 'normal',  map: 'normal',
+  nnoremap: 'normal', nmap: 'normal',
+  vnoremap: 'visual', vmap: 'visual',
+  xnoremap: 'visual', xmap: 'visual',
+  inoremap: 'insert', imap: 'insert',
+}
+
+export const VIM_UNMAP_CMD_MODES: Record<VimUnmapCmd, VimMode> = {
+  unmap: 'normal',  nunmap: 'normal',
+  vunmap: 'visual', xunmap: 'visual',
+  iunmap: 'insert',
+}
+
+export const VIM_NOREMAP_CMDS = new Set<VimMapCmd>([
+  'noremap', 'nnoremap', 'vnoremap', 'xnoremap', 'inoremap',
+])
+
+export const VIM_UNMAP_CMDS = new Set<VimUnmapCmd>([
+  'unmap', 'nunmap', 'vunmap', 'xunmap', 'iunmap',
+])

--- a/packages/app-core/src/lib/vim-mappings.ts
+++ b/packages/app-core/src/lib/vim-mappings.ts
@@ -1,34 +1,173 @@
+import type { KeymapDefinition } from './keymaps'
+
 export type VimMode = 'normal' | 'visual' | 'insert'
 
 export type VimMapCmd =
-  | 'noremap' | 'map'
-  | 'nnoremap' | 'nmap'
-  | 'vnoremap' | 'vmap'
-  | 'xnoremap' | 'xmap'
-  | 'inoremap' | 'imap'
+  | 'noremap'
+  | 'map'
+  | 'nnoremap'
+  | 'nmap'
+  | 'vnoremap'
+  | 'vmap'
+  | 'xnoremap'
+  | 'xmap'
+  | 'inoremap'
+  | 'imap'
 
 export type VimUnmapCmd = 'unmap' | 'nunmap' | 'vunmap' | 'xunmap' | 'iunmap'
 
 export type AppliedVimMapping = { lhs: string; mode: VimMode }
 
 export const VIM_MAP_CMD_MODES: Record<VimMapCmd, VimMode> = {
-  noremap: 'normal',  map: 'normal',
-  nnoremap: 'normal', nmap: 'normal',
-  vnoremap: 'visual', vmap: 'visual',
-  xnoremap: 'visual', xmap: 'visual',
-  inoremap: 'insert', imap: 'insert',
+  noremap: 'normal',
+  map: 'normal',
+  nnoremap: 'normal',
+  nmap: 'normal',
+  vnoremap: 'visual',
+  vmap: 'visual',
+  xnoremap: 'visual',
+  xmap: 'visual',
+  inoremap: 'insert',
+  imap: 'insert',
 }
 
 export const VIM_UNMAP_CMD_MODES: Record<VimUnmapCmd, VimMode> = {
-  unmap: 'normal',  nunmap: 'normal',
-  vunmap: 'visual', xunmap: 'visual',
+  unmap: 'normal',
+  nunmap: 'normal',
+  vunmap: 'visual',
+  xunmap: 'visual',
   iunmap: 'insert',
 }
 
 export const VIM_NOREMAP_CMDS = new Set<VimMapCmd>([
-  'noremap', 'nnoremap', 'vnoremap', 'xnoremap', 'inoremap',
+  'noremap',
+  'nnoremap',
+  'vnoremap',
+  'xnoremap',
+  'inoremap',
 ])
 
 export const VIM_UNMAP_CMDS = new Set<VimUnmapCmd>([
-  'unmap', 'nunmap', 'vunmap', 'xunmap', 'iunmap',
+  'unmap',
+  'nunmap',
+  'vunmap',
+  'xunmap',
+  'iunmap',
 ])
+
+export type VimMappingDiagnosticKind =
+  | 'unknown-command'
+  | 'missing-rhs'
+  | 'app-conflict'
+
+export interface VimMappingDiagnostic {
+  kind: VimMappingDiagnosticKind
+  line: number
+  message: string
+  keymapId?: string
+}
+
+export function toVimKeyName(base: string): string {
+  if (base === 'Space') return 'Space'
+  if (base === 'Enter') return 'CR'
+  if (base === 'Esc' || base === 'Escape') return 'Esc'
+  if (base === 'Tab') return 'Tab'
+  if (base === 'ArrowUp') return 'Up'
+  if (base === 'ArrowDown') return 'Down'
+  if (base === 'ArrowLeft') return 'Left'
+  if (base === 'ArrowRight') return 'Right'
+  return base
+}
+
+function toVimSequenceToken(token: string): string | null {
+  const parts = token
+    .split('+')
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (parts.length === 0) return null
+  const base = parts.pop()
+  if (!base) return null
+  const keyName = toVimKeyName(base)
+  if (parts.length === 0) {
+    if (base.length === 1) return base
+    return `<${keyName}>`
+  }
+  const modifiers = parts
+    .map((part) => {
+      if (part === 'Ctrl') return 'C'
+      if (part === 'Alt') return 'A'
+      if (part === 'Shift') return 'S'
+      if (part === 'Meta' || part === 'Mod') return 'D'
+      return null
+    })
+    .filter(Boolean) as string[]
+  const normalizedKey = base.length === 1 ? base.toLowerCase() : keyName
+  return `<${[...modifiers, normalizedKey].join('-')}>`
+}
+
+export function toVimSequence(binding: string): string | null {
+  const tokens = binding
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .map((token) => toVimSequenceToken(token))
+  if (tokens.length === 0 || tokens.some((token) => !token)) return null
+  return tokens.join('')
+}
+
+export function diagnoseVimMappings(
+  raw: string,
+  leaderKey: string,
+  seqMap: Map<string, KeymapDefinition>,
+): VimMappingDiagnostic[] {
+  const resolve = (token: string): string =>
+    token.replace(/<leader>/gi, leaderKey)
+
+  const diagnostics: VimMappingDiagnostic[] = []
+
+  raw.split('\n').forEach((line, idx) => {
+    const lineNumber = idx + 1
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('"')) return
+
+    const parts = trimmed.split(/\s+/)
+    const cmd = parts[0]
+    const rawLhs = parts[1]
+    const rawRhs = parts[2]
+    const lhs = rawLhs ? resolve(rawLhs) : undefined
+
+    const isMapCmd = cmd in VIM_MAP_CMD_MODES
+    const isUnmapCmd = VIM_UNMAP_CMDS.has(cmd as VimUnmapCmd)
+
+    if (!isMapCmd && !isUnmapCmd) {
+      diagnostics.push({
+        kind: 'unknown-command',
+        line: lineNumber,
+        message: `Unknown command "${cmd}", only map/noremap/unmap variants are supported.`,
+      })
+      return
+    }
+
+    if (!lhs) return
+
+    if (isMapCmd && !rawRhs) {
+      diagnostics.push({
+        kind: 'missing-rhs',
+        line: lineNumber,
+        message: `"${cmd} ${rawLhs}" is missing a right-hand side.`,
+      })
+      return
+    }
+    const def = seqMap.get(lhs)
+    if (isMapCmd && def) {
+      diagnostics.push({
+        kind: 'app-conflict',
+        line: lineNumber,
+        message: `"${rawLhs}" is already bound to ${def.title}`,
+        keymapId: def.id,
+      })
+    }
+  })
+
+  return diagnostics
+}

--- a/packages/app-core/src/lib/vim-mappings.ts
+++ b/packages/app-core/src/lib/vim-mappings.ts
@@ -28,7 +28,7 @@ export const VIM_MAP_CMD_MODES: Record<VimMapCmd, VimMode> = {
   xnoremap: 'visual',
   xmap: 'visual',
   inoremap: 'insert',
-  imap: 'insert',
+  imap: 'insert'
 }
 
 export const VIM_UNMAP_CMD_MODES: Record<VimUnmapCmd, VimMode> = {
@@ -36,7 +36,7 @@ export const VIM_UNMAP_CMD_MODES: Record<VimUnmapCmd, VimMode> = {
   nunmap: 'normal',
   vunmap: 'visual',
   xunmap: 'visual',
-  iunmap: 'insert',
+  iunmap: 'insert'
 }
 
 export const VIM_NOREMAP_CMDS = new Set<VimMapCmd>([
@@ -44,7 +44,7 @@ export const VIM_NOREMAP_CMDS = new Set<VimMapCmd>([
   'nnoremap',
   'vnoremap',
   'xnoremap',
-  'inoremap',
+  'inoremap'
 ])
 
 export const VIM_UNMAP_CMDS = new Set<VimUnmapCmd>([
@@ -52,7 +52,7 @@ export const VIM_UNMAP_CMDS = new Set<VimUnmapCmd>([
   'nunmap',
   'vunmap',
   'xunmap',
-  'iunmap',
+  'iunmap'
 ])
 
 export type VimMappingDiagnosticKind =
@@ -118,7 +118,7 @@ export function toVimSequence(binding: string): string | null {
 export function diagnoseVimMappings(
   raw: string,
   leaderKey: string,
-  seqMap: Map<string, KeymapDefinition>,
+  seqMap: Map<string, KeymapDefinition>
 ): VimMappingDiagnostic[] {
   const resolve = (token: string): string =>
     token.replace(/<leader>/gi, leaderKey)
@@ -143,7 +143,7 @@ export function diagnoseVimMappings(
       diagnostics.push({
         kind: 'unknown-command',
         line: lineNumber,
-        message: `Unknown command "${cmd}", only map/noremap/unmap variants are supported.`,
+        message: `Unknown command "${cmd}", only map/noremap/unmap variants are supported.`
       })
       return
     }
@@ -154,7 +154,7 @@ export function diagnoseVimMappings(
       diagnostics.push({
         kind: 'missing-rhs',
         line: lineNumber,
-        message: `"${cmd} ${rawLhs}" is missing a right-hand side.`,
+        message: `"${cmd} ${rawLhs}" is missing a right-hand side.`
       })
       return
     }
@@ -164,7 +164,7 @@ export function diagnoseVimMappings(
         kind: 'app-conflict',
         line: lineNumber,
         message: `"${rawLhs}" is already bound to ${def.title}`,
-        keymapId: def.id,
+        keymapId: def.id
       })
     }
   })

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -4032,7 +4032,7 @@ export const useStore = create<Store>((set, get) => {
     savePrefs(collectPrefs(get()))
   },
   setVimMappings: (mappings) =>{
-    set({vimMappings: mappings.trim()})
+    set({vimMappings: mappings})
   },
   setKeymapBinding: (id, binding) => {
     set((s) => {

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -263,6 +263,8 @@ interface Prefs {
   /** Key sequence that exits insert mode (maps to <Esc>), e.g. "jk".
    *  Empty disables it. */
   vimInsertEscape: string
+  /* Stores .vimrc style mapping as plaintext */
+  vimMappings: string
   keymapOverrides: KeymapOverrides
   /** When true, pressing the leader key shows the next available Vim-style actions. */
   whichKeyHints: boolean
@@ -409,6 +411,7 @@ function normalizeKanbanColumnTitles(raw: unknown): Record<string, string> {
 const DEFAULT_PREFS: Prefs = {
   vimMode: true,
   vimInsertEscape: '',
+  vimMappings: '',
   keymapOverrides: {},
   whichKeyHints: true,
   whichKeyHintMode: 'timed',
@@ -483,6 +486,7 @@ function normalizePrefs(p: Partial<Prefs>): Prefs {
       : DEFAULT_PREFS.themeId
   return {
     vimMode: typeof p.vimMode === 'boolean' ? p.vimMode : DEFAULT_PREFS.vimMode,
+    vimMappings: typeof p.vimMappings === 'string' ? p.vimMappings : DEFAULT_PREFS.vimMappings,
     vimInsertEscape:
       typeof p.vimInsertEscape === 'string'
         ? p.vimInsertEscape.trim().slice(0, 5)
@@ -1057,6 +1061,7 @@ async function rewriteTagAcrossVault(
 function collectPrefs(s: {
   vimMode: boolean
   vimInsertEscape: string
+  vimMappings: string
   keymapOverrides: KeymapOverrides
   whichKeyHints: boolean
   whichKeyHintMode: WhichKeyHintMode
@@ -1114,6 +1119,7 @@ function collectPrefs(s: {
   return {
     vimMode: s.vimMode,
     vimInsertEscape: s.vimInsertEscape,
+    vimMappings: s.vimMappings,
     keymapOverrides: s.keymapOverrides,
     whichKeyHints: s.whichKeyHints,
     whichKeyHintMode: s.whichKeyHintMode,
@@ -1464,6 +1470,7 @@ interface Store {
   vimMode: boolean
   /** Key sequence that exits insert mode (maps to <Esc>), e.g. "jk". Persisted. */
   vimInsertEscape: string
+  vimMappings: string
   keymapOverrides: KeymapOverrides
   whichKeyHints: boolean
   whichKeyHintMode: WhichKeyHintMode
@@ -1742,6 +1749,7 @@ interface Store {
   setFocusMode: (focus: boolean) => void
   setVimMode: (on: boolean) => void
   setVimInsertEscape: (sequence: string) => void
+  setVimMappings: (mappings: string) => void
   setKeymapBinding: (id: KeymapId, binding: string | null) => void
   resetAllKeymaps: () => void
   setWhichKeyHints: (on: boolean) => void
@@ -2686,6 +2694,7 @@ export const useStore = create<Store>((set, get) => {
   zenRestoreState: null,
   vimMode: loadPrefs().vimMode,
   vimInsertEscape: loadPrefs().vimInsertEscape,
+  vimMappings: loadPrefs().vimMappings,
   keymapOverrides: loadPrefs().keymapOverrides,
   whichKeyHints: loadPrefs().whichKeyHints,
   whichKeyHintMode: loadPrefs().whichKeyHintMode,
@@ -4021,6 +4030,9 @@ export const useStore = create<Store>((set, get) => {
   setVimInsertEscape: (sequence) => {
     set({ vimInsertEscape: sequence.trim().slice(0, 5) })
     savePrefs(collectPrefs(get()))
+  },
+  setVimMappings: (mappings) =>{
+    set({vimMappings: mappings.trim()})
   },
   setKeymapBinding: (id, binding) => {
     set((s) => {


### PR DESCRIPTION
Issue https://github.com/ZenNotes/zennotes/issues/143
# Goal
Vimscript support to enable flexible remapping

# Design desicion
Currently codebase has contracts for keymaps with different scopes of `KeymapScope`. What this PR aims to do is not do a full refactor of existing architecture, but to allow flexibility for users to define their own keymap

> User defined vimscript will be referred as `user-mappings` for this context

user-mappings are treated as a different entity from `KeymapDefinition`. Why? 
1. To eliminate complexity early on from managed keys and user's preferences
2. Allows complete flexibility to users as long as they know what they are doing (which if you use this app, you probably used vim before)

user-mappings interact directly with codemirror's api

user-mappings are defined inside settings > keymaps > Vimrc opposed as to source it using the file system to give reactive feedback like conflicting keymaps and errors. This is also because we could not possibly support every syntax for example setting a variable.

Going with this direction, to improve UX, conflicting keymaps should be surfaced as warnings for users to manage

# Summary
- Add Vimscript support for custom key mappings in the Editor settings, surfaced as a textarea in the Keymaps panel 
- Introduce diagnostics for user-mappings and flag unknown commands, missing RHS, and conflicts with existing app keymaps inline below the textarea
Supported syntax are as such
```ts
export type VimMode = 'normal' | 'visual' | 'insert'

export type VimMapCmd =
  | 'noremap'
  | 'map'
  | 'nnoremap'
  | 'nmap'
  | 'vnoremap'
  | 'vmap'
  | 'xnoremap'
  | 'xmap'
  | 'inoremap'
  | 'imap'

export type VimUnmapCmd = 'unmap' | 'nunmap' | 'vunmap' | 'xunmap' | 'iunmap'
```
-  Detect keymap collisions which is a plus feature

# Notes
There are noisy diffs from differences in linter, if you could specify a .prettierrc it would be great :)

---

<img width="1140" height="991" alt="image" src="https://github.com/user-attachments/assets/84413c43-fc89-484b-a3dd-718ba9cde018" />
