### PR TITLE
fix: set quick capture window title

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2755,6 +2755,7 @@ function ensureQuickCaptureWindow(): BrowserWindow {
     height: 340,
     minWidth: 460,
     minHeight: 260,
+    title: 'ZenNotes Quick Capture',
     show: false,
     frame: false,
     titleBarStyle: mac ? 'hiddenInset' : 'hidden',

--- a/packages/app-core/src/components/QuickCaptureApp.tsx
+++ b/packages/app-core/src/components/QuickCaptureApp.tsx
@@ -228,6 +228,11 @@ export function QuickCaptureApp(): JSX.Element {
   const [overlay, setOverlay] = useState<'none' | 'search' | 'command'>('none')
   const editorRef = useRef<EditorView | null>(null)
 
+  // Set a different title for the quick capture window.
+  useEffect(() => {
+    document.title = 'ZenNotes Quick Capture'
+  }, [])
+
   // Apply theme + font CSS vars before paint.
   useEffect(() => {
     applyTheme(prefs)


### PR DESCRIPTION
## Summary

This small PR fixes the title of the quick capture window, making it distinguishable from the main `ZenNotes` window on Wayland compositors.

The quick capture window now has a different title: `ZenNotes Quick Capture`

This gives compositor rules something stable to match against.

Fixes [#155](https://github.com/ZenNotes/zennotes/issues/155)

## Testing:

- Open ZenNotes on Linux with a Wayland compositor. I tested with `niri`.
- Open the quick capture window.
- Run `niri msg pick-window` or an equivalent window inspection command.
- Confirm that the title of the quick capture window is now: `ZenNotes Quick Capture`.