### PR TITLE
chore: add a nix flake to the project root

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1781074563,
@@ -18,7 +36,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,127 @@
+{
+  description = "ZenNotes - Local-first Markdown Notes App";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    # Für dieses Beispiel hardcoden wir auf Linux.
+    # Für Multi-Platform (MacOS/Linux) nutzt man meist flake-utils.
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {inherit system;};
+    version = "2.3.0";
+
+    frontend-web = pkgs.buildNpmPackage {
+      pname = "zennotes-web";
+      version = "${version}";
+      # whole repo as part, because of turbo, building with workspace param
+      src = ./.;
+      npmDepsHash = "sha256-7IpGnxVjaJvfSZyKjOylGMhFqa1bx8Ry5O1yqYfNnCE=";
+
+      # we use the nix electon here and dont want NPM to donwload it
+      ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+      buildPhase = ''
+        echo "building the web frontend..."
+        npm run build --workspace=apps/web
+      '';
+
+      #copy the built web frontend to package it with the backend, needed by go:embed
+      installPhase = ''
+        mkdir -p $out/share/zennotes-web
+        cp -r apps/web/dist/* $out/share/zennotes-web/
+      '';
+    };
+    backend = pkgs.buildGoModule {
+      pname = "zennotes-server";
+      version = "${version}";
+
+      src = ./apps/server;
+
+      vendorHash = "sha256-wYBF7CjM6AvoWMWql9hFmIaj6pCmli4vOef6POyGkfU=";
+
+      preBuild = ''
+        mkdir -p web/dist
+        cp -r ${frontend-web}/share/zennotes-web/* web/dist/
+      '';
+    };
+
+    frontend-desktop = pkgs.buildNpmPackage {
+      pname = "zennotes-frontend-desktop";
+      version = "${version}";
+
+      # whole repo as src, see fronten-web part
+      src = ./.;
+
+      npmDepsHash = "sha256-7IpGnxVjaJvfSZyKjOylGMhFqa1bx8Ry5O1yqYfNnCE=";
+
+      # we use the nix electon here and dont want NPM to donwload it
+      ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+      buildPhase = ''
+        echo "Start turborepo build for desktop..."
+        npm run build --workspace=apps/desktop
+      '';
+
+      # copy the compiled files and node_modules for dependencies
+      installPhase = ''
+        mkdir -p $out/share/zennotes
+        cp -r apps/desktop/out/* $out/share/zennotes/
+        cp -r -L node_modules $out/share/zennotes/
+      '';
+      postFixup = ''
+        # allow nix store inside the index.js file
+
+        sed -i '/function isTrustedRendererUrl/a \  if (url.includes("nix/store")) return true;' \
+          $out/share/zennotes/main/index.js
+      '';
+    };
+  in {
+    packages.${system} = {
+      default = pkgs.stdenv.mkDerivation {
+        pname = "zennotes";
+        version = "${version}";
+
+        # wo only combine here
+        dontUnpack = true;
+
+        nativeBuildInputs = [pkgs.makeWrapper];
+
+        installPhase = ''
+              mkdir -p $out/bin
+               mkdir -p $out/share/zennotes
+
+            # copy the frontend  files into the final path
+               cp -r ${frontend-desktop}/share/zennotes/* $out/share/zennotes/
+
+          # wrap application with electron
+               makeWrapper ${pkgs.electron}/bin/electron $out/bin/zennotes \
+                 --add-flags "$out/share/zennotes/main/index.js" \
+                 --set NODE_PATH "$out/share/zennotes/node_modules" \
+                 --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
+        '';
+      };
+
+      # server only for selfhosting
+      server = backend;
+    };
+
+    devShells.${system}.default = pkgs.mkShell {
+      buildInputs = with pkgs; [
+        nodejs_22
+        go_1_22
+        electron
+        turbo
+      ];
+
+      shellHook = ''
+        export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+        echo "ZenNotes Dev Environment loaded - using the nix electron, skipping npm download!"
+      '';
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,7 @@
           mkdir -p $out/share/zennotes
           cp -r apps/desktop/out/* $out/share/zennotes/
           cp -r -L node_modules $out/share/zennotes/
+          cp -r apps/desktop/build/icons $out/share/zennotes
         '';
         postFixup = ''
           # allow nix store inside the index.js file
@@ -89,21 +90,21 @@
           # wo only combine here
           dontUnpack = true;
 
+          nativeBuildInputs = with pkgs; [
+            makeWrapper
+            copyDesktopItems
+          ];
+
           desktopItems = [
             (pkgs.makeDesktopItem {
               name = "zennotes";
-              exec = "zennotes"; # This calls the binary wrapper we made in $out/bin
-              icon = "zennotes"; # The system looks for an icon named 'zennotes'
+              exec = "zennotes";
+              icon = "zennotes";
               desktopName = "ZenNotes";
               genericName = "Note-Taking App";
               comment = "An elegant, sandboxed markdown note-taking app";
               categories = ["Office" "Utility" "TextEditor"];
             })
-          ];
-
-          nativeBuildInputs = with pkgs; [
-            makeWrapper
-            copyDesktopItems
           ];
 
           installPhase =
@@ -120,9 +121,10 @@
                 --set NODE_PATH "$APP_DIR/Resources/node_modules" \
                 --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
 
-              # 3. CLI-Link fürs Terminal
               mkdir -p $out/bin
               ln -s "$APP_DIR/MacOS/ZenNotes" $out/bin/zennotes
+
+              runHook postInstall
             ''
             else ''
               mkdir -p $out/bin
@@ -137,11 +139,12 @@
                 --set NODE_PATH "$out/share/zennotes/node_modules" \
                 --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
 
-              if [ -d "apps/desktop/resources/icons" ]; then
+              if [ -d "${frontend-desktop}/share/zennotes/icons" ]; then
                 mkdir -p $out/share/icons/hicolor/512x512/apps
-                # Adjust this path depending on where your actual app icon sits in your source
-                cp apps/desktop/resources/icon.png $out/share/icons/hicolor/512x512/apps/zennotes.png
+                cp ${frontend-desktop}/share/zennotes/icons/512x512.png $out/share/icons/hicolor/512x512/apps/zennotes.png
               fi
+
+              runHook postInstall
             '';
         };
 
@@ -149,10 +152,10 @@
         server = backend;
       };
 
-      devShells.${system}.default = pkgs.mkShell {
+      devShells.default = pkgs.mkShell {
         buildInputs = with pkgs; [
           nodejs_22
-          go_1_22
+          go
           electron
           turbo
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -3,125 +3,143 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = {
     self,
     nixpkgs,
-  }: let
-    # Für dieses Beispiel hardcoden wir auf Linux.
-    # Für Multi-Platform (MacOS/Linux) nutzt man meist flake-utils.
-    system = "x86_64-linux";
-    pkgs = import nixpkgs {inherit system;};
-    version = "2.3.0";
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      version = "2.3.0";
 
-    frontend-web = pkgs.buildNpmPackage {
-      pname = "zennotes-web";
-      version = "${version}";
-      # whole repo as part, because of turbo, building with workspace param
-      src = ./.;
-      npmDepsHash = "sha256-7IpGnxVjaJvfSZyKjOylGMhFqa1bx8Ry5O1yqYfNnCE=";
+      frontend-web = pkgs.buildNpmPackage {
+        pname = "zennotes-web";
+        version = "${version}";
+        # whole repo as part, because of turbo, building with workspace param
+        src = ./.;
+        npmDepsHash = "sha256-7IpGnxVjaJvfSZyKjOylGMhFqa1bx8Ry5O1yqYfNnCE=";
 
-      # we use the nix electon here and dont want NPM to donwload it
-      ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+        # we use the nix electon here and dont want NPM to donwload it
+        ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-      buildPhase = ''
-        echo "building the web frontend..."
-        npm run build --workspace=apps/web
-      '';
+        buildPhase = ''
+          echo "building the web frontend..."
+          npm run build --workspace=apps/web
+        '';
 
-      #copy the built web frontend to package it with the backend, needed by go:embed
-      installPhase = ''
-        mkdir -p $out/share/zennotes-web
-        cp -r apps/web/dist/* $out/share/zennotes-web/
-      '';
-    };
-    backend = pkgs.buildGoModule {
-      pname = "zennotes-server";
-      version = "${version}";
-
-      src = ./apps/server;
-
-      vendorHash = "sha256-wYBF7CjM6AvoWMWql9hFmIaj6pCmli4vOef6POyGkfU=";
-
-      preBuild = ''
-        mkdir -p web/dist
-        cp -r ${frontend-web}/share/zennotes-web/* web/dist/
-      '';
-    };
-
-    frontend-desktop = pkgs.buildNpmPackage {
-      pname = "zennotes-frontend-desktop";
-      version = "${version}";
-
-      # whole repo as src, see fronten-web part
-      src = ./.;
-
-      npmDepsHash = "sha256-7IpGnxVjaJvfSZyKjOylGMhFqa1bx8Ry5O1yqYfNnCE=";
-
-      # we use the nix electon here and dont want NPM to donwload it
-      ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-
-      buildPhase = ''
-        echo "Start turborepo build for desktop..."
-        npm run build --workspace=apps/desktop
-      '';
-
-      # copy the compiled files and node_modules for dependencies
-      installPhase = ''
-        mkdir -p $out/share/zennotes
-        cp -r apps/desktop/out/* $out/share/zennotes/
-        cp -r -L node_modules $out/share/zennotes/
-      '';
-      postFixup = ''
-        # allow nix store inside the index.js file
-
-        sed -i '/function isTrustedRendererUrl/a \  if (url.includes("nix/store")) return true;' \
-          $out/share/zennotes/main/index.js
-      '';
-    };
-  in {
-    packages.${system} = {
-      default = pkgs.stdenv.mkDerivation {
-        pname = "zennotes";
+        #copy the built web frontend to package it with the backend, needed by go:embed
+        installPhase = ''
+          mkdir -p $out/share/zennotes-web
+          cp -r apps/web/dist/* $out/share/zennotes-web/
+        '';
+      };
+      backend = pkgs.buildGoModule {
+        pname = "zennotes-server";
         version = "${version}";
 
-        # wo only combine here
-        dontUnpack = true;
+        src = ./apps/server;
 
-        nativeBuildInputs = [pkgs.makeWrapper];
+        vendorHash = "sha256-wYBF7CjM6AvoWMWql9hFmIaj6pCmli4vOef6POyGkfU=";
 
-        installPhase = ''
-              mkdir -p $out/bin
-               mkdir -p $out/share/zennotes
-
-            # copy the frontend  files into the final path
-               cp -r ${frontend-desktop}/share/zennotes/* $out/share/zennotes/
-
-          # wrap application with electron
-               makeWrapper ${pkgs.electron}/bin/electron $out/bin/zennotes \
-                 --add-flags "$out/share/zennotes/main/index.js" \
-                 --set NODE_PATH "$out/share/zennotes/node_modules" \
-                 --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
+        preBuild = ''
+          mkdir -p web/dist
+          cp -r ${frontend-web}/share/zennotes-web/* web/dist/
         '';
       };
 
-      # server only for selfhosting
-      server = backend;
-    };
+      frontend-desktop = pkgs.buildNpmPackage {
+        pname = "zennotes-frontend-desktop";
+        version = "${version}";
 
-    devShells.${system}.default = pkgs.mkShell {
-      buildInputs = with pkgs; [
-        nodejs_22
-        go_1_22
-        electron
-        turbo
-      ];
+        # whole repo as src, see fronten-web part
+        src = ./.;
 
-      shellHook = ''
-        export ELECTRON_SKIP_BINARY_DOWNLOAD=1
-        echo "ZenNotes Dev Environment loaded - using the nix electron, skipping npm download!"
-      '';
-    };
-  };
+        npmDepsHash = "sha256-7IpGnxVjaJvfSZyKjOylGMhFqa1bx8Ry5O1yqYfNnCE=";
+
+        # we use the nix electon here and dont want NPM to donwload it
+        ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+        buildPhase = ''
+          echo "Start turborepo build for desktop..."
+          npm run build --workspace=apps/desktop
+        '';
+
+        # copy the compiled files and node_modules for dependencies
+        installPhase = ''
+          mkdir -p $out/share/zennotes
+          cp -r apps/desktop/out/* $out/share/zennotes/
+          cp -r -L node_modules $out/share/zennotes/
+        '';
+        #postFixup = ''
+        # allow nix store inside the index.js file
+
+        #sed -i '/function isTrustedRendererUrl/a \  if (url.includes("nix/store")) return true;' \
+        #  $out/share/zennotes/main/index.js
+        #'';
+      };
+    in {
+      packages = {
+        default = pkgs.stdenv.mkDerivation {
+          pname = "zennotes";
+          version = "${version}";
+
+          # wo only combine here
+          dontUnpack = true;
+
+          nativeBuildInputs = [pkgs.makeWrapper];
+
+          installPhase =
+            if pkgs.stdenv.hostPlatform.isDarwin
+            then ''
+              APP_DIR="$out/Applications/ZenNotes.app/Contents"
+              mkdir -p "$APP_DIR/MacOS"
+              mkdir -p "$APP_DIR/Resources"
+
+              cp -r ${frontend-desktop}/share/zennotes/* "$APP_DIR/Resources/"
+
+              makeWrapper ${pkgs.electron}/Applications/Electron.app/Contents/MacOS/Electron "$APP_DIR/MacOS/ZenNotes" \
+                --add-flags "$APP_DIR/Resources/main/index.js" \
+                       --set NODE_PATH "$APP_DIR/Resources/node_modules" \
+                --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
+
+              # 3. CLI-Link fürs Terminal
+              mkdir -p $out/bin
+              ln -s "$APP_DIR/MacOS/ZenNotes" $out/bin/zennotes
+            ''
+            else ''
+                  mkdir -p $out/bin
+                   mkdir -p $out/share/zennotes
+
+                # copy the frontend  files into the final path
+                   cp -r ${frontend-desktop}/share/zennotes/* $out/share/zennotes/
+
+              # wrap application with electron
+                   makeWrapper ${pkgs.electron}/bin/electron $out/bin/zennotes \
+                     --add-flags "$out/share/zennotes/main/index.js" \
+                     --set NODE_PATH "$out/share/zennotes/node_modules" \
+                     --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
+            '';
+        };
+
+        # server only for selfhosting
+        server = backend;
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          nodejs_22
+          go_1_22
+          electron
+          turbo
+        ];
+
+        shellHook = ''
+          export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+          echo "ZenNotes Dev Environment loaded - using the nix electron, skipping npm download!"
+        '';
+      };
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -73,12 +73,12 @@
           cp -r apps/desktop/out/* $out/share/zennotes/
           cp -r -L node_modules $out/share/zennotes/
         '';
-        #postFixup = ''
-        # allow nix store inside the index.js file
+        postFixup = ''
+          # allow nix store inside the index.js file
 
-        #sed -i '/function isTrustedRendererUrl/a \  if (url.includes("nix/store")) return true;' \
-        #  $out/share/zennotes/main/index.js
-        #'';
+          sed -i '/function isTrustedRendererUrl/a \  if (url.includes("nix/store")) return true;' \
+            $out/share/zennotes/main/index.js
+        '';
       };
     in {
       packages = {
@@ -89,7 +89,22 @@
           # wo only combine here
           dontUnpack = true;
 
-          nativeBuildInputs = [pkgs.makeWrapper];
+          desktopItems = [
+            (pkgs.makeDesktopItem {
+              name = "zennotes";
+              exec = "zennotes"; # This calls the binary wrapper we made in $out/bin
+              icon = "zennotes"; # The system looks for an icon named 'zennotes'
+              desktopName = "ZenNotes";
+              genericName = "Note-Taking App";
+              comment = "An elegant, sandboxed markdown note-taking app";
+              categories = ["Office" "Utility" "TextEditor"];
+            })
+          ];
+
+          nativeBuildInputs = with pkgs; [
+            makeWrapper
+            copyDesktopItems
+          ];
 
           installPhase =
             if pkgs.stdenv.hostPlatform.isDarwin
@@ -102,7 +117,7 @@
 
               makeWrapper ${pkgs.electron}/Applications/Electron.app/Contents/MacOS/Electron "$APP_DIR/MacOS/ZenNotes" \
                 --add-flags "$APP_DIR/Resources/main/index.js" \
-                       --set NODE_PATH "$APP_DIR/Resources/node_modules" \
+                --set NODE_PATH "$APP_DIR/Resources/node_modules" \
                 --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
 
               # 3. CLI-Link fürs Terminal
@@ -110,17 +125,23 @@
               ln -s "$APP_DIR/MacOS/ZenNotes" $out/bin/zennotes
             ''
             else ''
-                  mkdir -p $out/bin
-                   mkdir -p $out/share/zennotes
+              mkdir -p $out/bin
+              mkdir -p $out/share/zennotes
 
-                # copy the frontend  files into the final path
-                   cp -r ${frontend-desktop}/share/zennotes/* $out/share/zennotes/
+              # copy the frontend  files into the final path
+              cp -r ${frontend-desktop}/share/zennotes/* $out/share/zennotes/
 
               # wrap application with electron
-                   makeWrapper ${pkgs.electron}/bin/electron $out/bin/zennotes \
-                     --add-flags "$out/share/zennotes/main/index.js" \
-                     --set NODE_PATH "$out/share/zennotes/node_modules" \
-                     --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
+              makeWrapper ${pkgs.electron}/bin/electron $out/bin/zennotes \
+                --add-flags "$out/share/zennotes/main/index.js" \
+                --set NODE_PATH "$out/share/zennotes/node_modules" \
+                --prefix PATH : ${pkgs.lib.makeBinPath [backend]}
+
+              if [ -d "apps/desktop/resources/icons" ]; then
+                mkdir -p $out/share/icons/hicolor/512x512/apps
+                # Adjust this path depending on where your actual app icon sits in your source
+                cp apps/desktop/resources/icon.png $out/share/icons/hicolor/512x512/apps/zennotes.png
+              fi
             '';
         };
 


### PR DESCRIPTION
**What this pr does:**
- Adds flake.nix & flake.lock: Sets up a deterministic environment for everyone using the nix package manager.
- devShells.default: A isolated shell with all the CLI tools, linters, and libraries pre-loaded.
- packages.default: A clean, hermetic way to build the project locally via Nix and embedd it into their system configuration.

**How to use:**
`nix develop` -> creates a new shell with all the packages defined for the environment

`nix build` -> runs through all the build steps defined in the flake.nix, builds it and creates a ./result symlink into the /nix/store to the built application.

**Steps:**
[x] `nix flake check` succeeds
[x] The application starts and runs after building
[x] Verified the Linux build
[ ] Verified the MacOS build