### PR TITLE
feat: add Rose Pine theme famile (main, moon & dawn)

### DIFF
--- a/packages/app-core/src/components/OnboardingWizard.tsx
+++ b/packages/app-core/src/components/OnboardingWizard.tsx
@@ -84,6 +84,12 @@ const FAMILY_DESCRIPTORS: ThemeFamilyDescriptor[] = [
     label: 'Tokyo Night',
     light: { bg: '#e1e2e7', fg: '#3760bf', accent: '#2e7de9' },
     dark: { bg: '#1a1b26', fg: '#a9b1d6', accent: '#7aa2f7' }
+  },
+  {
+    family: 'rose-pine',
+    label: 'Rose Pine',
+    light: { bg: '#f0f0f1', fg: '#575279', accent: '#31748f' },
+    dark: { bg: '#26233a', fg: '#e0def4', accent: '#9ccfd8' }
   }
 ]
 

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -501,7 +501,8 @@ export function SettingsModal(): JSX.Element {
       { id: 'one', label: 'One' },
       { id: 'nord', label: 'Nord' },
       { id: 'tokyo-night', label: 'Tokyo Night' },
-      { id: 'black-metal', label: 'Black Metal' }
+      { id: 'black-metal', label: 'Black Metal' },
+      { id: 'rose-pine', label: 'Rose Pine' }
     ],
     []
   )
@@ -580,6 +581,7 @@ export function SettingsModal(): JSX.Element {
       solarized: { light: 'solarized-light', dark: 'solarized-dark' },
       one: { light: 'one-light', dark: 'one-dark' },
       nord: { light: 'nord-light', dark: 'nord-dark' },
+      "rose-pine": { light: 'rose-pine-dawn', dark: 'rose-pine-main' },
       'tokyo-night': { light: 'tokyo-night-day', dark: 'tokyo-night-storm' },
       'black-metal': { light: 'black-metal-day', dark: 'black-metal' }
     }
@@ -724,7 +726,7 @@ export function SettingsModal(): JSX.Element {
           id: 'theme-family',
           title: 'Theme family',
           description: 'Pick the visual system ZenNotes uses across the app.',
-          keywords: ['theme', 'family', 'apple', 'gruvbox', 'catppuccin', 'github', 'solarized', 'nord', 'tokyo night']
+          keywords: ['theme', 'family', 'apple', 'gruvbox', 'catppuccin', 'github', 'solarized', 'nord', 'tokyo night', 'rose pine']
         },
         {
           id: 'theme-mode',

--- a/packages/app-core/src/lib/themes.ts
+++ b/packages/app-core/src/lib/themes.ts
@@ -19,6 +19,7 @@ export type ThemeFamily =
   | 'nord'
   | 'tokyo-night'
   | 'black-metal'
+  | 'rose-pine'
 export type ThemeMode = 'light' | 'dark' | 'auto'
 
 export interface ThemeOption {
@@ -98,7 +99,12 @@ export const THEMES: ThemeOption[] = [
   // Monochrome: true-black background, soft grey text, a single muted
   // teal accent. The dark variant follows the repo's default (bathory).
   { id: 'black-metal', label: 'Black', family: 'black-metal', mode: 'dark' },
-  { id: 'black-metal-day', label: 'Day', family: 'black-metal', mode: 'light' }
+  { id: 'black-metal-day', label: 'Day', family: 'black-metal', mode: 'light' },
+
+  // --- Rose Pine (rose-pine) --------------------------------------------
+  { id: 'rose-pine-main', label: 'Main', family: 'rose-pine', mode: 'dark' },
+  { id: 'rose-pine-moon', label: 'Moon', family: 'rose-pine', mode: 'dark' },
+  { id: 'rose-pine-dawn', label: 'Dawn', family: 'rose-pine', mode: 'light' },
 ]
 
 export const DEFAULT_THEME_ID = 'dark-hard'
@@ -159,6 +165,9 @@ export function resolveAuto(
   }
   if (family === 'black-metal') {
     return targetMode === 'dark' ? 'black-metal' : 'black-metal-day'
+  }
+  if (family === 'rose-pine') {
+    return targetMode === 'dark' ? 'rose-pine-main' : 'rose-pine-dawn'
   }
   // github
   return targetMode === 'dark' ? 'github-dark' : 'github-light'

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -144,7 +144,8 @@ const VALID_FAMILIES: ThemeFamily[] = [
   'solarized',
   'one',
   'nord',
-  'tokyo-night'
+  'tokyo-night',
+  'rose-pine'
 ]
 const VALID_MODES: ThemeMode[] = ['light', 'dark', 'auto']
 const VALID_SORTS: NoteSortOrder[] = [

--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -336,7 +336,10 @@
 :root[data-theme="one-dark"],
 :root[data-theme="nord-dark"],
 :root[data-theme="tokyo-night-storm"],
-:root[data-theme="black-metal"] {
+:root[data-theme="black-metal"],
+:root[data-theme="rose-pine-main"],
+:root[data-theme="rose-pine-moon"],
+:root[data-theme="rose-pine-dawn"] {
   --z-glass-a1: 0.58;
   --z-glass-a2: 0.46;
   --z-glass-a3: 0.32;
@@ -1029,6 +1032,96 @@
   --z-aqua: 79 115 115;
   --z-shadow: 0 0 0;
 }
+
+/* ===========================================================================
+ * Rose Pine — https://github.com/rose-pine/neovim
+ * "Main" (warmest), "Moon" (mid-tones), "Dawn" (light) variants.
+ * =======================================================================*/
+
+/* ---- Rose Pine Main (warmest) ------------------------ */
+:root[data-theme="rose-pine-main"] {
+  color-scheme: dark;
+  --z-bg: 25 23 36;
+  --z-bg-softer: 33 32 46;
+  --z-bg-1: 31 29 46;
+  --z-bg-2: 38 35 58;
+  --z-bg-3: 64 61 82;
+  --z-bg-4: 82 79 103;
+  --z-fg: 224 222 244; /* text */
+  --z-fg-1: 144 140 170; /* */
+  --z-fg-2: 110 106 134;
+  --z-grey-2: 144 140 170;
+  --z-grey-1: 110 106 134;
+  --z-grey-0: 82 79 103;
+  --z-grey-dim: 64 61 82;
+  --z-accent: 196 167 231;
+  --z-accent-soft: 246 193 119;
+  --z-accent-muted: 156 207 216;
+  --z-red: 235 111 146;
+  --z-green: 49 116 143;
+  --z-yellow: 246 193 119;
+  --z-blue: 156 207 216;
+  --z-purple: 196 167 231;
+  --z-aqua: 49 111 143;
+  --z-shadow: 25 23 36;
+}
+
+/* ---- Rose Pine Moon (midtones) ------------------------ */
+:root[data-theme="rose-pine-moon"] {
+  color-scheme: dark;
+  --z-bg: 35 33 54;
+  --z-bg-softer: 42 40 62;
+  --z-bg-1: 42 39 63;
+  --z-bg-2: 57 53 82;
+  --z-bg-3: 68 65 90;
+  --z-bg-4: 86 82 110;
+  --z-fg: 224 222 244; /* text */
+  --z-fg-1: 144 140 170; /* */
+  --z-fg-2: 110 106 134;
+  --z-grey-2: 144 140 170;
+  --z-grey-1: 110 106 134;
+  --z-grey-0: 86 82 110;
+  --z-grey-dim: 68 65 90;
+  --z-accent: 196 167 231;
+  --z-accent-soft: 246 193 119;
+  --z-accent-muted: 156 207 216;
+  --z-red: 235 111 146;
+  --z-green: 62 143 176;
+  --z-yellow: 246 193 119;
+  --z-blue: 156 207 216;
+  --z-purple: 196 167 231;
+  --z-aqua: 62 143 176;
+  --z-shadow: 0 0 0;
+}
+
+/* ---- Rose Pine Dawn (light) ------------------------ */
+:root[data-theme="rose-pine-dawn"] {
+  color-scheme: light;
+  --z-bg: 250 244 237;
+  --z-bg-softer: 244 237 232;
+  --z-bg-1: 255 250 243;
+  --z-bg-2: 242 233 222;
+  --z-bg-3: 223 218 217;
+  --z-bg-4: 206 202 205;
+  --z-fg: 87 82 121;
+  --z-fg-1: 121 117 147;
+  --z-fg-2: 152 147 165;
+  --z-grey-2: 121 117 147;
+  --z-grey-1: 152 147 165;
+  --z-grey-0: 206 202 205;
+  --z-grey-dim: 223 218 217;
+  --z-accent: 144 122 169;
+  --z-accent-soft: 234 157 52;
+  --z-accent-muted: 86 148 159;
+  --z-red: 180 99 122;
+  --z-green: 40 105 131;
+  --z-yellow: 234 157 52;
+  --z-blue: 86 148 159;
+  --z-purple: 144 122 169;
+  --z-aqua: 40 105 131;
+  --z-shadow: 87 82 121;
+}
+
 
 html,
 body,


### PR DESCRIPTION
### Adds the Rosé Pine theme family (Main, Moon, Dawn) to ZenNotes.
- 3 CSS theme blocks in `index.css` with all 23 `--z-*` variables
- Registered in `themes.ts`, `store.ts`, `SettingsModal.tsx`, `OnboardingWizard.tsx`
- Maps the official 15-color Rosé Pine palette into the app's 23-variable system
- Works with auto mode, variant picker, and theme persistence