### PR TITLE
feat(quick-capture): add `/` autocompletion to the quick capture editor

### DIFF
--- a/packages/app-core/src/components/QuickCaptureApp.tsx
+++ b/packages/app-core/src/components/QuickCaptureApp.tsx
@@ -47,6 +47,15 @@ import { markdownListIndentPlugin } from '../lib/cm-markdown-list-indent'
 import { syntaxHighlighting, HighlightStyle, defaultHighlightStyle } from '@codemirror/language'
 import { tags as t } from '@lezer/highlight'
 import { searchKeymap } from '@codemirror/search'
+import {
+  autocompletion,
+  completionKeymap,
+  completionStatus,
+  closeCompletion
+} from '@codemirror/autocomplete'
+import { Prec } from '@codemirror/state'
+import { completionNavKeymap } from '../lib/cm-completion-nav'
+import { templateSlashCommandSource, slashCommandRender } from '../lib/cm-slash-commands'
 import type { NoteMeta } from '@shared/ipc'
 import {
   DEFAULT_THEME_ID,
@@ -415,7 +424,32 @@ export function QuickCaptureApp(): JSX.Element {
           syntaxHighlighting(captureHighlight),
           syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
           placeholder('Start writing…'),
-          keymap.of([indentWithTab, ...defaultKeymap, ...historyKeymap, ...searchKeymap]),
+          autocompletion({
+            override: [templateSlashCommandSource],
+            addToOptions: [{ render: slashCommandRender.render, position: 0 }],
+            icons: false,
+            optionClass: () => 'slash-cmd-option'
+          }),
+          completionNavKeymap,
+          Prec.highest(
+            EditorView.domEventHandlers({
+              keydown: (event, view) => {
+                if (event.key !== 'Escape') return false
+                if (completionStatus(view.state) !== 'active') return false
+                closeCompletion(view)
+                event.preventDefault()
+                event.stopPropagation()
+                return true
+              }
+            })
+          ),
+          keymap.of([
+            indentWithTab,
+            ...completionKeymap,
+            ...defaultKeymap,
+            ...historyKeymap,
+            ...searchKeymap
+          ]),
           EditorView.updateListener.of((upd) => {
             if (!upd.docChanged) return
             const doc = upd.state.doc.toString()


### PR DESCRIPTION
## Context
**Disclaimer: mainly ai agent code with manual review, feel free to close if you discourage llm generated code** 

Adds the same Notion-style `/` command autocompletion the main editor has to the Quick Capture editor, which previously had none.

## Changes
- Wire slash-command autocompletion into the Quick Capture editor via the store-free `templateSlashCommandSource` (excludes the store-dependent "Page" command, which has no meaning in the capture renderer). The full menu (headings, lists, todo, quote, code, …) is available.
- Add a high-precedence Esc handler so dismissing an open slash menu only closes the menu, rather than bubbling to the window-level Esc that saves and hides the window — mirroring the existing `completionNavKeymap` pattern.

Tested locally and it seems to work fine.

Related: #182