### PR TITLE
packaging: pin v2.4.0 AUR + Flatpak hashes

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -13,6 +13,6 @@ pkgbase = zennotes-bin
 	conflicts = zennotes
 	options = !strip
 	source = ZenNotes-2.4.0-linux-x64.tar.gz::https://github.com/ZenNotes/zennotes/releases/download/v2.4.0/ZenNotes-2.4.0-linux-x64.tar.gz
-	sha256sums = SKIP
+	sha256sums = 63e97f6e13ff97d6d47ac3c03fe7fdc0718498c494f207b382696aa69615c5ab
 
 pkgname = zennotes-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -28,7 +28,7 @@ source=(
 # No artifact to hash yet — the v2.4.0 tarball is created at release time, so
 # SKIP is a placeholder. Run `updpkgsums` against the uploaded release asset
 # before publishing to AUR (step 2 above) to pin the real checksum.
-sha256sums=('SKIP')
+sha256sums=('63e97f6e13ff97d6d47ac3c03fe7fdc0718498c494f207b382696aa69615c5ab')
 
 package() {
   cd "${srcdir}"

--- a/packaging/flatpak/com.adibhanna.zennotes.yml
+++ b/packaging/flatpak/com.adibhanna.zennotes.yml
@@ -46,12 +46,10 @@ modules:
       - install -Dm644 com.adibhanna.zennotes.metainfo.xml
           /app/share/metainfo/com.adibhanna.zennotes.metainfo.xml
     sources:
-      # Bump `url` + `sha256` on each release (see README.md). The sha256 below
-      # is a placeholder — set it to the real hash of the v2.4.0 AppImage once
-      # the release is published: `shasum -a 256 ZenNotes-2.4.0-linux-x86_64.AppImage`.
+      # Bump `url` + `sha256` on each release (see README.md).
       - type: file
         url: https://github.com/ZenNotes/zennotes/releases/download/v2.4.0/ZenNotes-2.4.0-linux-x86_64.AppImage
-        sha256: 0000000000000000000000000000000000000000000000000000000000000000
+        sha256: 57bbbea3b3d043c765771f7230640d58dc4ace8b169bca20efb93d0fbb8215ad
         dest-filename: ZenNotes.AppImage
       - type: file
         path: zennotes.sh


### PR DESCRIPTION
Post-release: pin the real sha256 checksums now that the v2.4.0 assets are published.

- **AUR** `PKGBUILD` + `.SRCINFO` → `ZenNotes-2.4.0-linux-x64.tar.gz` (`63e97f6e…`), replacing the `SKIP` placeholder. The `makepkg (Arch)` CI check now runs the real build instead of skipping.
- **Flatpak** manifest → `ZenNotes-2.4.0-linux-x86_64.AppImage` (`57bbbea3…`).

The AUR package itself is published separately by pushing the `zennotes-bin` clone. Nix `release-data.json` (version + 3 hashes) still needs nix tooling and is handled separately.