### PR TITLE
ci(nix): add workflow to recompute release-data.json hashes

### DIFF
--- a/.github/workflows/nix-update.yml
+++ b/.github/workflows/nix-update.yml
@@ -1,0 +1,89 @@
+name: Update Nix hashes
+
+# Recompute packaging/nix/release-data.json for a published release, on a Nix
+# runner — so maintainers without a Linux/Nix machine can update the Nix package.
+# Run it from the Actions tab after the GitHub release exists; it opens a PR with
+# the bumped version + the three fixed-output hashes, verified by a real build.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without the leading v (e.g. 2.4.0)"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Compute hashes & update release-data.json
+        env:
+          V: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          DATA=packaging/nix/release-data.json
+          FAKE="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+          # 1) Source hash — the fetchFromGitHub tree for tag v$V.
+          SRC_HASH=$(nix run nixpkgs#nix-prefetch-github -- ZenNotes zennotes --rev "v$V" | jq -r '.hash // .sha256')
+          echo "hash (source) = $SRC_HASH"
+
+          # 2) npmDepsHash — from the tag's root package-lock.json (npm workspaces
+          #    use one root lockfile, which is what buildNpmPackage hashes).
+          curl -fsSL "https://raw.githubusercontent.com/ZenNotes/zennotes/v$V/package-lock.json" -o /tmp/package-lock.json
+          NPM_HASH=$(nix run nixpkgs#prefetch-npm-deps -- /tmp/package-lock.json)
+          echo "npmDepsHash = $NPM_HASH"
+
+          # Write version + source + npm now; leave vendorHash fake so the Go
+          # build surfaces the real one.
+          jq --arg v "$V" --arg h "$SRC_HASH" --arg n "$NPM_HASH" --arg f "$FAKE" \
+            '.version=$v | .hash=$h | .npmDepsHash=$n | .vendorHash=$f' "$DATA" > "$DATA.tmp"
+          mv "$DATA.tmp" "$DATA"
+
+          # 3) vendorHash — build the server; the Go vendor fixed-output derivation
+          #    reports the real hash as a mismatch against the fake one.
+          set +e
+          nix build .#zennotes-server --no-link 2> build.log
+          set -e
+          VENDOR_HASH=$(grep -oE 'got:[[:space:]]+sha256-[A-Za-z0-9+/=]+' build.log \
+            | grep -oE 'sha256-[A-Za-z0-9+/=]+' | head -1 || true)
+          if [ -z "$VENDOR_HASH" ]; then
+            echo "::error::Could not extract vendorHash from the build output."
+            cat build.log
+            exit 1
+          fi
+          echo "vendorHash = $VENDOR_HASH"
+          jq --arg vh "$VENDOR_HASH" '.vendorHash=$vh' "$DATA" > "$DATA.tmp"
+          mv "$DATA.tmp" "$DATA"
+
+          echo "=== updated release-data.json ==="
+          cat "$DATA"
+
+      - name: Verify the packages build with the new hashes
+        run: nix build .#zennotes-desktop .#zennotes-server --no-link --print-build-logs
+
+      - name: Open a PR with the update
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: nix/update-v${{ inputs.version }}
+          add-paths: packaging/nix/release-data.json
+          commit-message: "packaging(nix): bump to v${{ inputs.version }} + recompute hashes"
+          title: "packaging(nix): update release-data.json for v${{ inputs.version }}"
+          body: |
+            Automated Nix update for **v${{ inputs.version }}** (computed on a CI runner via the **Update Nix hashes** workflow):
+
+            - `version`
+            - `hash` (source) — `nix-prefetch-github`
+            - `npmDepsHash` — `prefetch-npm-deps`
+            - `vendorHash` — Go fixed-output build
+
+            Verified with `nix build .#zennotes-desktop .#zennotes-server`.


### PR DESCRIPTION
Adds a manual **workflow_dispatch** (`.github/workflows/nix-update.yml`) that updates `packaging/nix/release-data.json` on a CI runner — so the Nix package can be bumped without a local Linux/Nix machine.

On dispatch (input: `version`, e.g. `2.4.0`) it runs on `ubuntu-latest` with Nix installed and computes the three fixed-output hashes:

- **`hash`** (source) — `nix-prefetch-github ZenNotes zennotes --rev vX.Y.Z`
- **`npmDepsHash`** — `prefetch-npm-deps` on the tag's root `package-lock.json`
- **`vendorHash`** — fake-hash the Go build, scrape the real hash from the mismatch error

Then it verifies with `nix build .#zennotes-desktop .#zennotes-server` and opens a PR with the updated `release-data.json` (version + all three hashes).

### Usage per release
Actions → **Update Nix hashes** → type the version → Run → review/merge the PR it opens.

### Note
Requires the repo setting **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** to be enabled for the PR-open step.