### PR TITLE
packaging(nix): update release-data.json for v2.4.0

### DIFF
--- a/packaging/nix/release-data.json
+++ b/packaging/nix/release-data.json
@@ -1,6 +1,6 @@
 {
-	"version": "2.3.0",
-	"hash": "sha256-+tLPVnnMbtMa5blSwHav9ZMlnkUsrdG62mMGxhbmy6g=",
-	"npmDepsHash": "sha256-7IpGnxVjaJvfSZyKjOylGMhFqa1bx8Ry5O1yqYfNnCE=",
-	"vendorHash": "sha256-wYBF7CjM6AvoWMWql9hFmIaj6pCmli4vOef6POyGkfU="
+  "version": "2.4.0",
+  "hash": "sha256-v+0Iyxz0B5IQ6FnzD6WecIfrM1j4PUzizH63JMvkp8Y=",
+  "npmDepsHash": "sha256-OgehLwGj216oBUJOuEmzxzzr/BlwoUaE5IAbT5rvgTQ=",
+  "vendorHash": "sha256-wYBF7CjM6AvoWMWql9hFmIaj6pCmli4vOef6POyGkfU="
 }


### PR DESCRIPTION
Bumps the Nix package to **v2.4.0** with the three fixed-output hashes, computed **and build-verified** on a CI runner by the **Update Nix hashes** workflow (run [27852949047](https://github.com/ZenNotes/zennotes/actions/runs/27852949047)):

| field | value |
|---|---|
| `version` | `2.4.0` |
| `hash` (source) | `sha256-v+0Iyxz0B5IQ6FnzD6WecIfrM1j4PUzizH63JMvkp8Y=` |
| `npmDepsHash` | `sha256-OgehLwGj216oBUJOuEmzxzzr/BlwoUaE5IAbT5rvgTQ=` |
| `vendorHash` | `sha256-wYBF7CjM6AvoWMWql9hFmIaj6pCmli4vOef6POyGkfU=` (unchanged — Go deps didn't move) |

The workflow's **Verify** step passed, i.e. `nix build .#zennotes-desktop .#zennotes-server` succeeded with these hashes — so they're known-good.

Opened manually because the workflow's auto-PR step is blocked by *Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"* being off. Enabling that makes future runs open this PR themselves; the branch is pushed either way.