### PR TITLE
Add quick capture deep link fallback for Wayland

### DIFF
--- a/apps/desktop/src/main/deep-links.test.ts
+++ b/apps/desktop/src/main/deep-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseOpenNoteDeepLink } from './deep-links'
+import { parseOpenNoteDeepLink, parseQuickCaptureDeepLink } from './deep-links'
 
 describe('parseOpenNoteDeepLink', () => {
   it('parses encoded vault-relative paths', () => {
@@ -39,5 +39,17 @@ describe('parseOpenNoteDeepLink', () => {
     expect(parseOpenNoteDeepLink('zennotes://open?path=..%2Fsecret.md')).toBeNull()
     expect(parseOpenNoteDeepLink('zennotes://open?path=notes%2F..%2Fsecret.md')).toBeNull()
     expect(parseOpenNoteDeepLink('zennotes://open?path=C%3A%2FUsers%2Fnote.md')).toBeNull()
+  })
+})
+
+describe('parseQuickCaptureDeepLink', () => {
+  it('parses quick capture links', () => {
+    expect(parseQuickCaptureDeepLink('zennotes://quick-capture')).toBe(true)
+    expect(parseQuickCaptureDeepLink('zennotes:/quick-capture')).toBe(true)
+  })
+
+  it('rejects other links', () => {
+    expect(parseQuickCaptureDeepLink('zennotes://open?path=note.md')).toBe(false)
+    expect(parseQuickCaptureDeepLink('https://quick-capture')).toBe(false)
   })
 })

--- a/apps/desktop/src/main/deep-links.ts
+++ b/apps/desktop/src/main/deep-links.ts
@@ -14,6 +14,24 @@ const OPEN_NOTE_ACTION_TARGETS: Record<string, OpenNoteDeepLinkTarget> = {
   'open-window': 'window'
 }
 
+function deepLinkAction(parsed: URL): string {
+  return parsed.hostname || parsed.pathname.replace(/^\/+/, '')
+}
+
+export function parseQuickCaptureDeepLink(rawUrl: string): boolean {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) return false
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return false
+  }
+
+  return parsed.protocol === `${ZENNOTES_DEEP_LINK_SCHEME}:` && deepLinkAction(parsed) === 'quick-capture'
+}
+
 export function parseOpenNoteDeepLink(rawUrl: string): OpenNoteDeepLinkRequest | null {
   const trimmed = rawUrl.trim()
   if (!trimmed) return null
@@ -27,7 +45,7 @@ export function parseOpenNoteDeepLink(rawUrl: string): OpenNoteDeepLinkRequest |
 
   if (parsed.protocol !== `${ZENNOTES_DEEP_LINK_SCHEME}:`) return null
 
-  const action = parsed.hostname || parsed.pathname.replace(/^\/+/, '')
+  const action = deepLinkAction(parsed)
   const target = OPEN_NOTE_ACTION_TARGETS[action]
   if (!target) return null
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -154,6 +154,7 @@ import {
 import { recordMainPerf } from './perf'
 import {
   parseOpenNoteDeepLink,
+  parseQuickCaptureDeepLink,
   ZENNOTES_DEEP_LINK_SCHEME
 } from './deep-links'
 import {
@@ -326,20 +327,29 @@ async function flushPendingFloatingNoteRequests(): Promise<void> {
   }
 }
 
-function handleExternalOpenUrl(rawUrl: string): boolean {
+type ExternalOpenUrlResult = 'none' | 'note' | 'quick-capture'
+
+function handleExternalOpenUrl(rawUrl: string): ExternalOpenUrlResult {
+  if (parseQuickCaptureDeepLink(rawUrl)) {
+    toggleQuickCaptureWindow()
+    return 'quick-capture'
+  }
   const request = parseOpenNoteDeepLink(rawUrl)
-  if (!request) return false
+  if (!request) return 'none'
   if (request.target === 'window') queueFloatingNoteRequest(request.path)
   else queueOpenNoteRequest(request.path)
-  return true
+  return 'note'
 }
 
-function handleStartupDeepLinks(argv: string[]): void {
+function handleStartupDeepLinks(argv: string[]): ExternalOpenUrlResult {
+  let result: ExternalOpenUrlResult = 'none'
   for (const arg of argv) {
     if (arg.startsWith(`${ZENNOTES_DEEP_LINK_SCHEME}:`)) {
-      handleExternalOpenUrl(arg)
+      const next = handleExternalOpenUrl(arg)
+      if (next !== 'none') result = next
     }
   }
+  return result
 }
 
 function focusWindow(win: BrowserWindow): void {
@@ -2908,11 +2918,18 @@ function registerQuickCaptureHotkey(hotkey: string): { ok: boolean; error?: stri
   const trimmed = hotkey.trim()
   if (!trimmed) return { ok: true }
   try {
-    const ok = globalShortcut.register(trimmed, toggleQuickCaptureWindow)
+    const ok = globalShortcut.register(trimmed, () => {
+      console.info(`[zen:quick-capture] hotkey pressed: ${trimmed}`)
+      toggleQuickCaptureWindow()
+    })
     if (!ok) {
       return { ok: false, error: `Failed to register quick capture hotkey: ${trimmed}` }
     }
+    if (!globalShortcut.isRegistered(trimmed)) {
+      return { ok: false, error: `Quick capture hotkey was not registered by the system: ${trimmed}` }
+    }
     registeredQuickCaptureHotkey = trimmed
+    console.info(`[zen:quick-capture] registered hotkey: ${trimmed}`)
     return { ok: true }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
@@ -3171,6 +3188,10 @@ async function runMenuUpdateCheck(): Promise<void> {
 // before `app.whenReady()`.
 if (process.platform === 'linux') {
   app.commandLine.appendSwitch('disable-features', 'VaapiVideoDecoder,VaapiVideoEncoder')
+  // Wayland compositors (including Hyprland/Omarchy) expose global shortcuts
+  // through xdg-desktop-portal, but Electron only wires that path when this
+  // Chromium feature is enabled before app.whenReady().
+  app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal')
 }
 
 app.whenReady().then(async () => {
@@ -3289,7 +3310,7 @@ app.whenReady().then(async () => {
 
 app.on('open-url', (event, url) => {
   event.preventDefault()
-  if (!handleExternalOpenUrl(url)) {
+  if (handleExternalOpenUrl(url) === 'none') {
     console.warn(`Ignoring unsupported ${ZENNOTES_DEEP_LINK_SCHEME} URL: ${url}`)
   }
 })
@@ -3307,9 +3328,9 @@ app.on('open-file', (event, filePath) => {
 // already running) forwards its argv here instead of starting a second
 // process.
 app.on('second-instance', (_event, argv) => {
-  handleStartupDeepLinks(argv)
+  const deepLinkResult = handleStartupDeepLinks(argv)
   handleStartupMarkdownArgs(argv, false)
-  if (mainWindow && !mainWindow.isDestroyed()) focusWindow(mainWindow)
+  if (deepLinkResult !== 'quick-capture' && mainWindow && !mainWindow.isDestroyed()) focusWindow(mainWindow)
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -331,7 +331,7 @@ type ExternalOpenUrlResult = 'none' | 'note' | 'quick-capture'
 
 function handleExternalOpenUrl(rawUrl: string): ExternalOpenUrlResult {
   if (parseQuickCaptureDeepLink(rawUrl)) {
-    toggleQuickCaptureWindow()
+    void toggleQuickCaptureWindow()
     return 'quick-capture'
   }
   const request = parseOpenNoteDeepLink(rawUrl)
@@ -2631,7 +2631,7 @@ function registerIpc(): void {
   })
 
   handle(IPC.WINDOW_TOGGLE_QUICK_CAPTURE, async () => {
-    toggleQuickCaptureWindow()
+    await toggleQuickCaptureWindow()
   })
 
   handle(IPC.APP_GET_QUICK_CAPTURE_HOTKEY, async () => {
@@ -2797,7 +2797,7 @@ let registeredQuickCaptureHotkey: string | null = null
  *  auto-hide on blur. Mirrors PersistedConfig.quickCapturePinned. */
 let quickCapturePinned = false
 
-function ensureQuickCaptureWindow(): BrowserWindow {
+async function ensureQuickCaptureWindow(): Promise<BrowserWindow> {
   if (quickCaptureWindow && !quickCaptureWindow.isDestroyed()) return quickCaptureWindow
   const mac = isMac()
   const sourceWindow = BrowserWindow.getFocusedWindow() ?? mainWindow
@@ -2860,6 +2860,10 @@ function ensureQuickCaptureWindow(): BrowserWindow {
   applyZoomFactor(win, currentZoomFactor)
   if (sourceWindow && !sourceWindow.isDestroyed()) {
     inheritWindowWorkspaceSession(sourceWindow, win)
+  } else {
+    await ipcWindowContext.run(win, async () => {
+      await loadCurrentVaultFromConfig()
+    })
   }
 
   const params = '?quickCapture=1'
@@ -2884,8 +2888,8 @@ function applyQuickCapturePinned(): void {
   win.setAlwaysOnTop(true, quickCapturePinned ? 'screen-saver' : 'floating')
 }
 
-function showQuickCaptureWindow(): void {
-  const win = ensureQuickCaptureWindow()
+async function showQuickCaptureWindow(): Promise<void> {
+  const win = await ensureQuickCaptureWindow()
   const sourceWindow = BrowserWindow.getFocusedWindow() ?? mainWindow
   if (sourceWindow && sourceWindow.id !== win.id && !sourceWindow.isDestroyed()) {
     inheritWindowWorkspaceSession(sourceWindow, win)
@@ -2894,13 +2898,13 @@ function showQuickCaptureWindow(): void {
   win.focus()
 }
 
-function toggleQuickCaptureWindow(): void {
+async function toggleQuickCaptureWindow(): Promise<void> {
   const win = quickCaptureWindow
   if (win && !win.isDestroyed() && win.isVisible() && win.isFocused()) {
     win.hide()
     return
   }
-  showQuickCaptureWindow()
+  await showQuickCaptureWindow()
 }
 
 function unregisterQuickCaptureHotkey(): void {
@@ -2920,7 +2924,7 @@ function registerQuickCaptureHotkey(hotkey: string): { ok: boolean; error?: stri
   try {
     const ok = globalShortcut.register(trimmed, () => {
       console.info(`[zen:quick-capture] hotkey pressed: ${trimmed}`)
-      toggleQuickCaptureWindow()
+      void toggleQuickCaptureWindow()
     })
     if (!ok) {
       return { ok: false, error: `Failed to register quick capture hotkey: ${trimmed}` }
@@ -3265,14 +3269,14 @@ app.whenReady().then(async () => {
   registerIpc()
   initAppUpdater()
   registerAppDeepLinkProtocol()
-  handleStartupDeepLinks(process.argv)
+  const startupDeepLinkResult = handleStartupDeepLinks(process.argv)
   handleStartupMarkdownArgs(process.argv, true)
 
   // Honor a file ZenNotes was launched to open before falling back to a
   // default-vault window, so double-clicking a .md doesn't also pop an
   // unrelated window.
   const openedFromFile = await flushPendingFileOpens()
-  if (!openedFromFile) {
+  if (!openedFromFile && startupDeepLinkResult !== 'quick-capture') {
     await ensureMainWindow()
   }
   void flushPendingFloatingNoteRequests()
@@ -3330,7 +3334,12 @@ app.on('open-file', (event, filePath) => {
 app.on('second-instance', (_event, argv) => {
   const deepLinkResult = handleStartupDeepLinks(argv)
   handleStartupMarkdownArgs(argv, false)
-  if (deepLinkResult !== 'quick-capture' && mainWindow && !mainWindow.isDestroyed()) focusWindow(mainWindow)
+  if (deepLinkResult === 'quick-capture') return
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    focusWindow(mainWindow)
+    return
+  }
+  void ensureMainWindow()
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
Adds `zennotes://quick-capture` as a fallback entrypoint for opening the floating quick capture window.

Motivation:
- On Wayland, Electron `globalShortcut.register(...)` can report successful registration while the shortcut callback is never invoked.
- Reproduced on Omarchy/Hyprland, and a similar issue was observed on Ubuntu Wayland.
- Enabling `GlobalShortcutsPortal` helps route through the Wayland portal, but did not make the callback fire reliably in the tested Hyprland setup.

What changed:
- Adds parsing for `zennotes://quick-capture`.
- Routes that deep link to the same quick capture window toggle used by the existing shortcut path.
- Avoids refocusing the main window after quick-capture deep links on second-instance launches.
- Adds focused deep-link tests.

Tested:
- `npm run test:run --workspace @zennotes/desktop -- src/main/deep-links.test.ts`
- `npm run typecheck --workspace @zennotes/desktop`
- `npm run pack --workspace @zennotes/desktop`
- Verified on Omarchy/Hyprland with:
  `xdg-open zennotes://quick-capture`

Example Linux Wayland binding:
```conf
bindd = CTRL SHIFT, F, ZenNotes quick capture, exec, xdg-open zennotes://quick-capture
This keeps the existing Electron global shortcut path intact while providing a compositor/desktop-environment friendly fallback.
