### PR TITLE
feat(settings): make the Tasks view label customizable

### DIFF
--- a/packages/app-core/src/components/BufferPalette.tsx
+++ b/packages/app-core/src/components/BufferPalette.tsx
@@ -83,7 +83,7 @@ function buildEntries(deps: BuildDeps): BufferEntry[] {
     if (isTasksTabPath(path)) {
       entries.push({
         path,
-        title: 'Tasks',
+        title: labels.tasks,
         subtitle: 'Vault-wide task list',
         keywords: 'tasks todos checklist vault virtual',
         badge,

--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -2278,7 +2278,7 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
         if (isTasksTabPath(path)) {
           return {
             ...base,
-            title: 'Tasks',
+            title: folderLabels.tasks,
             isTasks: true
           }
         }
@@ -2354,7 +2354,7 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
         }
       })
     },
-    [tabs, pinnedTabs, previewTab, content, notes, folderLabels.quick, folderLabels.archive, folderLabels.trash]
+    [tabs, pinnedTabs, previewTab, content, notes, folderLabels.quick, folderLabels.archive, folderLabels.trash, folderLabels.tasks]
   )
 
   const tabMenuItems = useMemo<ContextMenuItem[]>(() => {

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -1549,6 +1549,12 @@ export function SettingsModal(): JSX.Element {
           title: 'Trash label',
           description: 'Display name for deleted-note recovery.',
           keywords: ['system folders', 'folder label']
+        },
+        {
+          id: 'tasks-label',
+          title: 'Tasks label',
+          description: 'Display name for the vault-wide task list.',
+          keywords: ['system folders', 'folder label', 'tasks']
         }
       ],
       content: (
@@ -2065,8 +2071,16 @@ export function SettingsModal(): JSX.Element {
               settingId="trash-label"
               onChange={(next) => setSystemFolderLabel('trash', next)}
             />
+            <TextInputRow
+              label="Tasks label"
+              description="Display name for the vault-wide task list."
+              value={systemFolderLabels.tasks ?? ''}
+              placeholder={DEFAULT_SYSTEM_FOLDER_LABELS.tasks}
+              settingId="tasks-label"
+              onChange={(next) => setSystemFolderLabel('tasks', next)}
+            />
             <InlineNote>
-              Current labels: {getSystemFolderLabel('quick', systemFolderLabels)}, {getSystemFolderLabel('inbox', systemFolderLabels)}, {getSystemFolderLabel('archive', systemFolderLabels)}, and {getSystemFolderLabel('trash', systemFolderLabels)}.
+              Current labels: {getSystemFolderLabel('quick', systemFolderLabels)}, {getSystemFolderLabel('inbox', systemFolderLabels)}, {getSystemFolderLabel('archive', systemFolderLabels)}, {getSystemFolderLabel('trash', systemFolderLabels)}, and {getSystemFolderLabel('tasks', systemFolderLabels)}.
             </InlineNote>
           </Section>
         </div>

--- a/packages/app-core/src/components/Sidebar.tsx
+++ b/packages/app-core/src/components/Sidebar.tsx
@@ -2974,6 +2974,7 @@ export function Sidebar(): JSX.Element {
           <SidebarSectionHeading label="Quick access" />
 
           <TaskSidebarRow
+            label={folderLabels.tasks}
             active={tasksViewActive}
             onClick={() => void openTasksView()}
             sidebarIdx={idxCounter.current.value++}
@@ -4764,12 +4765,14 @@ function TreeRow({
 // Top-level utility row. These align their icon center to the folder chevron
 // rail, but do not reserve a full fake chevron slot.
 function TaskSidebarRow({
+  label,
   active,
   onClick,
   sidebarIdx,
   vimHighlight,
   sidebarFocused = false,
 }: {
+  label: string;
   active: boolean;
   onClick: () => void;
   sidebarIdx?: number;
@@ -4811,7 +4814,7 @@ function TaskSidebarRow({
       <SidebarGlyph active={strongActive} rowActive={active}>
         <CheckSquareIcon width={12} height={12} strokeWidth={2.15} />
       </SidebarGlyph>
-      <span className="flex-1 truncate">Tasks</span>
+      <span className="flex-1 truncate">{label}</span>
     </div>
   );
 }

--- a/packages/app-core/src/components/TasksView.tsx
+++ b/packages/app-core/src/components/TasksView.tsx
@@ -8,6 +8,7 @@ import { TasksCalendar } from './TasksCalendar'
 import { TasksKanban } from './TasksKanban'
 import { CalendarIcon, CheckSquareIcon, KanbanIcon, ListIcon } from './icons'
 import { advanceSequence, getKeymapBinding, matchesSequenceToken } from '../lib/keymaps'
+import { getSystemFolderLabel } from '../lib/system-folder-labels'
 import { isImeComposing } from '../lib/ime'
 import { isAppOverlayOpen } from '../lib/overlay-open'
 
@@ -35,6 +36,8 @@ export function TasksView(): JSX.Element {
   const rawTasks = useStore((s) => s.vaultTasks)
   const notes = useStore((s) => s.notes)
   const vaultSettings = useStore((s) => s.vaultSettings)
+  const systemFolderLabels = useStore((s) => s.systemFolderLabels)
+  const tasksLabel = getSystemFolderLabel('tasks', systemFolderLabels)
   const loading = useStore((s) => s.tasksLoading)
   const filter = useStore((s) => s.tasksFilter)
   const cursorIndex = useStore((s) => s.taskCursorIndex)
@@ -357,7 +360,7 @@ export function TasksView(): JSX.Element {
     >
       <div className="flex items-center gap-2 border-b border-paper-300/45 px-4 py-3">
         <CheckSquareIcon width={18} height={18} />
-        <h1 className="text-sm font-semibold">Tasks</h1>
+        <h1 className="text-sm font-semibold">{tasksLabel}</h1>
         <span className="ml-2 rounded bg-paper-300/60 px-1.5 py-0.5 text-xs text-current/60">
           {tasks.length} total
         </span>

--- a/packages/app-core/src/components/TitleBar.tsx
+++ b/packages/app-core/src/components/TitleBar.tsx
@@ -21,7 +21,7 @@ export function TitleBar(): JSX.Element {
     : isQuickNotesTabPath(selectedPath)
       ? labels.quick
     : isTasksTabPath(selectedPath)
-      ? 'Tasks'
+      ? labels.tasks
       : isTagsTabPath(selectedPath)
         ? 'Tags'
         : isHelpTabPath(selectedPath)

--- a/packages/app-core/src/lib/commands.ts
+++ b/packages/app-core/src/lib/commands.ts
@@ -895,7 +895,7 @@ export function buildCommands(options?: { includeUnavailable?: boolean }): Comma
   cmds.push(
     {
       id: 'view.tasks',
-      title: 'Open Tasks',
+      title: `Open ${labels().tasks}`,
       category: 'View',
       shortcut: ':tasks',
       keywords: 'todo checklist due waiting done vault',

--- a/packages/app-core/src/lib/system-folder-labels.test.ts
+++ b/packages/app-core/src/lib/system-folder-labels.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_SYSTEM_FOLDER_LABELS,
+  normalizeSystemFolderLabels,
+  getSystemFolderLabel,
+  resolveSystemFolderLabels
+} from './system-folder-labels'
+
+describe('system folder labels', () => {
+  it('defaults cover the four folders plus the virtual tasks view', () => {
+    expect(DEFAULT_SYSTEM_FOLDER_LABELS).toEqual({
+      inbox: 'Inbox',
+      quick: 'Quick Notes',
+      archive: 'Archive',
+      trash: 'Trash',
+      tasks: 'Tasks'
+    })
+  })
+
+  describe('getSystemFolderLabel', () => {
+    it('returns the default when there is no override', () => {
+      expect(getSystemFolderLabel('tasks')).toBe('Tasks')
+      expect(getSystemFolderLabel('inbox', {})).toBe('Inbox')
+    })
+
+    it('returns the override when present', () => {
+      expect(getSystemFolderLabel('tasks', { tasks: 'To-dos' })).toBe('To-dos')
+    })
+  })
+
+  describe('resolveSystemFolderLabels', () => {
+    it('falls back to defaults for unset keys', () => {
+      expect(resolveSystemFolderLabels({ tasks: 'Work' })).toEqual({
+        inbox: 'Inbox',
+        quick: 'Quick Notes',
+        archive: 'Archive',
+        trash: 'Trash',
+        tasks: 'Work'
+      })
+    })
+  })
+
+  describe('normalizeSystemFolderLabels', () => {
+    it('keeps the tasks override alongside folder overrides', () => {
+      expect(normalizeSystemFolderLabels({ tasks: 'My Tasks', inbox: 'In' })).toEqual({
+        tasks: 'My Tasks',
+        inbox: 'In'
+      })
+    })
+
+    it('trims and collapses internal whitespace', () => {
+      expect(normalizeSystemFolderLabels({ tasks: '  My   Tasks  ' })).toEqual({
+        tasks: 'My Tasks'
+      })
+    })
+
+    it('drops empty / whitespace-only labels so the default shows through', () => {
+      expect(normalizeSystemFolderLabels({ tasks: '   ', inbox: '' })).toEqual({})
+    })
+
+    it('caps labels at 48 characters', () => {
+      const long = 'a'.repeat(60)
+      expect(normalizeSystemFolderLabels({ tasks: long }).tasks).toHaveLength(48)
+    })
+
+    it('ignores non-string values and non-object input', () => {
+      expect(normalizeSystemFolderLabels({ tasks: 123 })).toEqual({})
+      expect(normalizeSystemFolderLabels(null)).toEqual({})
+      expect(normalizeSystemFolderLabels('nope')).toEqual({})
+    })
+  })
+})

--- a/packages/app-core/src/lib/system-folder-labels.ts
+++ b/packages/app-core/src/lib/system-folder-labels.ts
@@ -1,15 +1,18 @@
 import type { NoteFolder } from '@shared/ipc'
 
-export type SystemFolderLabels = Partial<Record<NoteFolder, string>>
+export type SystemLabelKey = NoteFolder | 'tasks'
 
-export const DEFAULT_SYSTEM_FOLDER_LABELS: Record<NoteFolder, string> = {
+export type SystemFolderLabels = Partial<Record<SystemLabelKey, string>>
+
+export const DEFAULT_SYSTEM_FOLDER_LABELS: Record<SystemLabelKey, string> = {
   inbox: 'Inbox',
   quick: 'Quick Notes',
   archive: 'Archive',
-  trash: 'Trash'
+  trash: 'Trash',
+  tasks: 'Tasks'
 }
 
-const SYSTEM_FOLDERS: NoteFolder[] = ['inbox', 'quick', 'archive', 'trash']
+const SYSTEM_FOLDERS: SystemLabelKey[] = ['inbox', 'quick', 'archive', 'trash', 'tasks']
 
 function normalizeSystemFolderLabel(value: unknown): string | null {
   if (typeof value !== 'string') return null
@@ -20,7 +23,7 @@ function normalizeSystemFolderLabel(value: unknown): string | null {
 
 export function normalizeSystemFolderLabels(value: unknown): SystemFolderLabels {
   if (!value || typeof value !== 'object') return {}
-  const raw = value as Partial<Record<NoteFolder, unknown>>
+  const raw = value as Partial<Record<SystemLabelKey, unknown>>
   const next: SystemFolderLabels = {}
   for (const folder of SYSTEM_FOLDERS) {
     const label = normalizeSystemFolderLabel(raw[folder])
@@ -30,7 +33,7 @@ export function normalizeSystemFolderLabels(value: unknown): SystemFolderLabels 
 }
 
 export function getSystemFolderLabel(
-  folder: NoteFolder,
+  folder: SystemLabelKey,
   overrides?: SystemFolderLabels | null
 ): string {
   return overrides?.[folder] ?? DEFAULT_SYSTEM_FOLDER_LABELS[folder]
@@ -38,11 +41,12 @@ export function getSystemFolderLabel(
 
 export function resolveSystemFolderLabels(
   overrides?: SystemFolderLabels | null
-): Record<NoteFolder, string> {
+): Record<SystemLabelKey, string> {
   return {
     inbox: getSystemFolderLabel('inbox', overrides),
     quick: getSystemFolderLabel('quick', overrides),
     archive: getSystemFolderLabel('archive', overrides),
-    trash: getSystemFolderLabel('trash', overrides)
+    trash: getSystemFolderLabel('trash', overrides),
+    tasks: getSystemFolderLabel('tasks', overrides)
   }
 }

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -71,6 +71,7 @@ import type { KeymapId, KeymapOverrides } from './lib/keymaps'
 import { normalizeKeymapOverrides } from './lib/keymaps'
 import {
   type SystemFolderLabels,
+  type SystemLabelKey,
   normalizeSystemFolderLabels
 } from './lib/system-folder-labels'
 import { recordRendererPerf } from './lib/perf'
@@ -1886,7 +1887,7 @@ interface Store {
   setInterfaceFont: (family: string | null) => void
   setTextFont: (family: string | null) => void
   setMonoFont: (family: string | null) => void
-  setSystemFolderLabel: (folder: NoteFolder, label: string | null) => void
+  setSystemFolderLabel: (folder: SystemLabelKey, label: string | null) => void
   setSidebarWidth: (px: number) => void
   setNoteListWidth: (px: number) => void
   setNoteSortOrder: (order: NoteSortOrder) => void


### PR DESCRIPTION
Add a "Tasks label" field under Settings → Vault → System Folders so the vault-wide Tasks view can be renamed like the inbox, quick, archive, and trash labels. Tasks stays a virtual view, so the label key is modeled as SystemLabelKey = NoteFolder | 'tasks' rather than touching NoteFolder.

The resolved label is used everywhere the view surfaces: sidebar row, tab title, title bar, buffer palette, command palette, and the view heading.

Related: #225 

<img width="1121" height="981" alt="screenshot 2026-06-22 at 14 42 08" src="https://github.com/user-attachments/assets/559b0072-cea3-47bf-a5b0-b9f0f515e0a2" />
<img width="1658" height="707" alt="screenshot 2026-06-22 at 14 42 56" src="https://github.com/user-attachments/assets/a5fc9a6f-653a-40f1-b2e8-6fdea682a5a1" />

Palette:
<img width="566" height="387" alt="screenshot 2026-06-22 at 14 43 50" src="https://github.com/user-attachments/assets/7344c2e9-dd7e-427c-a4db-ffef5b2884a3" />
Buffer:
<img width="563" height="200" alt="screenshot 2026-06-22 at 14 54 12" src="https://github.com/user-attachments/assets/e7a71f91-717c-47e0-a417-663ae50502c8" />
