### PR TITLE
Feat/macos accessibility support

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -3258,6 +3258,19 @@ app.whenReady().then(async () => {
     return
   }
 
+  // Force Chromium's renderer accessibility tree on. By default Chromium builds
+  // it lazily, only once it detects an assistive client through the macOS
+  // accessibility activation handshake. Tools that read the tree without
+  // performing that handshake are otherwise left blind: they find the native
+  // window but never see the CodeMirror contentEditable text. Enabling it
+  // unconditionally exposes editor content to that whole class of accessibility
+  // clients (e.g. the Grammarly desktop app and similar proofreaders, which
+  // would otherwise show their UI but report nothing). macOS-only to avoid the
+  // small always-on cost where it isn't needed.
+  if (process.platform === 'darwin') {
+    app.setAccessibilitySupportEnabled(true)
+  }
+
   await migrateLegacyRemoteWorkspaceSecrets()
 
   protocol.handle(LOCAL_ASSET_SCHEME, async (request) => {

--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -1461,6 +1461,12 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
         doc: initialBody,
         extensions: [
           appMarkdownSnippetExtension(),
+          // Give the editable surface an accessible name so accessibility
+          // clients (screen readers, proofreaders such as Grammarly) identify
+          // it as a text field.
+          EditorView.contentAttributes.of({
+            'aria-label': 'Note editor'
+          }),
           vimCompartment.of(s0.vimMode ? vim() : []),
           historyCompartment.of(history()),
           drawSelection(),

--- a/packages/app-core/src/lib/cm-heading-fold.ts
+++ b/packages/app-core/src/lib/cm-heading-fold.ts
@@ -168,6 +168,14 @@ class HeadingFoldArrow extends WidgetType {
     el.setAttribute('role', 'button')
     el.setAttribute('aria-label', this.folded ? 'Expand heading' : 'Collapse heading')
     el.setAttribute('aria-expanded', String(!this.folded))
+    // Keep this decorative affordance out of the accessibility tree. It sits
+    // (via side:-1) at the very start of the heading line, so as an AX-visible
+    // `role="button"` it becomes the editable field's leading element. Some
+    // accessibility clients (e.g. Grammarly) inspect a field's leading content
+    // and, finding a button, treat the whole field as a non-prose control and
+    // disengage. Folding stays reachable by mouse, keyboard, and vim, so hiding
+    // it from the accessibility tree costs nothing.
+    el.setAttribute('aria-hidden', 'true')
     el.textContent = this.folded ? '▸' : '▾'
     // Eat mousedown so CodeMirror's own handler doesn't interpret the
     // click as a caret position and steal focus before we dispatch

--- a/packages/app-core/src/lib/cm-wysiwyg-blocks.ts
+++ b/packages/app-core/src/lib/cm-wysiwyg-blocks.ts
@@ -40,6 +40,10 @@ class BulletWidget extends WidgetType {
     const span = document.createElement('span')
     span.className = 'cm-wq-bullet'
     span.textContent = '•'
+    // Decorative marker only — keep it out of the accessibility tree so it
+    // doesn't pollute the field's text value for clients that read it (screen
+    // readers, proofreaders). The underlying `- ` is still the source text.
+    span.setAttribute('aria-hidden', 'true')
     return span
   }
   ignoreEvent(): boolean {


### PR DESCRIPTION
# Expose the editor to macOS accessibility clients

## Problem

On macOS, accessibility tools that read the system accessibility (AX) tree could not see the editor's text. Chromium builds its renderer accessibility tree lazily, only after an assistive client performs the macOS activation handshake. Tools that read the tree without performing that handshake were left blind: they could see the app window but not the CodeMirror content, so they appeared to attach, yet did nothing. The Grammarly desktop app is the clearest example (its bubble showed, but it never flagged anything), but this affects the whole class of AX-based text tools.

A second, related issue: a document whose first line was a heading disabled checking for the entire field because the heading fold arrow is at `opacity: 0` but is an accessibility-visible `role="button"` placed at the very start of the line. Clients that inspect a field's leading content treated the whole field as a non prose control.

## Changes

- **Enable the renderer accessibility tree on macOS** (`app.setAccessibilitySupportEnabled(true)` in `whenReady`). This exposes editor content to AX clients that do not trigger Chromium's lazy activation on their own.
- **Mark the heading fold arrow `aria-hidden`**  so it no longer sits in the accessibility tree as a leading interactive element. Folding is unchanged and still available by mouse, keyboard, and Vim.
- **Mark the live preview list bullet `aria-hidden`**  so the decorative glyph does not pollute the field's text value.
- **Add an `aria-label` to the editor surface** so clients announce it as a named text field.

No rendering or editing behavior changes. Typecheck and the full test suite pass.

## Tradeoffs to flag

- Enabling accessibility unconditionally has a small, always-present memory and CPU cost (Chromium keeps the tree live and updates it as you type), paid by every macOS user. The alternative is to gate it behind a setting; happy to do that if preferred. Scoped to macOS for now; the same API would likely help Windows (UI Automation) too.
- Hiding the fold arrow from the accessibility tree means a screen reader can no longer discover that one affordance, though folding remains reachable by keyboard and Vim.

## Not addressed (out of scope)

- Tools that skip the first word after a list marker: reproduce in unrelated editors, so it is the tool's behavior, not ours.
- Live preview tables: editable cells are nested in a `contenteditable="false"` widget, so AX clients disengage inside them. Workaround: the existing "Render tables in live preview" setting.