### PR TITLE
ci: build and release Linux arm64 artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          # GitHub's free arm64 Linux runner for public repos.
+          - ubuntu-24.04-arm
           - macos-latest
           - windows-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,13 @@ jobs:
           - name: Windows
             os: windows-latest
             command: npm run dist:win
-          - name: Linux
+          - name: Linux x64
             os: ubuntu-latest
+            command: npm run dist:linux
+          - name: Linux arm64
+            # GitHub's free arm64 Linux runner for public repos. This should 
+            # produce native aarch64 artifacts with no cross-compilation.
+            os: ubuntu-24.04-arm
             command: npm run dist:linux
     env:
       NODE_OPTIONS: "--max-old-space-size=12288"
@@ -85,9 +90,10 @@ jobs:
           done
 
       - name: Install Linux packaging tools
-        if: matrix.name == 'Linux'
+        if: startsWith(matrix.name, 'Linux')
         # `bsdtar` (libarchive-tools) is required by electron-builder's pacman
-        # target to generate the package .MTREE; it isn't on ubuntu-latest.
+        # target to generate the package .MTREE; it isn't on the GitHub Ubuntu
+        # runners (x64 or arm64).
         run: sudo apt-get update && sudo apt-get install -y libarchive-tools
 
       - name: Build release artifacts


### PR DESCRIPTION
Adds native arm64 Linux release artifacts (AppImage, deb, pacman, tar.gz) so aarch64 users get first-class downloads, matching what macOS already ships with `[arm64, x64]`. Closes #129.

It builds on GitHub's free `ubuntu-24.04-arm` runner. I also added arm64 to `ci.yml`: since `release.yml` only fires on tags, this keeps the arm64 build validated on every PR — in the same spirit as the existing `nix-build` and `aur-check` jobs.

One thing to flag for your preference: I left two short comments explaining the arm64 runner choice, following the rationale-comment style already in these files. Happy to drop them if you'd rather the matrix entries stay lean.
