### PR TITLE
chore: fix attachments typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ ZenNotes now works better with existing Obsidian-style vaults.
 - loose files anywhere in the vault are surfaced as files/assets
 - embedded files like `![[image.png]]` resolve more like Obsidian
 - new referenced files default to the vault root instead of a required attachments folder
-- legacy `attachements/` and `_assets/` folders are still recognized
+- legacy `attachments/` and `_assets/` folders are still recognized
 
 This means imported vaults with top-level notes, folders, and loose images/files behave much more naturally.
 

--- a/apps/desktop/src/main/assets-migrate.test.ts
+++ b/apps/desktop/src/main/assets-migrate.test.ts
@@ -27,8 +27,8 @@ describe('migrateLooseAssets (#185 assets/ unification)', () => {
     await writeFile(path.join(root, 'photo.png'), 'x', 'utf8')
     await writeFile(path.join(root, 'note.md'), '# hi', 'utf8') // a note — must stay
     await writeFile(path.join(root, 'books.csv'), 'id\n', 'utf8') // legacy db — must stay
-    await mkdir(path.join(root, 'attachements'), { recursive: true })
-    await writeFile(path.join(root, 'attachements', 'doc.pdf'), 'x', 'utf8')
+    await mkdir(path.join(root, 'attachments'), { recursive: true })
+    await writeFile(path.join(root, 'attachments', 'doc.pdf'), 'x', 'utf8')
 
     const { moved, skipped } = await migrateLooseAssets(root)
     expect(moved.sort()).toEqual(['assets/doc.pdf', 'assets/photo.png'])
@@ -37,7 +37,7 @@ describe('migrateLooseAssets (#185 assets/ unification)', () => {
     expect(await exists(root, 'assets/photo.png')).toBe(true)
     expect(await exists(root, 'assets/doc.pdf')).toBe(true)
     expect(await exists(root, 'photo.png')).toBe(false)
-    expect(await exists(root, 'attachements')).toBe(false) // emptied + removed
+    expect(await exists(root, 'attachments')).toBe(false) // emptied + removed
     // Notes and database files are untouched.
     expect(await exists(root, 'note.md')).toBe(true)
     expect(await exists(root, 'books.csv')).toBe(true)

--- a/apps/desktop/src/main/vault.test.ts
+++ b/apps/desktop/src/main/vault.test.ts
@@ -464,7 +464,7 @@ describe('listNotes metadata parsing', () => {
     const imageRel = 'inbox/image.md'
     const embedRel = 'inbox/embed.md'
     await writeFile(path.join(root, plainRel), '# Plain\n\n[[Project Note]]\n', 'utf8')
-    await writeFile(path.join(root, imageRel), '# Image\n\n![diagram](../attachements/diagram.png)\n', 'utf8')
+    await writeFile(path.join(root, imageRel), '# Image\n\n![diagram](../attachments/diagram.png)\n', 'utf8')
     await writeFile(path.join(root, embedRel), '# Embed\n\n![[brief.pdf]]\n', 'utf8')
 
     const notes = await listNotes(root)

--- a/apps/desktop/src/main/vault.ts
+++ b/apps/desktop/src/main/vault.ts
@@ -65,10 +65,10 @@ import { DEMO_TOUR_ASSETS, DEMO_TOUR_NOTES } from './demo-tour-data'
 const CONFIG_FILE = 'zennotes.config.json'
 const FOLDERS: NoteFolder[] = ['inbox', 'quick', 'archive', 'trash']
 const SYSTEM_FOLDERS = new Set<NoteFolder>(FOLDERS)
-// Assets are unified under a top-level `assets/` folder. `attachements`/`_assets`
+// Assets are unified under a top-level `assets/` folder. `attachments`/`_assets`
 // are recognized legacy dirs (read + migrated, never the import target). (#185)
 const ASSETS_DIR = 'assets'
-const PRIMARY_ATTACHMENTS_DIR = 'attachements'
+const PRIMARY_ATTACHMENTS_DIR = 'attachments'
 const LEGACY_ATTACHMENTS_DIRS = [PRIMARY_ATTACHMENTS_DIR, '_assets']
 const ATTACHMENTS_DIRS = [ASSETS_DIR, ...LEGACY_ATTACHMENTS_DIRS]
 const INTERNAL_VAULT_DIR = '.zennotes'
@@ -1174,7 +1174,7 @@ export async function ensureVaultLayout(root: string): Promise<void> {
 
 /**
  * One-time, idempotent migration: unify assets under `assets/`. Moves loose
- * root-level attachments and any files in the legacy `attachements/` / `_assets/`
+ * root-level attachments and any files in the legacy `attachments/` / `_assets/`
  * dirs into `assets/`, skipping a file whose basename already exists there (so
  * the basename-fallback resolution of `![[…]]`/`![](…)` embeds stays
  * unambiguous). Never touches notes (`.md`) or database files. Safe on every

--- a/apps/desktop/src/main/watcher.ts
+++ b/apps/desktop/src/main/watcher.ts
@@ -4,7 +4,7 @@ import type { NoteFolder, VaultChangeEvent, VaultChangeKind } from '@shared/ipc'
 import { databaseCsvPathFor } from '@shared/databases'
 import { folderForRelativePath } from './vault'
 
-const ATTACHMENTS_DIRS = new Set(['assets', 'attachements', '_assets'])
+const ATTACHMENTS_DIRS = new Set(['assets', 'attachments', '_assets'])
 const INTERNAL_VAULT_DIR = '.zennotes'
 const VAULT_SETTINGS_RELATIVE_PATH = `${INTERNAL_VAULT_DIR}/vault.json`
 const NOTE_COMMENTS_PREFIX = `${INTERNAL_VAULT_DIR}/comments/`

--- a/apps/desktop/src/main/window-vaults.test.ts
+++ b/apps/desktop/src/main/window-vaults.test.ts
@@ -112,10 +112,10 @@ describe('WindowVaultRegistry', () => {
     registry.setLocalVault(1, { root: rootA, name: 'A' })
     registry.setLocalVault(2, { root: rootB, name: 'B' })
 
-    expect(registry.isPathInsideOpenLocalVault(path.join(rootA, 'attachements', 'a.png'))).toBe(
+    expect(registry.isPathInsideOpenLocalVault(path.join(rootA, 'attachments', 'a.png'))).toBe(
       true
     )
-    expect(registry.isPathInsideOpenLocalVault(path.join(rootB, 'attachements', 'b.png'))).toBe(
+    expect(registry.isPathInsideOpenLocalVault(path.join(rootB, 'attachments', 'b.png'))).toBe(
       true
     )
     expect(registry.isPathInsideOpenLocalVault(`${rootA}-evil/secret.png`)).toBe(false)

--- a/apps/desktop/src/mcp/vault-ops.ts
+++ b/apps/desktop/src/mcp/vault-ops.ts
@@ -20,7 +20,7 @@ const LIVE_FOLDERS: NoteFolder[] = ['inbox', 'quick', 'archive']
  *  note/folder surface, so the walks skip these folders. */
 const isFormDirName = (name: string): boolean => name.toLowerCase().endsWith('.base')
 const ASSETS_DIR = 'assets'
-const PRIMARY_ATTACHMENTS_DIR = 'attachements'
+const PRIMARY_ATTACHMENTS_DIR = 'attachments'
 const LEGACY_ATTACHMENTS_DIRS = [PRIMARY_ATTACHMENTS_DIR, '_assets']
 const ATTACHMENTS_DIRS = [ASSETS_DIR, ...LEGACY_ATTACHMENTS_DIRS]
 const INTERNAL_VAULT_DIR = '.zennotes'

--- a/apps/server/internal/vault/parse_test.go
+++ b/apps/server/internal/vault/parse_test.go
@@ -15,7 +15,7 @@ func TestBodyHasLocalAssetDetectsOnlyLocalAssets(t *testing.T) {
 		},
 		{
 			name: "relative image",
-			body: "# Image\n\n![diagram](../attachements/diagram.png)\n",
+			body: "# Image\n\n![diagram](../attachments/diagram.png)\n",
 			want: true,
 		},
 		{

--- a/apps/server/internal/vault/vault.go
+++ b/apps/server/internal/vault/vault.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	// AssetsDir is the canonical top-level folder for assets; attachements/_assets
+	// AssetsDir is the canonical top-level folder for assets; attachments/_assets
 	// are recognized legacy dirs. Asset migration runs on the desktop (#185).
 	AssetsDir             = "assets"
-	PrimaryAttachmentsDir = "attachements"
+	PrimaryAttachmentsDir = "attachments"
 	internalVaultDir      = ".zennotes"
 	vaultSettingsFile     = "vault.json"
 	noteMetaCacheFile     = "note-meta-cache-v1.json"

--- a/docs/reference/vault-and-folder-model.md
+++ b/docs/reference/vault-and-folder-model.md
@@ -109,7 +109,7 @@ ZenNotes now behaves more like an Obsidian-compatible file-based vault:
 
 New referenced files default to the vault root rather than forcing a special attachments folder.
 
-Legacy attachment locations such as `attachements/` and `_assets/` are still recognized for compatibility.
+Legacy attachment locations such as `attachments/` and `_assets/` are still recognized for compatibility.
 
 ## Selection and bulk actions
 

--- a/docs/web-architecture.md
+++ b/docs/web-architecture.md
@@ -135,7 +135,7 @@ self-host.
                                      │  │    quick/          │  │
                                      │  │    archive/        │  │
                                      │  │    trash/          │  │
-                                     │  │    attachements/   │  │
+                                     │  │    attachments/    │  │
                                      │  └─────────▲──────────┘  │
                                      │            │             │
                                      │  ┌─────────┴──────────┐  │
@@ -512,7 +512,7 @@ Unchanged from the desktop build. The server cares about:
   quick/
   archive/
   trash/
-  attachements/
+  attachments/
   .zennotes/
     server.json      ← config: auth token, ports, feature flags
     index.db         ← SQLite FTS (optional)

--- a/packages/app-core/src/lib/vault-layout.ts
+++ b/packages/app-core/src/lib/vault-layout.ts
@@ -23,7 +23,7 @@ const RESERVED_ROOT_NAMES = new Set<string>([
   'archive',
   'trash',
   'assets',
-  'attachements',
+  'attachments',
   '_assets',
   '.zennotes'
 ])


### PR DESCRIPTION
Chore: fixes the typo `attachements`(which should be `attachments`) across the codebase.

_Disclaimer: this PR is driven by Codex but I have manually checked every instance to make sure we are changing exactly the places needed._