### PR TITLE
fix(vim): let Space leader fire on the home view (#273)

### DIFF
--- a/packages/app-core/src/components/VimNav.tsx
+++ b/packages/app-core/src/components/VimNav.tsx
@@ -9,7 +9,8 @@ import {
   isEditorInsertMode,
   isEditorFocused,
   isVimAwaitingArgument,
-  resolveNextPanel
+  resolveNextPanel,
+  shouldYieldToHomeNav
 } from '../lib/vim-nav'
 import { focusPaneInDirection } from '../lib/pane-nav'
 import { findLeaf } from '../lib/pane-layout'
@@ -319,8 +320,19 @@ export function VimNav(): JSX.Element | null {
       // The selection format toolbar handles its own keyboard navigation
       // (arrows / Enter / Esc) once focused — yield to it entirely.
       if (target?.closest('[data-selection-toolbar]')) return
-      // The home view owns its own roving-focus navigation (↑/↓/j/k/Enter).
-      if (target?.closest('[data-home-nav]')) return
+      // The home view owns its own roving-focus navigation (↑/↓/j/k/Enter), but
+      // it does not handle the leader key — so the leader (and any pending leader
+      // sequence) must fall through to VimNav, or Space-as-leader is swallowed
+      // while the home view is focused (no note open). (#273)
+      if (
+        shouldYieldToHomeNav(
+          target,
+          sequenceTokenFromEvent(e) === leaderToken,
+          !!leaderPending.current
+        )
+      ) {
+        return
+      }
       // The database/table view runs its own vim-style motion grid; yield to it
       // so sidebar/note-list navigation doesn't steal j/k/h/l etc. — EXCEPT the
       // pane prefix (Ctrl+W) and its pending direction key, so the grid can hand

--- a/packages/app-core/src/lib/vim-nav.test.ts
+++ b/packages/app-core/src/lib/vim-nav.test.ts
@@ -10,7 +10,7 @@ vi.mock('@replit/codemirror-vim', () => ({
   getCM: () => ({ state: { vim: cmMock.vim } })
 }))
 
-import { hintTargetOpensNote, isVimAwaitingArgument } from './vim-nav'
+import { hintTargetOpensNote, isVimAwaitingArgument, shouldYieldToHomeNav } from './vim-nav'
 
 function el(html: string): HTMLElement {
   const container = document.createElement('div')
@@ -51,6 +51,30 @@ describe('hintTargetOpensNote (#100 — hint into a note lands in the editor)', 
   it('is false for a plain button and for null', () => {
     expect(hintTargetOpensNote(el('<button>Settings</button>'))).toBe(false)
     expect(hintTargetOpensNote(null)).toBe(false)
+  })
+})
+
+describe('shouldYieldToHomeNav (#273 — Space leader must work on the home view)', () => {
+  const homeTarget = (): HTMLElement => {
+    const home = el('<div data-home-nav><button data-home-item>Recent</button></div>')
+    return home.querySelector('button') as HTMLElement
+  }
+
+  it('yields for a non-leader key (home view owns j/k/arrows/Enter)', () => {
+    expect(shouldYieldToHomeNav(homeTarget(), false, false)).toBe(true)
+  })
+
+  it('does NOT yield for the leader key — it falls through to VimNav', () => {
+    expect(shouldYieldToHomeNav(homeTarget(), true, false)).toBe(false)
+  })
+
+  it('does NOT yield while a leader sequence is pending', () => {
+    expect(shouldYieldToHomeNav(homeTarget(), false, true)).toBe(false)
+  })
+
+  it('is false outside the home view, so VimNav handles keys normally', () => {
+    expect(shouldYieldToHomeNav(el('<button>Settings</button>'), false, false)).toBe(false)
+    expect(shouldYieldToHomeNav(null, false, false)).toBe(false)
   })
 })
 

--- a/packages/app-core/src/lib/vim-nav.ts
+++ b/packages/app-core/src/lib/vim-nav.ts
@@ -17,6 +17,26 @@ export function hintTargetOpensNote(element: HTMLElement | null | undefined): bo
   return !!tabPath && !isWorkspaceVirtualTabPath(tabPath)
 }
 
+/**
+ * True when a keydown inside the home view (`data-home-nav`) should yield to the
+ * home view's own roving-focus handler instead of VimNav's global bindings.
+ *
+ * The home view owns ↑/↓/j/k/Enter, but it does NOT handle the leader key — so
+ * the leader (and any in-progress leader sequence) must fall through to VimNav,
+ * otherwise Space-as-leader is silently swallowed while the home view is focused
+ * (no note open). (#273)
+ */
+export function shouldYieldToHomeNav(
+  target: HTMLElement | null | undefined,
+  isLeaderKey: boolean,
+  leaderPending: boolean
+): boolean {
+  if (!target?.closest('[data-home-nav]')) return false
+  // Keep leader input flowing through to VimNav's leader handling.
+  if (isLeaderKey || leaderPending) return false
+  return true
+}
+
 // ---------------------------------------------------------------------------
 // Panel types & navigation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This is the for the issue #273
The home view's keydown bail swallowed every key while it was focused, including the leader. Yield to it for its own nav keys but let the leader and pending leader sequences fall through to VimNav.