### PR TITLE
ci: fix Linux arm64 release by using a native fpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,21 @@ jobs:
         # `bsdtar` (libarchive-tools) is required by electron-builder's pacman
         # target to generate the package .MTREE; it isn't on the GitHub Ubuntu
         # runners (x64 or arm64).
-        run: sudo apt-get update && sudo apt-get install -y libarchive-tools
+        #
+        # electron-builder only bundles an x86 `fpm`, so the deb/pacman targets
+        # fail with "Exec format error" on the native arm64 runner. Install a
+        # native fpm there and switch electron-builder to it via USE_SYSTEM_FPM.
+        # Scope the flag to arm64 by exporting it to $GITHUB_ENV only here:
+        # defining USE_SYSTEM_FPM at all (even empty) makes electron-builder use
+        # a system fpm, which the x64 runner doesn't have.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarchive-tools
+          if [ "${{ matrix.name }}" = "Linux arm64" ]; then
+            sudo apt-get install -y ruby ruby-dev build-essential
+            sudo gem install fpm --no-document
+            echo "USE_SYSTEM_FPM=true" >> "$GITHUB_ENV"
+          fi
 
       - name: Build release artifacts
         run: ${{ matrix.command }}


### PR DESCRIPTION
Fixes #307

## Problem

electron-builder bundles only an x86 `fpm` binary, which the `deb` and `pacman` targets shell out to. On the native `ubuntu-24.04-arm` runner it can't execute:

```
cannot execute binary file: Exec format error
```

`AppImage` and `tar.gz` don't use `fpm`, so they build first and the job only dies at the `deb` step, failing the whole `dist:linux` run. The result: v2.9.0 shipped with no Linux arm64 assets while every other platform succeeded.

## Fix

On the arm64 leg only, install a native `fpm` and set `USE_SYSTEM_FPM=true` so electron-builder packages `deb`/`pacman` with it. The x64 leg is unchanged and keeps using the bundled binary.

## Verification

Full release matrix run on my fork. Linux x64, Linux arm64, and Windows all built and uploaded; macOS fails only because my fork lacks the code-signing secrets, which is unrelated to this change.

- Proof release, arm64 `.deb`/`.pacman`/`.AppImage`/`.tar.gz` attached: https://github.com/robwilkerson/zennotes/releases/tag/v2.9.2
- Green Linux arm64 job: https://github.com/robwilkerson/zennotes/actions/runs/28559119900/job/84672925443
- Full run: https://github.com/robwilkerson/zennotes/actions/runs/28559119900
