### PR TITLE
fix(tables): preserve latex backslashes and escape pipes (#319)

### DIFF
--- a/packages/app-core/src/lib/markdown-table.test.ts
+++ b/packages/app-core/src/lib/markdown-table.test.ts
@@ -82,6 +82,27 @@ describe('parseTable', () => {
 })
 
 describe('serializeTable round-trip', () => {
+  it('preserves latex backslashes on serialize', () => {
+    const t = setCell(parse(SIMPLE), { row: 0, col: 0 }, '\\sum')
+    const out = serializeTable(t)
+    expect(out).toContain('\\sum')
+    expect(parse(out).rows[0][0]).toBe('\\sum')
+  })
+
+  it('still escapes literal pipes', () => {
+    const t = setCell(parse(SIMPLE), { row: 0, col: 0 }, 'a | b')
+    const out = serializeTable(t)
+    expect(out).toContain('a \\| b')
+    expect(parse(out).rows[0][0]).toBe('a | b')
+  })
+
+  it('round-trips latex and pipes together', () => {
+    const t = setCell(parse(SIMPLE), { row: 0, col: 0 }, '\\sum | x')
+    const out = serializeTable(t)
+    expect(out).toContain('\\sum \\| x')
+    expect(parse(out).rows[0][0]).toBe('\\sum | x')
+  })
+
   it('produces aligned, padded markdown', () => {
     const t = parse(SIMPLE)
     expect(serializeTable(t)).toBe(`| A   | B   |

--- a/packages/app-core/src/lib/markdown-table.ts
+++ b/packages/app-core/src/lib/markdown-table.ts
@@ -111,7 +111,7 @@ function unescapeCell(text: string): string {
 }
 
 function escapeCell(text: string): string {
-  return text.replace(/([|\\])/g, '\\$1')
+  return text.replace(/\|/g, '\\|')
 }
 
 function parseAlign(spec: string): ColumnAlign {


### PR DESCRIPTION
Preview KaTeX inside tables was broken after editing because table serialization turned `\sum` into `\\sum` and `$P \longrightarrow Q$` into `P \\longrightarrow Q`. This change preserves LaTeX backslashes while still escaping literal pipes, so Preview renders math correctly again. Closes #319.