### PR TITLE
feat(vim): add ':sav' and ':saveas' command to save active note with …

### DIFF
--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -362,6 +362,11 @@ function registerVimCommands(): void {
   Vim.defineEx('write', 'w', () => {
     void useStore.getState().persistActive()
   })
+  Vim.defineEx('saveas', 'sav', (_cm: unknown, params: { argString?: string } | undefined) => {
+  const newName = (params?.argString ?? '').trim()
+  if (!newName) return
+  void useStore.getState().saveActiveNoteAs(newName)
+})
   Vim.defineEx('format', 'format', () => {
     void useStore.getState().formatActiveNote()
   })
@@ -935,6 +940,8 @@ const MANUAL_EX_NAMES = new Set([
   'zenmode',
   'editmode',
   'splitmode',
+  'saveas',
+  'sav',
   'previewmode',
   'trash',
   'fold',

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -2366,6 +2366,7 @@ interface Store {
     opts?: { folder?: NoteFolder; subpath?: string; title?: string; date?: Date }
   ) => Promise<void>
   saveActiveNoteAsTemplate: () => Promise<void>
+  saveActiveNoteAs: (newName: string) => Promise<void>
   setWordWrap: (on: boolean) => void
   setPreviewSmoothScroll: (on: boolean) => void
   setEditorMaxWidth: (px: number) => void
@@ -5821,6 +5822,19 @@ export const useStore = create<Store>((set, get) => {
     if (!trimmed) return
     const raw = composeTemplateFile({ name: trimmed, category: 'Custom', body: active.body })
     await get().saveCustomTemplate({ slug: slugifyTemplateName(trimmed), raw })
+  },
+
+  saveActiveNoteAs: async (newName: string) => {
+    const active = get().activeNote
+    const notePath = active?.path
+    if (!active || !notePath) return
+    // Strip a user-supplied extension so note renames stay title-based;
+    // the backend appends the note's real file extension.
+    const trimmedName = newName.trim().replace(/\.md$/i, '')
+    if (!trimmedName) return
+    if (trimmedName === active.title) return
+    await get().persistNote(notePath)
+    await get().renameNote(notePath, trimmedName)
   },
 
   setWordWrap: (on) => {


### PR DESCRIPTION
Implements Vim-style save commands for the editor:
- `:sav` / `:saveas` saves the active note under a new title

The save-as flow persists the current note state first, then renames it via the existing `renameNote` path. The backend handles file extension and folder placement. Pane tabs update automatically through `renameNoteState`.

Closes #265