### PR TITLE
fix: enter and backspace in vim normal mode

### DIFF
--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -53,7 +53,7 @@ import { isImeComposing } from '../lib/ime'
 import { resolveCodeLanguage } from '../lib/cm-code-languages'
 import { markdownListIndentPlugin } from '../lib/cm-markdown-list-indent'
 import { completionNavKeymap } from '../lib/cm-completion-nav'
-import { vimAwareDefaultKeymap } from '../lib/cm-vim-default-keymap'
+import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap } from '../lib/cm-vim-default-keymap'
 import { setYankToClipboardEnabled } from '../lib/cm-vim-clipboard'
 import { wireYankHighlight, yankHighlightExtension } from '../lib/cm-yank-highlight'
 import { frontmatterStyle } from '../lib/cm-frontmatter'
@@ -289,7 +289,8 @@ function buildEditorKeymap(vimMode: boolean, overrides: KeymapOverrides): Extens
 
 function markdownEditingExtensions(): Extension[] {
   return [
-    markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: true }),
+    markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: false }),
+    vimAwareMarkdownKeymap,
     markdownListIndentPlugin,
     frontmatterStyle,
     orderedListRenumber,

--- a/packages/app-core/src/components/ExternalFileApp.tsx
+++ b/packages/app-core/src/components/ExternalFileApp.tsx
@@ -15,7 +15,7 @@ import { Annotation, Compartment, EditorState, type Transaction } from '@codemir
 import { EditorView, drawSelection, highlightActiveLine, keymap } from '@codemirror/view'
 import { Vim, vim } from '@replit/codemirror-vim'
 import { history, historyKeymap, indentWithTab } from '@codemirror/commands'
-import { vimAwareDefaultKeymap } from '../lib/cm-vim-default-keymap'
+import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap } from '../lib/cm-vim-default-keymap'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { resolveCodeLanguage } from '../lib/cm-code-languages'
 import { applyVimInsertEscape } from '../lib/vim-insert-escape'
@@ -116,7 +116,8 @@ export function ExternalFileApp(): JSX.Element {
           drawSelection(),
           highlightActiveLine(),
           prefs.wordWrap ? EditorView.lineWrapping : [],
-          markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: true }),
+          markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: false }),
+          vimAwareMarkdownKeymap,
           markdownListIndentPlugin,
           headingFolding(),
           syntaxHighlighting(paperHighlight),

--- a/packages/app-core/src/components/FloatingNoteApp.tsx
+++ b/packages/app-core/src/components/FloatingNoteApp.tsx
@@ -27,7 +27,7 @@ import {
 } from '@codemirror/view'
 import { Vim, vim } from '@replit/codemirror-vim'
 import { history, historyKeymap, indentWithTab } from '@codemirror/commands'
-import { vimAwareDefaultKeymap } from '../lib/cm-vim-default-keymap'
+import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap } from '../lib/cm-vim-default-keymap'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { resolveCodeLanguage } from '../lib/cm-code-languages'
 import { applyVimInsertEscape } from '../lib/vim-insert-escape'
@@ -299,7 +299,8 @@ export function FloatingNoteApp({ notePath }: { notePath: string }): JSX.Element
           drawSelection(),
           highlightActiveLine(),
           prefs.wordWrap ? EditorView.lineWrapping : [],
-          markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: true }),
+          markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: false }),
+          vimAwareMarkdownKeymap,
           markdownListIndentPlugin,
           headingFolding(),
           syntaxHighlighting(paperHighlight),

--- a/packages/app-core/src/components/PinnedReferencePane.tsx
+++ b/packages/app-core/src/components/PinnedReferencePane.tsx
@@ -27,7 +27,7 @@ import {
 } from '@codemirror/view'
 import { vim } from '@replit/codemirror-vim'
 import { history, historyKeymap, indentWithTab } from '@codemirror/commands'
-import { vimAwareDefaultKeymap } from '../lib/cm-vim-default-keymap'
+import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap } from '../lib/cm-vim-default-keymap'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { resolveCodeLanguage } from '../lib/cm-code-languages'
 import { markdownListIndentPlugin } from '../lib/cm-markdown-list-indent'
@@ -187,7 +187,8 @@ export function PinnedReferencePane(): JSX.Element | null {
           drawSelection(),
           highlightActiveLine(),
           EditorView.lineWrapping,
-          markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: true }),
+          markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: false }),
+          vimAwareMarkdownKeymap,
           markdownListIndentPlugin,
           headingFolding(),
           syntaxHighlighting(paperHighlight),

--- a/packages/app-core/src/components/QuickCaptureApp.tsx
+++ b/packages/app-core/src/components/QuickCaptureApp.tsx
@@ -41,7 +41,7 @@ import {
 } from '@codemirror/view'
 import { Vim, vim } from '@replit/codemirror-vim'
 import { history, historyKeymap, indentWithTab } from '@codemirror/commands'
-import { vimAwareDefaultKeymap } from '../lib/cm-vim-default-keymap'
+import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap } from '../lib/cm-vim-default-keymap'
 import { registerDisplayLineMotion } from '../lib/cm-vim-display-line'
 import { toggleWrap, wrapLink } from '../lib/cm-format'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
@@ -450,7 +450,8 @@ export function QuickCaptureApp(): JSX.Element {
           drawSelection(),
           highlightActiveLine(),
           EditorView.lineWrapping,
-          markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: true }),
+          markdown({ base: markdownLanguage, codeLanguages: resolveCodeLanguage, addKeymap: false }),
+          vimAwareMarkdownKeymap,
           markdownListIndentPlugin,
           syntaxHighlighting(captureHighlight),
           syntaxHighlighting(defaultHighlightStyle, { fallback: true }),

--- a/packages/app-core/src/components/TemplateEditorModal.tsx
+++ b/packages/app-core/src/components/TemplateEditorModal.tsx
@@ -10,7 +10,7 @@ import { Compartment, EditorState, type Transaction } from '@codemirror/state'
 import { EditorView, drawSelection, highlightActiveLine, keymap, tooltips } from '@codemirror/view'
 import { vim } from '@replit/codemirror-vim'
 import { history, historyKeymap, indentWithTab } from '@codemirror/commands'
-import { vimAwareDefaultKeymap } from '../lib/cm-vim-default-keymap'
+import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap } from '../lib/cm-vim-default-keymap'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { yamlFrontmatter } from '@codemirror/lang-yaml'
 import { syntaxHighlighting, HighlightStyle, defaultHighlightStyle } from '@codemirror/language'
@@ -123,9 +123,10 @@ export function TemplateEditorModal({
           content: markdown({
             base: markdownLanguage,
             codeLanguages: resolveCodeLanguage,
-            addKeymap: true
+            addKeymap: false
           })
         }),
+        vimAwareMarkdownKeymap,
         markdownListIndentPlugin,
         syntaxHighlighting(templateHighlight),
         syntaxHighlighting(defaultHighlightStyle, { fallback: true }),

--- a/packages/app-core/src/lib/cm-vim-default-keymap.test.ts
+++ b/packages/app-core/src/lib/cm-vim-default-keymap.test.ts
@@ -3,7 +3,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { EditorState } from '@codemirror/state'
 import { EditorView, keymap, type KeyBinding } from '@codemirror/view'
 import { vim } from '@replit/codemirror-vim'
-import { vimAwareDefaultKeymap } from './cm-vim-default-keymap'
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
+import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap } from './cm-vim-default-keymap'
 
 // Regression guard for the macOS Vim `Ctrl-d` bug: defaultKeymap's emacs-style
 // mac chords used to shadow Vim's <C-d> (half-page down) and delete a char.
@@ -109,5 +110,73 @@ describe('vim arrow bindings defer to the Vim plugin (issue #287)', () => {
     press(view, 'i', 73) // enter insert mode
     // Native cursorCharRight/etc. handle it (return true) so the caret still moves.
     expect(arrowRun('ArrowRight')(view)).toBe(true)
+  })
+
+  // Enter/Backspace are Vim motions in normal mode (<CR> → j^, <BS> → h) but
+  // editing commands in defaultKeymap — they must defer exactly like the arrows.
+  it('defers Enter and Backspace in normal mode (Vim motions, not edits)', () => {
+    const view = mountVim('hello\nworld')
+    expect(arrowRun('Enter')(view)).toBe(false)
+    expect(arrowRun('Backspace')(view)).toBe(false)
+    expect(view.state.doc.toString()).toBe('hello\nworld') // nothing edited
+  })
+
+  it('edits natively with Enter/Backspace in insert mode', () => {
+    const view = mountVim('hello')
+    press(view, 'i', 73) // enter insert mode
+    expect(arrowRun('Enter')(view)).toBe(true)
+    expect(view.state.doc.toString()).toBe('\nhello')
+  })
+})
+
+// The markdown language keymap (Enter → insertNewlineContinueMarkup at
+// Prec.high) used to swallow Enter before the Vim plugin, inserting a newline
+// in normal mode. vimAwareMarkdownKeymap replaces it (addKeymap: false) with
+// deferred bindings; this exercises the full dispatch chain the real editors
+// use: markdown keymap → default keymap → Vim plugin.
+describe('vimAwareMarkdownKeymap (Enter in Vim normal mode acts as <CR>)', () => {
+  const views: EditorView[] = []
+  afterEach(() => {
+    views.splice(0).forEach((v) => v.destroy())
+  })
+
+  const mount = (doc: string): EditorView => {
+    const view = new EditorView({
+      state: EditorState.create({
+        doc,
+        extensions: [
+          vim(),
+          markdown({ base: markdownLanguage, addKeymap: false }),
+          vimAwareMarkdownKeymap,
+          keymap.of([...vimAwareDefaultKeymap(true)])
+        ]
+      }),
+      parent: document.body
+    })
+    views.push(view)
+    view.focus()
+    return view
+  }
+
+  const press = (view: EditorView, key: string, keyCode: number): void => {
+    view.contentDOM.dispatchEvent(
+      new KeyboardEvent('keydown', { key, keyCode, bubbles: true, cancelable: true })
+    )
+  }
+
+  it('does not insert a newline on Enter in normal mode', () => {
+    const view = mount('hello\n  world')
+    // Before the fix, the markdown keymap's Enter → insertNewlineContinueMarkup
+    // fired here and edited the doc. The j^ motion itself can't be asserted:
+    // jsdom has no layout, so Vim's vertical motion cannot measure lines.
+    press(view, 'Enter', 13)
+    expect(view.state.doc.toString()).toBe('hello\n  world')
+  })
+
+  it('still continues list markup on Enter in insert mode', () => {
+    const view = mount('- item')
+    press(view, 'A', 65) // append at end of line → insert mode
+    press(view, 'Enter', 13)
+    expect(view.state.doc.toString()).toBe('- item\n- ')
   })
 })

--- a/packages/app-core/src/lib/cm-vim-default-keymap.ts
+++ b/packages/app-core/src/lib/cm-vim-default-keymap.ts
@@ -1,5 +1,7 @@
 import { defaultKeymap } from '@codemirror/commands'
-import type { EditorView, KeyBinding } from '@codemirror/view'
+import { markdownKeymap } from '@codemirror/lang-markdown'
+import { Prec, type Extension } from '@codemirror/state'
+import { keymap, type EditorView, type KeyBinding } from '@codemirror/view'
 import { getCM } from '@replit/codemirror-vim'
 
 /**
@@ -52,28 +54,43 @@ const defaultKeymapWithoutMacEmacs: readonly KeyBinding[] = defaultKeymap.filter
 const ARROW_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'])
 
 /**
- * Vim arrow-key conflict (arrows don't extend the selection in visual mode).
+ * Keys that Vim maps to motions in normal/visual mode but which `defaultKeymap`
+ * (and `markdownKeymap`) bind to *editing* commands: the arrows (issue #287),
+ * plus Enter (`<CR>` → `j^`: first non-blank of the next line) and Backspace
+ * (`<BS>` → `h`). Without deferral, Enter in normal mode inserts a newline
+ * (via `insertNewlineContinueMarkup` / `insertNewlineAndIndent`) and Backspace
+ * deletes a character, instead of moving the cursor like real Vim.
+ */
+const VIM_MOTION_KEYS = new Set([...ARROW_KEYS, 'Enter', 'Backspace'])
+
+/**
+ * Vim key conflicts (arrows / Enter / Backspace act as edits, not motions).
  *
  * `defaultKeymap` binds the arrows to caret motions (`cursorCharLeft`/…) with
- * `preventDefault: true`, and (like the mac emacs chords above) the keymap's
+ * `preventDefault: true`, Enter to `insertNewlineAndIndent`, and Backspace to
+ * `deleteCharBackward`; and (like the mac emacs chords above) the keymap's
  * handler runs at higher precedence than the Vim plugin's. So in Vim mode the
  * arrows just move the caret — which in *visual* mode collapses the selection
- * instead of extending it the way `h`/`j`/`k`/`l` do (issue #287). `hjkl` have
- * no competing keymap binding, so they were never affected — hence the
- * arrows-vs-hjkl asymmetry users hit.
+ * instead of extending it the way `h`/`j`/`k`/`l` do (issue #287) — and Enter/
+ * Backspace *edit the text* in normal mode instead of applying Vim's `<CR>`/
+ * `<BS>` motions. `hjkl` have no competing keymap binding, so they were never
+ * affected — hence the asymmetry users hit.
  *
- * Unlike the emacs chords we can't simply drop the arrows: Vim only maps them
- * to motions in normal/visual mode (`<Left>`→`h`, …), not in *insert* mode, so
- * insert-mode caret movement still relies on these bindings. Instead, in Vim
- * mode each plain-arrow binding defers to the Vim plugin while Vim is in a
- * non-insert mode — returning `false` with no `preventDefault` lets the
- * keypress fall through to the (lower-precedence) Vim plugin, which then
- * applies the motion. Insert mode (and Vim-off) keep the native caret motion.
- * The Shift-arrow selection handlers are left untouched.
+ * Unlike the emacs chords we can't simply drop these keys: Vim only maps them
+ * in normal/visual mode (`<Left>`→`h`, `<CR>`→`j^`, …), not in *insert* mode,
+ * so insert-mode caret movement, newline insertion and deletion still rely on
+ * these bindings. Instead, in Vim mode each binding defers to the Vim plugin
+ * while Vim is in a non-insert mode — returning `false` with no
+ * `preventDefault` lets the keypress fall through to the (lower-precedence)
+ * Vim plugin, which then applies the motion. Insert mode (and Vim-off) keep
+ * the native behavior. Shift-modified handlers are left untouched.
  */
-function deferArrowsToVim(bindings: readonly KeyBinding[]): KeyBinding[] {
+function deferKeysToVim(
+  bindings: readonly KeyBinding[],
+  keys: ReadonlySet<string>
+): KeyBinding[] {
   return bindings.map((binding) => {
-    if (!binding.key || !ARROW_KEYS.has(binding.key) || !binding.run) return binding
+    if (!binding.key || !keys.has(binding.key) || !binding.run) return binding
     const native = binding.run
     return {
       ...binding,
@@ -90,8 +107,11 @@ function deferArrowsToVim(bindings: readonly KeyBinding[]): KeyBinding[] {
   })
 }
 
-/** Vim-mode keymap: emacs chords stripped, arrows made Vim-aware (see above). */
-const vimModeKeymap: readonly KeyBinding[] = deferArrowsToVim(defaultKeymapWithoutMacEmacs)
+/** Vim-mode keymap: emacs chords stripped, motion keys made Vim-aware (see above). */
+const vimModeKeymap: readonly KeyBinding[] = deferKeysToVim(
+  defaultKeymapWithoutMacEmacs,
+  VIM_MOTION_KEYS
+)
 
 /**
  * CodeMirror's `defaultKeymap`, made Vim-aware: in Vim mode the macOS
@@ -102,3 +122,22 @@ const vimModeKeymap: readonly KeyBinding[] = deferArrowsToVim(defaultKeymapWitho
 export function vimAwareDefaultKeymap(vimMode: boolean): readonly KeyBinding[] {
   return vimMode ? vimModeKeymap : defaultKeymap
 }
+
+/**
+ * Vim-aware replacement for `markdown({ addKeymap: true })`'s keymap.
+ *
+ * The markdown language support binds Enter → `insertNewlineContinueMarkup`
+ * and Backspace → `deleteMarkupBackward` at `Prec.high`, which beats both the
+ * Vim plugin *and* the deferred bindings above — so in Vim normal mode Enter
+ * inserted a newline instead of moving to the first non-blank of the next
+ * line (`<CR>` → `j^`). Deferral can't be layered on top (returning `false`
+ * would fall through to the original high-precedence binding), so the editors
+ * must pass `addKeymap: false` to `markdown()` and add this extension instead:
+ * the same `markdownKeymap` at the same precedence, with Enter/Backspace
+ * deferring to Vim in non-insert mode. The wrapper checks the live Vim state
+ * per keypress (no-op when Vim is off), so this needs no reconfiguration on
+ * Vim toggle.
+ */
+export const vimAwareMarkdownKeymap: Extension = Prec.high(
+  keymap.of(deferKeysToVim(markdownKeymap, new Set(['Enter', 'Backspace'])))
+)


### PR DESCRIPTION
## Problem
In Vim normal mode, `Enter` inserted a newline and `Backspace` deleted a character.

## Root cause
`@codemirror/lang-markdown` keymap overrides Vim at `Prec.high`:
- `Enter → insertNewlineContinueMarkup`
- `Backspace → deleteMarkupBackward`

## Tests
- Added coverage for `Enter`/`Backspace` in normal vs insert mode
- Regression for markdown list continuation

## Limitation
In normal mode, `@replit/codemirror-vim` maps `Backspace` to `h`, so it won’t match Vim’s full `<BS>` behavior (e.g., wrap to previous line start). This is upstream behavior.