### PR TITLE
fix: CircuiTikZ loads indefinitely on desktop

### DIFF
--- a/apps/desktop/src/main/tikz.ts
+++ b/apps/desktop/src/main/tikz.ts
@@ -157,13 +157,32 @@ export async function renderTikz(
 
     try {
       const fn = await load();
+      // Only load pgfplots if it's referenced in the source code.
+      // pgfplots is extremely heavy and exhausts the TeX engine's pool size
+      // limit (~920k) when combined with other large packages (like circuitikz).
+      const texPackages: Record<string, string> = { amsmath: "", amssymb: "" };
+      const usesPgfPlots =
+        source.includes("pgfplots") ||
+        source.includes("axis") ||
+        source.includes("plot");
+      if (usesPgfPlots) {
+        texPackages.pgfplots = "";
+      }
+
+      const usesCircuiTikz =
+        source.includes("circuitikz") ||
+        source.includes("ctikzset");
+      if (usesCircuiTikz) {
+        texPackages.circuitikz = "";
+      }
+
       const svg = await fn(wrapSource(source), {
         showConsole: true,
         // Enable the common TikZ libraries people reach for first. The
         // wasm build ships with everything already compiled, so toggling
         // these flags only changes which `\usetikzlibrary{…}` / `\usepackage{…}`
         // statements get injected — negligible runtime cost.
-        texPackages: { pgfplots: "", amsmath: "", amssymb: "" },
+        texPackages,
         tikzLibraries:
           "arrows.meta,calc,positioning,shapes,decorations.pathreplacing,intersections,patterns",
       });


### PR DESCRIPTION
## Problem
On Linux desktop app, rendering circuits with CircuiTikZ loads indefinitely, or crashes entirely.

## Technical details (Antigravity)
`node-tikzjax` uses a WebAssembly port of TeX with a hardcoded memory limit (`pool_size` = 920,271 characters). ZenNotes was pre-loading the heavy `pgfplots` package by default for *all* TikZ blocks, leaving almost no room in the string pool for loading additional large packages like `circuitikz`.

## Changes
1. **Dynamic Loading for `pgfplots`**: Modified `apps/desktop/src/main/tikz.ts` to inspect the TikZ code block. `pgfplots` is now only loaded if the code block explicitly contains `"pgfplots"`, `"axis"`, or `"plot"`.
2. **Auto-detection for `circuitikz`**: The runner now scans the code block for `"circuitikz"` or `"ctikzset"` and automatically injects the `circuitikz` package into `texPackages`. This enables circuit schematics to render out-of-the-box without requiring users to write `\usepackage{circuitikz}` in their note preambles.
3. **No-op/Minimal Impact**: Standard plots continue to load `pgfplots` automatically, while other diagrams (circuit diagrams, block diagrams, logic trees) gain a significant memory pool margin, resolving the compilation crashes.

## Not addressed
- Circuits flash as I type it in, inside of split view mode.

https://github.com/user-attachments/assets/27e63844-031c-446f-87e4-cb38f9e743e4


<details>
<summary>CircuiTikZ Error</summary>
TikZ error: TeX engine render failed. Set `options.showConsole` to `true` to see logs.

! Emergency stop.
l.2 \ctikzset
             {bipoles/length=.9cm}
</details>

<details>
<summary>CircuiTikZ Code</summary>

```tikz
\ctikzset{bipoles/length=.9cm}
\begin{circuitikz}[american]
    \draw (-3,0.5) -- (3,0.5);
    \draw (0,0.5) -- (0,1) node[above]{$V_{CC}$};
    
    \draw (-3,0.5) to[R=$R_{C1}$] (-3,-1.5)
    -- (-3,-2) node[npn, anchor=C](Q1){$Q_1$};
    
    \draw (3,0.5) to[R=$R_{C2}$] (3,-1.5)
    -- (3,-2) node[npn, anchor=C, xscale=-1](Q2){%
        \scalebox{-1}[1]{$Q_2$}% Prevents label text from being mirrored
    };
    
    \draw (Q1.B) -- (-4.5, 0 |- Q1.B) 
    to[vsourcesin, l_=$v_{in1}$] (-4.5, -4.5) node[ground]{};
    
    \draw (Q2.B) -- (4.5, 0 |- Q2.B) 
    to[vsourcesin, l=$v_{in2}$] (4.5, -4.5) node[ground]{};
    
    \draw (Q1.E) |- (0,-3.5) node[circ]{} -| (Q2.E);
    
    \draw (0,-3.5) to[isource, l=$I_{EE}$] (0,-5)
    node[below]{$V_{EE}$};
\end{circuitikz}
```
```tikz
\ctikzset{bipoles/length=.9cm}
\begin{circuitikz}[american]
  % Horizontal VCC rail (at Y = 0.5)
  \draw (-3,0.5) -- (3,0.5);
  \draw (0,0.5) -- (0,1) node[above]{$V_{CC}$};
  
  % Left branch: collector resistor RC1 down to transistor Q1
  \draw (-3,0.5) to[R=$R_{C1}$] (-3,-1.5)
  -- (-3,-2) node[npn, anchor=C](Q1){$Q_1$};
  
  % Right branch: collector resistor RC2 down to transistor Q2 (flipped horizontally)
  \draw (3,0.5) to[R=$R_{C2}$] (3,-1.5)
  -- (3,-2) node[npn, anchor=C, xscale=-1](Q2){%
      \scalebox{-1}[1]{$Q_2$} % Prevents label text from being mirrored
  };
  
  % Base inputs (clean horizontal protruding wires)
  \draw (Q1.B) -- (-4, 0 |- Q1.B) node[left]{$V_{in1}$};
  \draw (Q2.B) -- (4, 0 |- Q2.B) node[right]{$V_{in2}$};
  
  % Emitters merge orthogonally at a common node with a junction dot
  \draw (Q1.E) |- (0,-3.5) node[circ]{} -| (Q2.E);
  
  % Common emitter resistor from junction down to VEE
  \draw (0,-3.5) to[R=$R_E$] (0,-5)
  node[below]{$V_{EE}$};
\end{circuitikz}
```
</details>

Note: Code edited by [Google Antigravity](https://antigravity.google)