### PR TITLE
fix: follow app theme in Excalidraw (fixes #363)

### DIFF
--- a/packages/app-core/src/components/ExcalidrawView.test.ts
+++ b/packages/app-core/src/components/ExcalidrawView.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// Guards: ExcalidrawView derives its theme from document.documentElement.dataset.themeMode
+// rather than looking up the theme id in THEMES. The THEMES array only contains built-in
+// themes, so a custom theme id (e.g. "custom-mine") would always resolve to "light" under
+// the old approach — THEMES.find returns undefined and undefined?.mode === 'dark' is false.
+// This test verifies that dark custom themes correctly produce a dark Excalidraw theme,
+// and would catch a regression back to THEMES.find().
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Spy on the Excalidraw component so we can inspect its theme prop.
+// vi.hoisted is needed so the variable is in scope for both the mock module factory
+// and the test body.
+const { mockExcalidraw } = vi.hoisted(() => {
+  const mockExcalidraw = vi.fn((_props: Record<string, unknown>) => null)
+  return { mockExcalidraw }
+})
+
+vi.mock('@excalidraw/excalidraw', () => ({
+  Excalidraw: mockExcalidraw,
+  serializeAsJSON: vi.fn(() => '{}')
+}))
+
+// Mock store: expose a custom theme id that does NOT exist in the built-in THEMES array.
+const { storeState } = vi.hoisted(() => {
+  const storeState: Record<string, unknown> = {
+    themeId: 'custom-test-theme',
+    themeMode: 'dark',
+  }
+  return { storeState }
+})
+
+vi.mock('../store', () => ({
+  useStore: (selector: (s: Record<string, unknown>) => unknown) => selector(storeState)
+}))
+
+import { ExcalidrawView } from './ExcalidrawView'
+
+describe('ExcalidrawView theme mode with custom themes', () => {
+  let root: Root
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    Object.defineProperty(window, 'zen', {
+      configurable: true,
+      value: {
+        readNote: vi.fn().mockResolvedValue({ body: '{}' }),
+        writeNote: vi.fn(),
+      }
+    })
+    host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it('renders dark Excalidraw theme when custom theme id + data-theme-mode=dark', async () => {
+    document.documentElement.dataset.themeMode = 'dark'
+
+    await act(async () => {
+      root.render(createElement(ExcalidrawView, { path: 'inbox/drawing.excalidraw' }))
+    })
+    // Flush the readNote effect so setInitialData runs and Excalidraw renders.
+    await act(async () => {})
+
+    expect(mockExcalidraw).toHaveBeenCalled()
+    const lastCall = mockExcalidraw.mock.lastCall
+    expect(lastCall?.[0].theme).toBe('dark')
+  })
+
+  it('renders light Excalidraw theme when custom theme id + data-theme-mode=light', async () => {
+    document.documentElement.dataset.themeMode = 'light'
+
+    await act(async () => {
+      root.render(createElement(ExcalidrawView, { path: 'inbox/drawing.excalidraw' }))
+    })
+    await act(async () => {})
+
+    expect(mockExcalidraw).toHaveBeenCalled()
+    const lastCall = mockExcalidraw.mock.lastCall
+    expect(lastCall?.[0].theme).toBe('light')
+  })
+
+  it('still uses the DOM attribute, not THEMES.find, even for a built-in-like theme id', async () => {
+    // Even if the store returns a built-in theme id, resolution goes through
+    // data-theme-mode — so overriding it to the opposite mode wins.
+    storeState.themeId = 'dark-hard'
+    storeState.themeMode = 'dark'
+    document.documentElement.dataset.themeMode = 'light'
+
+    await act(async () => {
+      root.render(createElement(ExcalidrawView, { path: 'inbox/drawing.excalidraw' }))
+    })
+    await act(async () => {})
+
+    expect(mockExcalidraw).toHaveBeenCalled()
+    const lastCall = mockExcalidraw.mock.lastCall
+    // data-theme-mode=light wins over the built-in dark-hard theme id
+    expect(lastCall?.[0].theme).toBe('light')
+  })
+})

--- a/packages/app-core/src/components/ExcalidrawView.test.ts
+++ b/packages/app-core/src/components/ExcalidrawView.test.ts
@@ -90,21 +90,4 @@ describe('ExcalidrawView theme mode with custom themes', () => {
     expect(lastCall?.[0].theme).toBe('light')
   })
 
-  it('still uses the DOM attribute, not THEMES.find, even for a built-in-like theme id', async () => {
-    // Even if the store returns a built-in theme id, resolution goes through
-    // data-theme-mode — so overriding it to the opposite mode wins.
-    storeState.themeId = 'dark-hard'
-    storeState.themeMode = 'dark'
-    document.documentElement.dataset.themeMode = 'light'
-
-    await act(async () => {
-      root.render(createElement(ExcalidrawView, { path: 'inbox/drawing.excalidraw' }))
-    })
-    await act(async () => {})
-
-    expect(mockExcalidraw).toHaveBeenCalled()
-    const lastCall = mockExcalidraw.mock.lastCall
-    // data-theme-mode=light wins over the built-in dark-hard theme id
-    expect(lastCall?.[0].theme).toBe('light')
-  })
 })

--- a/packages/app-core/src/components/ExcalidrawView.tsx
+++ b/packages/app-core/src/components/ExcalidrawView.tsx
@@ -4,7 +4,6 @@ import { Excalidraw, serializeAsJSON } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
 import { parseExcalidrawDocument } from '@shared/excalidraw'
 import { useStore } from '../store'
-import { THEMES } from '../lib/themes'
 
 type InitialData = ComponentProps<typeof Excalidraw>['initialData']
 
@@ -20,9 +19,14 @@ export function ExcalidrawView({ path }: { path: string }): JSX.Element {
   const pathRef = useRef(path)
   pathRef.current = path
 
-  // Match the app's light/dark theme.
-  const themeId = useStore((s) => s.themeId)
-  const excalidrawTheme = THEMES.find((t) => t.id === themeId)?.mode === 'dark' ? 'dark' : 'light'
+  // Read the resolved mode from the same DOM attribute used by the app shell.
+  // This also handles custom themes, which are not present in the built-in THEMES registry.
+  useStore((s) => s.themeId)
+  useStore((s) => s.themeMode)
+  const excalidrawTheme =
+    typeof document !== 'undefined' && document.documentElement.dataset.themeMode === 'dark'
+      ? 'dark'
+      : 'light'
 
   useEffect(() => {
     let cancelled = false


### PR DESCRIPTION
fixes #363
[My custom theme](https://github.com/Kamyil/.dotfiles/blob/main/zennotes/themes/kanagawa-paper/theme.css) already declares dark mode in the [manifest](https://github.com/Kamyil/.dotfiles/blob/c7af8262a71c7d57bd381a70666b122d82b0e79a/zennotes/themes/kanagawa-paper/manifest.json#L6):

```json
  {
    "modes": "dark"
  }
```

The problem is that the old Excalidraw code checked only the built-in THEMES registry:

```ts
  THEMES.find((t) => t.id === themeId)
```

My custom theme ID:

```text
  custom-kanagawa-paper
```

is not in that registry, so the lookup returned undefined regardless of the manifest.

The fix needs to be in ZenNotes code: Excalidraw must use ZenNotes’ resolved mode:

```ts
  document.documentElement.dataset.themeMode
```


co-oped with GPT 5.6 Luna (low) agent