### PR TITLE
feature: custom Kanagawa Papek Ink theme variant

### DIFF
--- a/packages/app-core/src/lib/help.ts
+++ b/packages/app-core/src/lib/help.ts
@@ -743,7 +743,7 @@ export const HELP_SETTINGS: HelpSettingsSection[] = [
   {
     title: 'Appearance',
     items: [
-      { label: 'Theme, mode, and variant', detail: 'Pick a theme family — Apple, Gruvbox, Catppuccin, GitHub, Solarized, One, Nord, Tokyo Night, Kanagawa (Wave / Dragon / Lotus), Rosé Pine (Rosé Pine / Moon / Dawn), or the monochrome, true-black (OLED-friendly) Black Metal — plus light or dark mode and the active flavor or contrast where the theme supports it.' },
+      { label: 'Theme, mode, and variant', detail: 'Pick a theme family — Apple, Gruvbox, Catppuccin, GitHub, Solarized, One, Nord, Tokyo Night, Kanagawa (Wave / Dragon / Paper Ink / Lotus), Rosé Pine (Rosé Pine / Moon / Dawn), or the monochrome, true-black (OLED-friendly) Black Metal — plus light or dark mode and the active flavor or contrast where the theme supports it.' },
       { label: 'Dark sidebar', detail: 'Tint the sidebar slightly darker than the canvas so the chrome reads as a distinct surface.' },
       { label: 'Sidebar arrows', detail: 'Show or hide disclosure arrows for collapsible sidebar folders and sections.' },
       { label: 'Use theme for PDF export', detail: 'Under Settings → Appearance → PDF export. Off by default, so exported PDFs use a clean light print theme. Turn it on to render the PDF in your current theme instead — colors and dark/light, including custom themes — as a full-bleed page.' }

--- a/packages/app-core/src/lib/help.ts
+++ b/packages/app-core/src/lib/help.ts
@@ -743,7 +743,7 @@ export const HELP_SETTINGS: HelpSettingsSection[] = [
   {
     title: 'Appearance',
     items: [
-      { label: 'Theme, mode, and variant', detail: 'Pick a theme family — Apple, Gruvbox, Catppuccin, GitHub, Solarized, One, Nord, Tokyo Night, Kanagawa (Wave / Dragon / Paper Ink / Lotus), Rosé Pine (Rosé Pine / Moon / Dawn), or the monochrome, true-black (OLED-friendly) Black Metal — plus light or dark mode and the active flavor or contrast where the theme supports it.' },
+      { label: 'Theme, mode, and variant', detail: 'Pick a theme family — Apple, Gruvbox, Catppuccin, GitHub, Solarized, One, Nord, Tokyo Night, Kanagawa (Wave / Dragon / Paper Ink (Custom) / Lotus), Rosé Pine (Rosé Pine / Moon / Dawn), or the monochrome, true-black (OLED-friendly) Black Metal — plus light or dark mode and the active flavor or contrast where the theme supports it.' },
       { label: 'Dark sidebar', detail: 'Tint the sidebar slightly darker than the canvas so the chrome reads as a distinct surface.' },
       { label: 'Sidebar arrows', detail: 'Show or hide disclosure arrows for collapsible sidebar folders and sections.' },
       { label: 'Use theme for PDF export', detail: 'Under Settings → Appearance → PDF export. Off by default, so exported PDFs use a clean light print theme. Turn it on to render the PDF in your current theme instead — colors and dark/light, including custom themes — as a full-bleed page.' }

--- a/packages/app-core/src/lib/themes.ts
+++ b/packages/app-core/src/lib/themes.ts
@@ -100,10 +100,11 @@ export const THEMES: ThemeOption[] = [
 
   // --- Kanagawa (rebelot/kanagawa.nvim) -------------------------------
   // Inspired by Hokusai's "The Great Wave off Kanagawa". Wave is the warm
-  // default dark, Dragon a darker/cooler dark, Lotus the light variant.
+  // default dark, Dragon a darker/cooler dark, and Paper Ink is a custom
+  // muted variant with a very dark purple background.
   { id: 'kanagawa-wave', label: 'Wave', family: 'kanagawa', mode: 'dark', variant: 'wave' },
   { id: 'kanagawa-dragon', label: 'Dragon', family: 'kanagawa', mode: 'dark', variant: 'dragon' },
-  { id: 'kanagawa-paper-ink', label: 'Paper Ink', family: 'kanagawa', mode: 'dark', variant: 'paper-ink' },
+  { id: 'kanagawa-paper-ink', label: 'Paper Ink (Custom)', family: 'kanagawa', mode: 'dark', variant: 'paper-ink' },
   { id: 'kanagawa-lotus', label: 'Lotus', family: 'kanagawa', mode: 'light', variant: 'lotus' },
 
   // --- Black Metal (metalelf0/black-metal-theme-neovim) ---------------

--- a/packages/app-core/src/lib/themes.ts
+++ b/packages/app-core/src/lib/themes.ts
@@ -103,6 +103,7 @@ export const THEMES: ThemeOption[] = [
   // default dark, Dragon a darker/cooler dark, Lotus the light variant.
   { id: 'kanagawa-wave', label: 'Wave', family: 'kanagawa', mode: 'dark', variant: 'wave' },
   { id: 'kanagawa-dragon', label: 'Dragon', family: 'kanagawa', mode: 'dark', variant: 'dragon' },
+  { id: 'kanagawa-paper-ink', label: 'Paper Ink', family: 'kanagawa', mode: 'dark', variant: 'paper-ink' },
   { id: 'kanagawa-lotus', label: 'Lotus', family: 'kanagawa', mode: 'light', variant: 'lotus' },
 
   // --- Black Metal (metalelf0/black-metal-theme-neovim) ---------------

--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -360,11 +360,12 @@
 :root[data-theme="one-dark"],
 :root[data-theme="nord-dark"],
 :root[data-theme="tokyo-night-storm"],
-:root[data-theme="kanagawa-wave"],
-:root[data-theme="kanagawa-dragon"],
-:root[data-theme="rose-pine-main"],
-:root[data-theme="rose-pine-moon"],
-:root[data-theme="black-metal"] {
+::root[data-theme="kanagawa-wave"],
+::root[data-theme="kanagawa-dragon"],
+::root[data-theme="kanagawa-paper-ink"],
+::root[data-theme="rose-pine-main"],
+::root[data-theme="rose-pine-moon"],
+::root[data-theme="black-metal"] {
   --z-glass-a1: 0.58;
   --z-glass-a2: 0.46;
   --z-glass-a3: 0.32;
@@ -1138,6 +1139,34 @@
   --z-purple: 162 146 163; /* dragonPink   #a292a3 */
   --z-aqua: 142 164 162; /* dragonAqua   #8ea4a2 */
   --z-shadow: 0 0 0;
+}
+
+/* ---- Paper Ink (dark — muted Kanagawa Paper) ----------------------- */
+:root[data-theme="kanagawa-paper-ink"] {
+  color-scheme: dark;
+  --z-bg: 20 19 27; /* custom ink canvas #14131b */
+  --z-bg-softer: 31 31 40; /* sumiInk3 #1f1f28 */
+  --z-bg-1: 42 42 55; /* sumiInk4 #2a2a37 */
+  --z-bg-2: 54 54 70; /* sumiInk5 #363646 */
+  --z-bg-3: 57 56 54; /* dragonBlack5 #393836 */
+  --z-bg-4: 84 84 109; /* sumiInk6 #54546d */
+  --z-fg: 220 215 186; /* fujiWhite #dcd7ba */
+  --z-fg-1: 200 192 147; /* oldWhite #c8c093 */
+  --z-fg-2: 158 155 147; /* dragonGray2 #9e9b93 */
+  --z-grey-2: 166 166 156; /* dragonGray #a6a69c */
+  --z-grey-1: 122 131 130; /* dragonGray3 #7a8382 */
+  --z-grey-0: 115 124 115; /* dragonAsh #737c73 */
+  --z-grey-dim: 57 56 54;
+  --z-accent: 142 164 158; /* dragonAqua #8ea49e */
+  --z-accent-soft: 112 142 158; /* dragonBlue3 #708e9e */
+  --z-accent-muted: 93 122 136; /* dragonBlue4 #5d7a88 */
+  --z-red: 196 116 110; /* dragonRed #c4746e */
+  --z-green: 105 148 105; /* dragonGreen #699469 */
+  --z-yellow: 196 178 138; /* dragonYellow #c4b28a */
+  --z-blue: 67 89 101; /* dragonBlue5 #435965 */
+  --z-purple: 162 146 163; /* dragonPink #a292a3 */
+  --z-aqua: 142 164 158;
+  --z-shadow: 13 12 12;
 }
 
 /* ---- Lotus (light) ------------------------------------------------- */

--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -1141,7 +1141,7 @@
   --z-shadow: 0 0 0;
 }
 
-/* ---- Paper Ink (dark — muted Kanagawa Paper) ----------------------- */
+/* ---- Paper Ink (custom dark variant — muted Kanagawa Paper) -------- */
 :root[data-theme="kanagawa-paper-ink"] {
   color-scheme: dark;
   --z-bg: 20 19 27; /* custom ink canvas #14131b */


### PR DESCRIPTION
It's a port of best Kanagawa variant theme for neovim (with muted colors:
https://github.com/thesimonho/kanagawa-paper.nvim

but with custom, little darker background for better focus

<img width="3016" height="1816" alt="image" src="https://github.com/user-attachments/assets/813b9037-aadb-4029-948c-086f3685bf3e" />
<img width="2988" height="1824" alt="image" src="https://github.com/user-attachments/assets/7c4eedfc-d4bc-443a-af9d-457a07a59b90" />
<img width="2990" height="1816" alt="image" src="https://github.com/user-attachments/assets/4dbca3e9-8dda-4d59-bf87-656ca7b8dedf" />

color pallette: https://github.com/thesimonho/kanagawa-paper.nvim/blob/master/palette_colors.md
