### PR TITLE
feat: preserve PDF URL hash fragments (#page, #search) in links and embeds

### DIFF
--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -25,7 +25,7 @@ import {
   wikilinkHeadingAnchor
 } from '../lib/wikilinks'
 import { openDatabaseFromWikilink, openWikilinkHeading } from '../lib/wikilink-navigation'
-import { classifyLocalAssetHref, resolveAssetVaultRelativePath } from '../lib/local-assets'
+import { classifyLocalAssetHref, hrefFragment, resolveAssetVaultRelativePath } from '../lib/local-assets'
 import { externalLinkUrl, extractLinkAtCursor, resolveInternalNoteHref } from '../lib/internal-links'
 import {
   buildMoveNotePrompt,
@@ -587,7 +587,8 @@ function registerVimCommands(): void {
       if (activePath && vaultRoot) {
         const abs = resolveAssetVaultRelativePath(vaultRoot, activePath, target)
         if (abs) {
-          state.pinAssetReferenceForNote(activePath, abs)
+          const fragment = hrefFragment(target)
+          state.pinAssetReferenceForNote(activePath, abs, fragment || null)
           return
         }
       }

--- a/packages/app-core/src/components/PinnedReferencePane.tsx
+++ b/packages/app-core/src/components/PinnedReferencePane.tsx
@@ -43,7 +43,7 @@ import { slashCommandSource, slashCommandRender } from '../lib/cm-slash-commands
 import { dateShortcutSource } from '../lib/cm-date-shortcuts'
 import { wikilinkSource, wikilinkHeadingSource } from '../lib/cm-wikilinks'
 import { completionNavKeymap } from '../lib/cm-completion-nav'
-import { classifyLocalAssetHref, type LocalAssetKind } from '../lib/local-assets'
+import { classifyLocalAssetHref, hrefFragment, type LocalAssetKind } from '../lib/local-assets'
 import { LazyPreview as Preview } from './LazyPreview'
 import { CloseIcon, PanelLeftIcon, PinIcon } from './icons'
 
@@ -118,9 +118,11 @@ export function PinnedReferencePane(): JSX.Element | null {
   const globalRefKind = useStore((s) => s.pinnedRefKind)
   const noteRefs = useStore((s) => s.noteRefs)
   const selectedPath = useStore((s) => s.selectedPath)
+  const globalRefFragment = useStore((s) => s.pinnedRefFragment)
   // Per-note pin (if any) overrides the global one.
   const noteRef = selectedPath ? noteRefs[selectedPath] : null
   const pinnedRefPath = noteRef?.path ?? globalRefPath
+  const pinnedRefFragment = noteRef?.fragment ?? globalRefFragment
   const pinnedRefKind = noteRef?.kind ?? globalRefKind
   const isPerNotePin = !!noteRef
   const pinnedRefVisible = useStore((s) => s.pinnedRefVisible)
@@ -335,6 +337,7 @@ export function PinnedReferencePane(): JSX.Element | null {
     pinnedRefPath && isAsset && vaultRoot
       ? window.zen.resolveVaultAssetUrl(vaultRoot, pinnedRefPath)
       : null
+  const assetUrlWithFragment = assetUrl ? assetUrl + (pinnedRefFragment ?? '') : null
   const assetKind: LocalAssetKind | null =
     pinnedRefPath && isAsset ? classifyLocalAssetHref(pinnedRefPath) ?? 'file' : null
   const useAssetIframe = assetKind === 'pdf' || assetKind === 'file'
@@ -347,15 +350,15 @@ export function PinnedReferencePane(): JSX.Element | null {
   // user cycles through many PDFs.
   const [seenAssetUrls, setSeenAssetUrls] = useState<string[]>([])
   useEffect(() => {
-    if (!assetUrl || !useAssetIframe) return
+    if (!assetUrlWithFragment || !useAssetIframe) return
     setSeenAssetUrls((prev) => {
-      if (prev[prev.length - 1] === assetUrl) return prev
-      const without = prev.filter((u) => u !== assetUrl)
-      const next = [...without, assetUrl]
+      if (prev[prev.length - 1] === assetUrlWithFragment) return prev
+      const without = prev.filter((u) => u !== assetUrlWithFragment)
+      const next = [...without, assetUrlWithFragment]
       while (next.length > 16) next.shift()
       return next
     })
-  }, [assetUrl, useAssetIframe])
+  }, [assetUrlWithFragment, useAssetIframe])
 
   const showEditor = pinnedRefMode === 'edit'
   const hidden = !pinnedRefPath || !pinnedRefVisible
@@ -514,7 +517,7 @@ export function PinnedReferencePane(): JSX.Element | null {
           <div
             className="absolute inset-0"
             style={{
-              display: isAsset && assetUrl && useAssetIframe ? 'block' : 'none'
+              display: isAsset && assetUrlWithFragment && useAssetIframe ? 'block' : 'none'
             }}
           >
             {seenAssetUrls.map((url) => (
@@ -524,7 +527,7 @@ export function PinnedReferencePane(): JSX.Element | null {
                 title={url}
                 className="absolute inset-0 h-full w-full border-0 bg-paper-50"
                 style={{
-                  display: url === assetUrl ? 'block' : 'none'
+                  display: url === assetUrlWithFragment ? 'block' : 'none'
                 }}
               />
             ))}

--- a/packages/app-core/src/components/Preview.tsx
+++ b/packages/app-core/src/components/Preview.tsx
@@ -17,6 +17,7 @@ import { externalLinkUrl, resolveInternalNoteHref } from "../lib/internal-links"
 import { toggleTaskAtIndex } from "../lib/tasklists";
 import {
   enhanceLocalAssetNodes,
+  hrefFragment,
   resolveAssetVaultRelativePath,
 } from "../lib/local-assets";
 import { assetTabPath } from "../lib/asset-tabs";
@@ -1037,13 +1038,15 @@ export const Preview = memo(function Preview({
         if (abs) window.zen.clipboardWriteText(abs);
       },
     });
+    const assetHref = assetMenu.href;
+    const fragment = hrefFragment(assetHref) || null;
     items.push(
       {
         label: "Open as Reference (This Note)",
         disabled: !vaultRel,
         onSelect: async () => {
           if (vaultRel) {
-            pinAssetReferenceForNote(notePath, vaultRel);
+            pinAssetReferenceForNote(notePath, vaultRel, fragment);
           }
         },
       },
@@ -1051,7 +1054,7 @@ export const Preview = memo(function Preview({
         label: "Open as Reference (Global)",
         disabled: !vaultRel,
         onSelect: async () => {
-          if (vaultRel) pinAssetReference(vaultRel);
+          if (vaultRel) pinAssetReference(vaultRel, fragment);
         },
       },
     );

--- a/packages/app-core/src/lib/cm-live-preview.ts
+++ b/packages/app-core/src/lib/cm-live-preview.ts
@@ -11,6 +11,7 @@ import {
 import { useStore } from '../store'
 import {
   classifyLocalAssetHref,
+  hrefFragment,
   resolveAssetVaultRelativePath,
   resolveLocalAssetUrl
 } from './local-assets'
@@ -431,7 +432,7 @@ class LocalPdfWidget extends WidgetType {
         const abs = resolveAssetVaultRelativePath(root, notePath, this.href)
         // Default to a per-note pin — the PDF stays attached to this
         // note and quietly disappears when the user navigates away.
-        if (abs) state.pinAssetReferenceForNote(notePath, abs)
+        if (abs) state.pinAssetReferenceForNote(notePath, abs, hrefFragment(this.href) || null)
       })
 
       const icon = document.createElement('span')
@@ -493,7 +494,7 @@ class LocalPdfWidget extends WidgetType {
       const notePath = state.activeNote?.path
       if (!root || !notePath) return
       const abs = resolveAssetVaultRelativePath(root, notePath, this.href)
-      if (abs) state.pinAssetReferenceForNote(notePath, abs)
+      if (abs) state.pinAssetReferenceForNote(notePath, abs, hrefFragment(this.href) || null)
     })
 
     const openButton = document.createElement('button')
@@ -535,7 +536,7 @@ class LocalPdfWidget extends WidgetType {
 
     const frame = document.createElement('iframe')
     frame.className = 'local-pdf-embed-frame'
-    frame.src = this.resolvedUrl
+    frame.src = this.resolvedUrl + hrefFragment(this.href)
     frame.title = this.label || 'PDF'
 
     figure.append(header, frame)

--- a/packages/app-core/src/lib/local-assets.ts
+++ b/packages/app-core/src/lib/local-assets.ts
@@ -22,6 +22,11 @@ function stripQueryAndHash(href: string): string {
   return href.split('#')[0]?.split('?')[0] ?? href
 }
 
+export function hrefFragment(href: string): string {
+  const hashIdx = href.indexOf('#')
+  return hashIdx >= 0 ? href.slice(hashIdx) : ''
+}
+
 function decodeHrefPath(value: string): string {
   const cleaned = stripQueryAndHash(value)
   try {
@@ -282,7 +287,7 @@ function buildEmbed(
   if (kind === 'pdf') {
     const frame = document.createElement('iframe')
     frame.className = 'local-asset-embed-frame'
-    frame.src = url
+    frame.src = url + hrefFragment(href)
     frame.title = label
     figure.append(frame)
     return figure
@@ -410,7 +415,7 @@ export function enhanceLocalAssetNodes(
 
     const assetVaultRel = resolveAssetVaultRelativePath(vaultRoot, notePath, raw)
     const kind = classifyLocalAssetHref(raw) ?? 'file'
-    anchor.href = resolved
+    anchor.href = resolved + hrefFragment(raw)
     anchor.dataset.localAssetUrl = resolved
     anchor.dataset.localAssetKind = kind
     anchor.dataset.localAssetHref = raw

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -2106,6 +2106,9 @@ interface Store {
   /** Pinned reference pane — an always-visible side panel that shows a
    *  single companion note while the user works in the main editor. */
   pinnedRefPath: string | null
+  /** URL hash fragment for the pinned asset (e.g. "#page=12") — passed
+   *  through to the iframe so the PDF viewer opens at the right page. */
+  pinnedRefFragment: string | null
   pinnedRefVisible: boolean
   pinnedRefWidth: number
   panelWidths: PanelWidths
@@ -2144,7 +2147,7 @@ interface Store {
 
   /** Per-note reference pins. Active note's entry overrides the
    *  global pinnedRefPath while that note is open. */
-  noteRefs: Record<string, { path: string; kind: 'note' | 'asset' }>
+  noteRefs: Record<string, { path: string; kind: 'note' | 'asset'; fragment?: string | null }>
 
   /** Center the editor + preview content (with the width cap) or
    *  left-align it to the pane edge. */
@@ -2477,11 +2480,11 @@ interface Store {
   pinReference: (path: string) => Promise<void>
   /** Pin a non-text asset (PDF, etc.) — rendered in the side pane via
    *  iframe, with no text-content cache. */
-  pinAssetReference: (path: string) => void
+  pinAssetReference: (path: string, fragment?: string | null) => void
   unpinReference: () => void
   /** Per-note variant: the pin only shows while `notePath` is the
    *  active note. Switching notes hides it; coming back shows it. */
-  pinAssetReferenceForNote: (notePath: string, assetPath: string) => void
+  pinAssetReferenceForNote: (notePath: string, assetPath: string, fragment?: string | null) => void
   unpinReferenceForNote: (notePath: string) => void
   togglePinnedRefVisible: () => void
   setPinnedRefWidth: (px: number) => void
@@ -3601,6 +3604,7 @@ export const useStore = create<Store>((set, get) => {
   showSidebarChevrons: loadPrefs().showSidebarChevrons,
   collapsedFolders: DEFAULT_PREFS.collapsedFolders,
   pinnedRefPath: loadPrefs().pinnedRefPath,
+  pinnedRefFragment: null,
   pinnedRefVisible: loadPrefs().pinnedRefVisible,
   pinnedRefWidth: loadPrefs().pinnedRefWidth,
   panelWidths: loadPrefs().panelWidths,
@@ -5746,7 +5750,7 @@ export const useStore = create<Store>((set, get) => {
     savePrefs(collectPrefs(get()))
   },
 
-  pinAssetReference: (path) => {
+  pinAssetReference: (path, fragment) => {
     if (!path) return
     const s = get()
     // If we were previously pinning a note, evict its content unless
@@ -5766,6 +5770,7 @@ export const useStore = create<Store>((set, get) => {
     }
     set({
       pinnedRefPath: path,
+      pinnedRefFragment: fragment ?? null,
       pinnedRefKind: 'asset',
       pinnedRefVisible: true,
       noteContents: contents,
@@ -5774,10 +5779,10 @@ export const useStore = create<Store>((set, get) => {
     savePrefs(collectPrefs(get()))
   },
 
-  pinAssetReferenceForNote: (notePath, assetPath) => {
+  pinAssetReferenceForNote: (notePath, assetPath, fragment) => {
     if (!notePath || !assetPath) return
     set((s) => ({
-      noteRefs: { ...s.noteRefs, [notePath]: { path: assetPath, kind: 'asset' } },
+      noteRefs: { ...s.noteRefs, [notePath]: { path: assetPath, kind: 'asset', fragment: fragment ?? null } },
       pinnedRefVisible: true
     }))
     savePrefs(collectPrefs(get()))
@@ -5813,6 +5818,7 @@ export const useStore = create<Store>((set, get) => {
     }
     set({
       pinnedRefPath: null,
+      pinnedRefFragment: null,
       pinnedRefKind: 'note',
       noteContents: contents,
       noteDirty: dirty


### PR DESCRIPTION
## Problem

Markdown links to PDFs with URL hash fragments (e.g. `#page=3`, `#search=keyword`) lose the fragment at multiple points in the resolution pipeline. Chromium's built-in PDF viewer natively supports these fragments, but they never reach it.

Closes #295

## Before

`[Guide](guide.pdf#page=3&search=installation)` → PDF opens at **page 1** (fragment stripped)

## After

`[Guide](guide.pdf#page=3&search=installation)` → PDF opens at **page 3** with "installation" highlighted

Works everywhere: inline embeds, the pinned reference pane, preview anchors, and Cmd/Ctrl+click in the editor.

## Example

```markdown
[Configuration](guide.pdf#page=3)
[Search: installation](guide.pdf#search=installation)
[Troubleshooting + search](guide.pdf#page=5&search=installation)
![[guide.pdf#page=3&search=installation]]
```

## Supported Chromium PDF parameters

Since we pass the fragment through to the native viewer, all standard parameters work:
- `#page=N` — jump to page N
- `#search=keyword` — highlight search results
- `#page=N&search=keyword` — combined jump + search
- `#zoom=scale` — set zoom level

## Use case

Link notes directly to specific PDF content without copying context into the note itself. For example, a bug report note can link to page 42 of a specification PDF where the regression is documented.

## Testing

1. Place a multi-page PDF in `vault/inbox/`
2. Create a note with `[Test](file.pdf#page=2)` on its own line
3. Verify the embedded iframe opens at page 2
4. Test `![[file.pdf#page=2&search=something]]` embed syntax
5. Cmd/Ctrl+click the link → verify reference pane shows page 2
6. Right-click the link → "Open as Reference" → verify fragment preserved

## Scope

- Only PDF link/embed fragment handling is modified
- No changes to image, audio, video, or other asset types
- No changes to PDF export, PDF creation, or vault management
- `pinnedRefFragment` is runtime-only (not persisted across sessions)

## Changes

| File | What |
|------|------|
| `local-assets.ts` | Add `hrefFragment()` helper; append fragment to PDF iframe src in `buildEmbed()` and anchor href in `enhanceLocalAssetNodes()` |
| `cm-live-preview.ts` | Append fragment to `LocalPdfWidget` iframe src; pass fragment through pin-reference button handlers |
| `store.ts` | Add `pinnedRefFragment` (runtime-only, not persisted); extend `noteRefs` type with optional fragment; accept fragment param in `pinAssetReference`/`pinAssetReferenceForNote` |
| `PinnedReferencePane.tsx` | Read fragment from store; apply to iframe URL and cache keys |
| `Editor.tsx` | Extract and pass fragment on Cmd+click PDF links |
| `Preview.tsx` | Extract and pass fragment in context-menu pin handlers |