### PR TITLE
fix: display leader key hints in lowercase to match actual keypresses

### DIFF
--- a/packages/app-core/src/components/WhichKeyOverlay.tsx
+++ b/packages/app-core/src/components/WhichKeyOverlay.tsx
@@ -54,7 +54,7 @@ export function WhichKeyOverlay({
                   .map((token, tokenIndex) => (
                     <span
                       key={`${prefix}-${item.keyLabel}-${tokenIndex}`}
-                      className="rounded-md border border-paper-300 bg-paper-200/85 px-2 py-0.5 text-center text-2xs font-semibold uppercase tracking-wide text-ink-700"
+                      className="rounded-md border border-paper-300 bg-paper-200/85 px-2 py-0.5 text-center text-2xs font-semibold tracking-wide text-ink-700"
                     >
                       {token}
                     </span>


### PR DESCRIPTION
# Description:
When pressing the leader key (Space), the which-key overlay displayed key hints in uppercase (e.g., O, F, S) due to the CSS uppercase class on the key label elements. However, the matching logic expects lowercase input, pressing uppercase O (Shift+O) does not trigger the action, only lowercase o does.
This mismatch is confusing for users who see "O" in the overlay and naturally try pressing Shift+O.
## Fix 
Remove the uppercase CSS class from the key label <span> in WhichKeyOverlay.tsx so the overlay displays keys exactly as they should be pressed (lowercase o, f, s, etc.). The "LEADER" prefix badge still uses its own uppercase class since that's a label, not a key to press.

# Test
now the preview shows action keys in lowercase as per the screenshot
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/bd405177-784c-4414-8623-d55949067f8e" />
