### PR TITLE
fix: use theme-aware syntax colors for preview code blocks

### DIFF
--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -2703,6 +2703,48 @@ textarea,
 .prose-zen .zen-code-block[data-code-folded="true"] .zen-code-block-summary {
   display: block;
 }
+/* --- Preview-mode code block syntax tokens (theme-aware) --- */
+/* Override the hardcoded highlight.js palette with the same CSS variables
+   the editor uses so preview code blocks adapt to the active theme. */
+.prose-zen .hljs-keyword,
+.prose-zen .hljs-doctag {
+  color: rgb(var(--z-accent));
+}
+.prose-zen .hljs-string,
+.prose-zen .hljs-regexp,
+.prose-zen .hljs-addition,
+.prose-zen .hljs-attribute {
+  color: rgb(var(--z-green));
+}
+.prose-zen .hljs-comment,
+.prose-zen .hljs-quote {
+  color: rgb(var(--z-fg-2));
+  font-style: italic;
+}
+.prose-zen .hljs-number,
+.prose-zen .hljs-literal {
+  color: rgb(var(--z-yellow));
+}
+.prose-zen .hljs-type,
+.prose-zen .hljs-built_in {
+  color: rgb(var(--z-purple));
+}
+.prose-zen .hljs-function,
+.prose-zen .hljs-title,
+.prose-zen .hljs-symbol,
+.prose-zen .hljs-meta {
+  color: rgb(var(--z-blue));
+}
+.prose-zen .hljs-section,
+.prose-zen .hljs-name,
+.prose-zen .hljs-tag {
+  color: rgb(var(--z-red));
+}
+.prose-zen .hljs-variable,
+.prose-zen .hljs-attr,
+.prose-zen .hljs-selector-class {
+  color: rgb(var(--z-fg));
+}
 .prose-zen table {
   border-collapse: collapse;
   width: 100%;


### PR DESCRIPTION
fixes #239 

# Description
Preview mode rendered code blocks with highlight.js's hardcoded atom-one-light palette, producing the same fixed light-theme colors regardless of the active ZenNotes theme. On dark themes this caused jarring bright code blocks that clashed with the rest of the UI, and the colors didn't match what users saw in edit mode.

## Fix
Override the hljs-* token classes with the same CSS variables the editor uses (--z-accent, --z-green, --z-yellow, etc.), scoped to .prose-zen so only preview mode is affected. Preview code blocks now use identical colors to edit mode and adapt to every theme automatically.

## Changes 
As the screenshots below depict, after the changes the preview mode colors adhere more to the original theme that we set in zennotes, instead of using a blanket atom theme for all.

<img width="350" height="350" alt="catpuccin-before" src="https://github.com/user-attachments/assets/b09d828b-0e6f-46c9-97b6-cf4a16ba4b44" />
<img width="350" height="350" alt="catpuccin-after" src="https://github.com/user-attachments/assets/69331026-4a98-4df6-87bf-454bcc58cab9" />
