### PR TITLE
fix(editor): restore Vim half-page shortcuts

### DIFF
--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -48,6 +48,7 @@ import { navigateActiveBuffer } from '../lib/buffer-navigation'
 import { applyVimInsertEscape } from '../lib/vim-insert-escape'
 import { listContinuationPrefix } from '../lib/list-continuation'
 import { focusEditorNormalMode } from '../lib/editor-focus'
+import { toVimSequence } from '../lib/vim-key-sequence'
 
 let vimCommandsRegistered = false
 let syncedVimBindings: Partial<Record<KeymapId, string[]>> = {}
@@ -76,54 +77,6 @@ function clearKnownVimMappings(): void {
       /* ignore */
     }
   }
-}
-
-function toVimKeyName(base: string): string {
-  if (base === 'Space') return 'Space'
-  if (base === 'Enter') return 'CR'
-  if (base === 'Esc' || base === 'Escape') return 'Esc'
-  if (base === 'Tab') return 'Tab'
-  if (base === 'ArrowUp') return 'Up'
-  if (base === 'ArrowDown') return 'Down'
-  if (base === 'ArrowLeft') return 'Left'
-  if (base === 'ArrowRight') return 'Right'
-  return base
-}
-
-function toVimSequenceToken(token: string): string | null {
-  const parts = token
-    .split('+')
-    .map((part) => part.trim())
-    .filter(Boolean)
-  if (parts.length === 0) return null
-  const base = parts.pop()
-  if (!base) return null
-  const keyName = toVimKeyName(base)
-  if (parts.length === 0) {
-    if (base.length === 1) return base
-    return `<${keyName}>`
-  }
-  const modifiers = parts
-    .map((part) => {
-      if (part === 'Ctrl') return 'C'
-      if (part === 'Alt') return 'A'
-      if (part === 'Shift') return 'S'
-      if (part === 'Meta' || part === 'Mod') return 'D'
-      return null
-    })
-    .filter(Boolean) as string[]
-  const normalizedKey = base.length === 1 ? base.toLowerCase() : keyName
-  return `<${[...modifiers, normalizedKey].join('-')}>`
-}
-
-function toVimSequence(binding: string): string | null {
-  const tokens = binding
-    .split(/\s+/)
-    .map((token) => token.trim())
-    .filter(Boolean)
-    .map((token) => toVimSequenceToken(token))
-  if (tokens.length === 0 || tokens.some((token) => !token)) return null
-  return tokens.join('')
 }
 
 function paneMapBindings(overrides: KeymapOverrides, actionId: KeymapId): string[] {

--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -55,6 +55,7 @@ import { markdownListIndentPlugin } from '../lib/cm-markdown-list-indent'
 import { forwardOnCheckboxArrow } from '../lib/cm-forward-task'
 import { completionNavKeymap } from '../lib/cm-completion-nav'
 import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap } from '../lib/cm-vim-default-keymap'
+import { toCodeMirrorKey, vimHalfPageKeymap } from '../lib/vim-half-page-keymap'
 import { scrollOff } from '../lib/cm-scrolloff'
 import { offerCreateNoteFromLink } from '../lib/create-note-from-link'
 import {
@@ -255,16 +256,6 @@ const LARGE_DOC_LIVE_PREVIEW_DEFER_CHARS = 120_000
 const LARGE_DOC_LIVE_PREVIEW_DEFER_MS = 3_000
 const LARGE_DOC_EDITOR_HYDRATE_DELAY_MS = 180
 
-/** Convert a ZenNotes binding string ("Alt+ArrowUp", "Mod+K") to a CodeMirror
- *  key string ("Alt-ArrowUp", "Mod-k"). */
-function toCmKey(binding: string): string {
-  const parts = binding.split('+')
-  const base = parts.pop() ?? ''
-  const mods = parts.join('-')
-  const baseOut = base.length === 1 ? base.toLowerCase() : base
-  return mods ? `${mods}-${baseOut}` : baseOut
-}
-
 // The editor keymap depends on Vim mode: in Vim mode the macOS emacs-style
 // chords are stripped from `defaultKeymap` so Vim's `<C-d>` & co. work (see
 // cm-vim-default-keymap). Built behind a compartment and reconfigured on Vim
@@ -283,8 +274,15 @@ function buildEditorKeymap(vimMode: boolean, overrides: KeymapOverrides): Extens
     // Move the current line (or selection) up/down — reorders the markdown so
     // it persists in the file. Listed before defaultKeymap so the configured
     // binding wins; works in Vim normal/insert and non-Vim alike.
-    { key: toCmKey(getKeymapBinding(overrides, 'editor.moveLineUp')), run: moveLineUp },
-    { key: toCmKey(getKeymapBinding(overrides, 'editor.moveLineDown')), run: moveLineDown },
+    {
+      key: toCodeMirrorKey(getKeymapBinding(overrides, 'editor.moveLineUp')),
+      run: moveLineUp
+    },
+    {
+      key: toCodeMirrorKey(getKeymapBinding(overrides, 'editor.moveLineDown')),
+      run: moveLineDown
+    },
+    ...vimHalfPageKeymap(vimMode, overrides),
     indentWithTab,
     ...vimAwareDefaultKeymap(vimMode),
     ...historyKeymap,

--- a/packages/app-core/src/lib/vim-half-page-keymap.test.ts
+++ b/packages/app-core/src/lib/vim-half-page-keymap.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { historyKeymap } from '@codemirror/commands'
+import { searchKeymap } from '@codemirror/search'
+import { EditorState } from '@codemirror/state'
+import { EditorView, keymap } from '@codemirror/view'
+import { Vim, vim } from '@replit/codemirror-vim'
+import type { KeymapOverrides } from './keymaps'
+import { vimHalfPageKeymap } from './vim-half-page-keymap'
+
+describe('vimHalfPageKeymap', () => {
+  const views: EditorView[] = []
+  const mapped: string[] = []
+
+  afterEach(() => {
+    views.splice(0).forEach((view) => view.destroy())
+    mapped.splice(0).forEach((binding) => Vim.unmap(binding, 'normal'))
+  })
+
+  function mount(overrides: KeymapOverrides = {}): EditorView {
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: 'one\ntwo\nthree',
+        extensions: [
+          vim(),
+          keymap.of([
+            ...vimHalfPageKeymap(true, overrides),
+            ...historyKeymap,
+            ...searchKeymap
+          ])
+        ]
+      }),
+      parent: document.body
+    })
+    views.push(view)
+    view.focus()
+    return view
+  }
+
+  function mapAction(binding: string, action: string, callback: () => void): void {
+    Vim.defineAction(action, callback)
+    Vim.mapCommand(binding, 'action', action, {}, { context: 'normal' })
+    mapped.push(binding)
+  }
+
+  function press(view: EditorView, key: string, modifiers: KeyboardEventInit): void {
+    view.contentDOM.dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...modifiers })
+    )
+  }
+
+  it('runs Ctrl+D and Ctrl+U through Vim before search and history keymaps', () => {
+    const calls: string[] = []
+    mapAction('<C-d>', 'testHalfPageDown', () => calls.push('down'))
+    mapAction('<C-u>', 'testHalfPageUp', () => calls.push('up'))
+    const view = mount()
+
+    press(view, 'd', { ctrlKey: true })
+    press(view, 'u', { ctrlKey: true })
+
+    expect(calls).toEqual(['down', 'up'])
+  })
+
+  it('uses configured bindings', () => {
+    let calls = 0
+    mapAction('<A-u>', 'testRemappedHalfPageDown', () => calls++)
+    const view = mount({ 'nav.halfPageDown': 'Alt+U' })
+
+    press(view, 'u', { altKey: true })
+
+    expect(calls).toBe(1)
+  })
+
+  it('defers outside Vim normal mode', () => {
+    let calls = 0
+    mapAction('<C-d>', 'testNormalHalfPageDown', () => calls++)
+    const view = mount()
+
+    press(view, 'i', {})
+    press(view, 'd', { ctrlKey: true })
+
+    expect(calls).toBe(0)
+    expect(vimHalfPageKeymap(false, {})).toEqual([])
+  })
+})

--- a/packages/app-core/src/lib/vim-half-page-keymap.ts
+++ b/packages/app-core/src/lib/vim-half-page-keymap.ts
@@ -1,0 +1,32 @@
+import type { KeyBinding } from '@codemirror/view'
+import { Vim, getCM } from '@replit/codemirror-vim'
+import { getKeymapBinding, type KeymapOverrides } from './keymaps'
+import { toVimSequence } from './vim-key-sequence'
+
+export function toCodeMirrorKey(binding: string): string {
+  const parts = binding.split('+')
+  const base = parts.pop() ?? ''
+  const modifiers = parts.join('-')
+  const key = base.length === 1 ? base.toLowerCase() : base
+  return modifiers ? `${modifiers}-${key}` : key
+}
+
+export function vimHalfPageKeymap(
+  vimMode: boolean,
+  overrides: KeymapOverrides
+): KeyBinding[] {
+  if (!vimMode) return []
+  return (['nav.halfPageDown', 'nav.halfPageUp'] as const).map((keymapId) => {
+    const binding = getKeymapBinding(overrides, keymapId)
+    const sequence = toVimSequence(binding)
+    return {
+      key: toCodeMirrorKey(binding),
+      run: (view): boolean => {
+        const cm = getCM(view)
+        const vim = cm?.state.vim
+        if (!cm || !vim || vim.insertMode || vim.visualMode || !sequence) return false
+        return !!Vim.handleKey(cm, sequence, 'user')
+      }
+    }
+  })
+}

--- a/packages/app-core/src/lib/vim-key-sequence.test.ts
+++ b/packages/app-core/src/lib/vim-key-sequence.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { getKeymapBinding, type KeymapOverrides } from './keymaps'
+import { toVimSequence } from './vim-key-sequence'
+
+describe('toVimSequence', () => {
+  it('converts default half-page bindings', () => {
+    expect(toVimSequence(getKeymapBinding({}, 'nav.halfPageDown'))).toBe('<C-d>')
+    expect(toVimSequence(getKeymapBinding({}, 'nav.halfPageUp'))).toBe('<C-u>')
+  })
+
+  it('converts configured half-page bindings', () => {
+    const overrides: KeymapOverrides = { 'nav.halfPageDown': 'Alt+U' }
+    expect(toVimSequence(getKeymapBinding(overrides, 'nav.halfPageDown'))).toBe('<A-u>')
+  })
+
+  it('converts multi-key sequences', () => {
+    expect(toVimSequence('Ctrl+W h')).toBe('<C-w>h')
+  })
+})

--- a/packages/app-core/src/lib/vim-key-sequence.ts
+++ b/packages/app-core/src/lib/vim-key-sequence.ts
@@ -1,0 +1,44 @@
+function toVimKeyName(base: string): string {
+  if (base === 'Space') return 'Space'
+  if (base === 'Enter') return 'CR'
+  if (base === 'Esc' || base === 'Escape') return 'Esc'
+  if (base === 'Tab') return 'Tab'
+  if (base === 'ArrowUp') return 'Up'
+  if (base === 'ArrowDown') return 'Down'
+  if (base === 'ArrowLeft') return 'Left'
+  if (base === 'ArrowRight') return 'Right'
+  return base
+}
+
+function toVimSequenceToken(token: string): string | null {
+  const parts = token
+    .split('+')
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (parts.length === 0) return null
+  const base = parts.pop()
+  if (!base) return null
+  const keyName = toVimKeyName(base)
+  if (parts.length === 0) return base.length === 1 ? base : `<${keyName}>`
+  const modifiers = parts
+    .map((part) => {
+      if (part === 'Ctrl') return 'C'
+      if (part === 'Alt') return 'A'
+      if (part === 'Shift') return 'S'
+      if (part === 'Meta' || part === 'Mod') return 'D'
+      return null
+    })
+    .filter(Boolean) as string[]
+  const normalizedKey = base.length === 1 ? base.toLowerCase() : keyName
+  return `<${[...modifiers, normalizedKey].join('-')}>`
+}
+
+export function toVimSequence(binding: string): string | null {
+  const tokens = binding
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .map((token) => toVimSequenceToken(token))
+  if (tokens.length === 0 || tokens.some((token) => !token)) return null
+  return tokens.join('')
+}


### PR DESCRIPTION
## Summary

Restore configured Vim half-page shortcuts in the main editor by giving them precedence over CodeMirror’s search and history keymaps.

The bindings still dispatch through `Vim.handleKey`, preserving CodeMirror-Vim’s normal command lifecycle and custom keymap overrides. Insert, visual, and non-Vim modes retain their existing behavior.

## Why

On Linux, CodeMirror interpreted `Mod-d` and `Mod-u` as Ctrl+D and Ctrl+U, consuming those events before CodeMirror-Vim received them. As a result, half-page scrolling worked in Preview but not in Edit or Split.

This reproduced with clean configurations in both source and packaged builds, confirming a source defect independent of a separate conflicting local configuration.

## Scope

This PR intentionally addresses only the Ctrl+D/Ctrl+U behavior reported in a comment on #272.

The other symptoms in that issue use different code paths:

- **Ctrl+W:** In Vim mode, ZenNotes intentionally reserves this as the pane-command prefix while a tab is open; tabs close with `:q`. Changing that behavior or its documentation is a separate product decision.
- **Quick capture:** Ctrl+Shift+Space is registered through Electron’s system-wide shortcut API and is subject to Wayland/compositor behavior. That path is independent of CodeMirror and has a separate `zennotes://quick-capture` fallback from #217/#219.

Keeping these concerns separate limits this change to the reproduced editor keymap-precedence defect and allows each remaining behavior to be evaluated independently.

This addresses the Ctrl+D/Ctrl+U portion of #272; it does not close the entire issue.

## Testing

- Added regression coverage for keymap precedence, configured overrides, and mode deferral
- App-core tests: 738 passed, 1 skipped
- Desktop typecheck and build passed
- Verified Edit, Split, and Preview behavior with an isolated runtime profile

This addresses the Ctrl+D/Ctrl+U portion of #272.