### PR TITLE
editor: fix frontmatter heading styling

### DIFF
--- a/packages/app-core/src/lib/markdown.test.ts
+++ b/packages/app-core/src/lib/markdown.test.ts
@@ -4,6 +4,17 @@ import { describe, expect, it } from 'vitest'
 import { renderMarkdown } from './markdown'
 
 describe('renderMarkdown', () => {
+  it('hides leading YAML/TOML frontmatter in preview output', () => {
+    const yaml = renderMarkdown('---\ntitle: Hidden\ntags: [a, b]\n---\n\n# Visible')
+    expect(yaml).toContain('<h1 data-source-line="6">Visible</h1>')
+    expect(yaml).not.toContain('title: Hidden')
+    expect(yaml).not.toContain('<hr')
+
+    const toml = renderMarkdown('+++\ntitle = "Hidden"\n+++\n\nBody')
+    expect(toml).toContain('<p data-source-line="5">Body</p>')
+    expect(toml).not.toContain('title =')
+  })
+
   it('sanitizes raw HTML and javascript URLs', () => {
     const html = renderMarkdown(
       [

--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -2065,8 +2065,32 @@ html[data-completed-task-style="gray-strikethrough"] .cm-editor .cm-task-done * 
   border-left: 1px solid rgb(var(--z-grey-0) / 0.13);
   border-right: 1px solid rgb(var(--z-grey-0) / 0.13);
 }
-.cm-editor .cm-frontmatter-line :is(.tok-meta, .tok-string, .tok-keyword, .tok-atom) {
+.cm-editor .cm-frontmatter-line
+  :is(
+    .tok-meta,
+    .tok-string,
+    .tok-keyword,
+    .tok-atom,
+    .tok-heading,
+    .tok-heading1,
+    .tok-heading2,
+    .tok-heading3,
+    .tok-heading4,
+    .tok-heading5,
+    .tok-heading6
+  ) {
   color: inherit;
+}
+/* Without a blank line before the closing `---`, CodeMirror's markdown parser
+ * can tokenize the previous frontmatter line as a setext heading. The metadata
+ * card owns frontmatter presentation, so suppress body heading typography here. */
+.cm-editor .cm-frontmatter-line
+  :is(.tok-heading, .tok-heading1, .tok-heading2, .tok-heading3, .tok-heading4, .tok-heading5, .tok-heading6) {
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  text-transform: none;
+  letter-spacing: 0;
 }
 /* The key (before the `:`) is a muted label; the value keeps the normal color. */
 .cm-editor .cm-frontmatter-key,


### PR DESCRIPTION
> **DISCLAIMER**: I'm not sure if this is the intended UI or not. But creating a PR anyway :)

Fix frontmatter styling in the editor.

CodeMirror can tokenize the line before a closing `---` frontmatter fence as a setext heading when there isn't a blank line before the fence. This caused valid frontmatter to render with large heading typography in edit mode.

This makes frontmatter card styling override heading tokens inside the frontmatter block, so both forms render consistently.

Also adds a preview regression test that verifies leading YAML/TOML frontmatter is hidden from rendered markdown.

**Before:**
<img width="2148" height="1382" alt="image" src="https://github.com/user-attachments/assets/9e3db839-f519-4825-9977-58729fb2b949" />

**After:**
<img width="2148" height="1382" alt="image" src="https://github.com/user-attachments/assets/0be8ca47-7159-4ffe-8102-19a7ff1304e5" />
