### PR TITLE
ui: hide window controls in web runtime

### DIFF
--- a/packages/app-core/src/components/TitleBar.tsx
+++ b/packages/app-core/src/components/TitleBar.tsx
@@ -6,6 +6,7 @@ import { isArchiveTabPath } from '@shared/archive'
 import { isTrashTabPath } from '@shared/trash'
 import { isQuickNotesTabPath } from '@shared/quick-notes'
 import { resolveSystemFolderLabels } from '../lib/system-folder-labels'
+import { shouldShowWindowControls } from '../lib/titlebar'
 
 export function TitleBar(): JSX.Element {
   const vault = useStore((s) => s.vault)
@@ -14,6 +15,7 @@ export function TitleBar(): JSX.Element {
   const systemFolderLabels = useStore((s) => s.systemFolderLabels)
   const workspaceMode = useStore((s) => s.workspaceMode)
   const isMac = window.zen.platformSync() === 'darwin'
+  const runtime = window.zen.getAppInfo().runtime
   const labels = resolveSystemFolderLabels(systemFolderLabels)
 
   const title = activeNote
@@ -47,7 +49,7 @@ export function TitleBar(): JSX.Element {
           </span>
         )}
       </div>
-      {!isMac && (
+      {shouldShowWindowControls(isMac ? 'darwin' : 'other', runtime) && (
         <div className="flex items-center gap-1">
           <WinButton onClick={() => window.zen.windowMinimize()} label="–" />
           <WinButton onClick={() => window.zen.windowToggleMaximize()} label="▢" />

--- a/packages/app-core/src/lib/titlebar.test.ts
+++ b/packages/app-core/src/lib/titlebar.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowWindowControls } from './titlebar'
+
+describe('shouldShowWindowControls — hidden on mac and in the web runtime', () => {
+  it('shows controls on desktop, non-mac', () => {
+    expect(shouldShowWindowControls('win32', 'desktop')).toBe(true)
+    expect(shouldShowWindowControls('linux', 'desktop')).toBe(true)
+  })
+
+  it('hides controls in the web runtime, regardless of platform', () => {
+    expect(shouldShowWindowControls('win32', 'web')).toBe(false)
+    expect(shouldShowWindowControls('linux', 'web')).toBe(false)
+  })
+
+  it('hides controls on mac, regardless of runtime', () => {
+    expect(shouldShowWindowControls('darwin', 'desktop')).toBe(false)
+    expect(shouldShowWindowControls('darwin', 'web')).toBe(false)
+  })
+})

--- a/packages/app-core/src/lib/titlebar.ts
+++ b/packages/app-core/src/lib/titlebar.ts
@@ -1,0 +1,9 @@
+/**
+ * Whether the native window controls (minimize/maximize/close) should
+ * be shown. They call Electron-only APIs, so they're hidden on mac
+ * (native traffic lights instead) and in the web runtime, where there
+ * is no native window to control.
+ */
+export function shouldShowWindowControls(platform: string, runtime: string): boolean {
+  return platform !== 'darwin' && runtime !== 'web'
+}


### PR DESCRIPTION
## Problem

`TitleBar` rendered native window control buttons (minimize / maximize
/ close) unconditionally on non-mac platforms. The buttons rendered
correctly with no visual issues, but they were non-functional when the
app is accessed as a web page served by the server: the click handlers
call Electron-only APIs (`windowMinimize`, `windowToggleMaximize`,
`windowClose`), and there is no native window to control in that
context.

## Fix

- Added `shouldShowWindowControls(platform, runtime)`, a pure function
  that returns whether the controls should render (hidden on mac and
  in the web runtime).
- `TitleBar` now uses `window.zen.getAppInfo().runtime` to detect the
  web runtime, passed into `shouldShowWindowControls` alongside the
  existing mac check.
- Added unit tests for `shouldShowWindowControls` covering desktop
  (win/linux), web runtime, and mac.

## Testing

- `npm test` — new unit tests pass.
- Desktop app (local build): controls render and work as before.
- Web-served UI (browser): controls are hidden, no other change in
  behavior.

## Scope

Limited to `TitleBar.tsx` and its new test file; no other behavior
changed.