### PR TITLE
editor: remove text-transform from h5 headers

### DIFF
--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -2204,7 +2204,6 @@ html[data-completed-task-style="gray-strikethrough"] .cm-editor .cm-task-done * 
 }
 .cm-editor .tok-heading5 {
   font-size: 1em;
-  text-transform: uppercase;
   letter-spacing: 0;
 }
 .cm-editor .tok-heading6 {
@@ -2698,7 +2697,6 @@ html[data-completed-task-style="gray-strikethrough"] .cm-editor .cm-task-done * 
   font-size: 1em;
   margin-top: var(--z-prose-section-gap);
   margin-bottom: var(--z-prose-heading-gap);
-  text-transform: uppercase;
   letter-spacing: 0;
 }
 .prose-zen h6 {


### PR DESCRIPTION
**Description:**
In the editor, text formatted as `#####` was always displayed in uppercase because of `text-transform`. The header should preserve the original text casing instead.

- [X] `npm run typecheck`
- [X] `npm run build`


Fixes #478

Before:
<img width="1920" height="1048" alt="{7A031F4D-E85C-4010-B17E-E04B13FDD1F5}" src="https://github.com/user-attachments/assets/119db6cb-a2a9-479c-af0c-e052773deaf6" />

After:
<img width="1920" height="1048" alt="{7DAAF8D8-6ED8-486A-A178-802B8BDAF69F}" src="https://github.com/user-attachments/assets/e49a4a1f-1015-487d-a8d9-0c9dcb4bb653" />
