### PR TITLE
preview: Fix mermaid labels clipped in preview

### DIFF
--- a/packages/app-core/src/components/Preview.tsx
+++ b/packages/app-core/src/components/Preview.tsx
@@ -93,6 +93,21 @@ function readThemeColor(name: string, fallback = "#888888"): string {
   return `#${hex(parts[0])}${hex(parts[1])}${hex(parts[2])}`;
 }
 
+/** Read a `--z-*` CSS font variable as a concrete font-family string.
+ *  Mermaid measures text in a temporary element appended to the document
+ *  body, so `fontFamily: "inherit"` can resolve to a different font than the
+ *  one used inside `.prose-zen`. Passing the resolved stack avoids clipped
+ *  labels caused by mismatched text metrics. */
+function readThemeFont(
+  name: string,
+  fallback = '"SF Mono", "SFMono-Regular", ui-monospace, "JetBrains Mono", Menlo, Consolas, "Liberation Mono", monospace',
+): string {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  return raw || fallback;
+}
+
 interface MermaidThemeConfig {
   theme: "base";
   themeVariables: Record<string, string>;
@@ -119,13 +134,17 @@ function buildMermaidTheme(mode: "light" | "dark"): MermaidThemeConfig {
   const blue = readThemeColor("--z-blue", "#45707a");
   const purple = readThemeColor("--z-purple", "#945e80");
   const aqua = readThemeColor("--z-aqua", "#4c7a5d");
+  const fontFamily = readThemeFont(
+    "--z-text-font",
+    '"SF Mono", "SFMono-Regular", ui-monospace, "JetBrains Mono", Menlo, Consolas, "Liberation Mono", monospace',
+  );
 
   return {
     theme: "base",
     darkMode: mode === "dark",
     themeVariables: {
       // Typography
-      fontFamily: "inherit",
+      fontFamily,
       fontSize: "14px",
 
       // Core palette — mermaid derives most diagrams from these.
@@ -321,6 +340,17 @@ async function renderMermaidBlocks(
   if (blocks.length === 0) return;
   const mermaid = await loadMermaid();
   const cfg = buildMermaidTheme(mode);
+  // Mermaid measures text in a temporary element. If the active font is
+  // still loading, metrics are taken against a fallback and the rendered
+  // labels end up clipped once the real font applies. Wait for fonts first
+  // so the measured widths match the final painted text.
+  if (typeof document !== "undefined" && document.fonts) {
+    try {
+      await document.fonts.ready;
+    } catch {
+      /* ignore font-api failures and render anyway */
+    }
+  }
   try {
     mermaid.initialize({
       startOnLoad: false,


### PR DESCRIPTION
Summary
--
Fixes clipped mermaid diagram labels in the preview by ensuring text metrics are measured against the same loaded font that will paint the final SVG.

Mermaid measures text in a temporary element appended to `document.body`. We were passing `fontFamily: "inherit"` in the theme, so the measurement font could resolve differently from the font actually used inside `.prose-zen`. Rendering also often ran before the active font finished loading, so labels were sized for a fallback font and then clipped once the real font painted.

Changes
--
- Read `--z-text-font` as a concrete font-family stack and pass it to mermaid's `themeVariables.fontFamily`.
- Await `document.fonts.ready` before calling `mermaid.render()` so text metrics are computed against the loaded font.

Screenshots
--
### Before
<img width="820" height="910" alt="SCR-20260802-juow" src="https://github.com/user-attachments/assets/e1ea43fb-afd6-403f-ae9a-73a6c2e81296" />

### After
<img width="837" height="915" alt="SCR-20260802-juwz" src="https://github.com/user-attachments/assets/7a924d44-9276-4311-b8dd-f2f3b6701e3d" />
