### PR TITLE
feat(editor): frontmatter tag autocomplete and clickable tags

### DIFF
--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -74,7 +74,7 @@ import {
 } from '../lib/cm-vim-clipboard'
 import { wireYankHighlight, yankHighlightExtension } from '../lib/cm-yank-highlight'
 import { vimVisualHighlightExtension } from '../lib/cm-vim-visual-highlight'
-import { frontmatterStyle } from '../lib/cm-frontmatter'
+import { frontmatterStyle, frontmatterTagExtension } from '../lib/cm-frontmatter'
 import { codeBlockFontPlugin } from '../lib/cm-code-block-font'
 import {
   orderedListRenumber,
@@ -105,6 +105,7 @@ import { hashtagExtension } from '../lib/cm-hashtags'
 import { taskMetadataExtension } from '../lib/cm-task-metadata'
 import { taskRollupExtension } from '../lib/cm-task-rollup'
 import { hashtagSource } from '../lib/cm-hashtag-complete'
+import { frontmatterTagSource } from '../lib/cm-frontmatter-tag-complete'
 import { applyHighlight, HIGHLIGHT_COLORS, highlightExtension } from '../lib/cm-highlight'
 import { wikilinkRenderExtension } from '../lib/cm-wikilink-render'
 import { mathRenderExtension } from '../lib/cm-math-render'
@@ -404,6 +405,7 @@ function markdownEditingExtensions(showHeadingLevelLabels = false): Extension[] 
     vimAwareMarkdownKeymap,
     markdownListIndentPlugin,
     frontmatterStyle,
+    frontmatterTagExtension,
     orderedListRenumber,
     forwardOnCheckboxArrow,
     headingFolding({ showLevelLabels: showHeadingLevelLabels }),
@@ -1780,6 +1782,7 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
               calloutTypeSource,
               dateShortcutSource,
               atNoteSource,
+              frontmatterTagSource,
               hashtagSource,
               wikilinkSource,
               wikilinkHeadingSource

--- a/packages/app-core/src/components/PinnedReferencePane.tsx
+++ b/packages/app-core/src/components/PinnedReferencePane.tsx
@@ -44,13 +44,14 @@ import { autocompletion } from '@codemirror/autocomplete'
 import { useStore } from '../store'
 import type { LineNumberMode } from '../store'
 import { livePreviewPlugin } from '../lib/cm-live-preview'
-import { frontmatterStyle } from '../lib/cm-frontmatter'
+import { frontmatterStyle, frontmatterTagExtension } from '../lib/cm-frontmatter'
 import { headingFolding } from '../lib/cm-heading-fold'
 import { slashCommandSource, slashCommandRender } from '../lib/cm-slash-commands'
 import { calloutTypeSource } from '../lib/cm-callouts'
 import { dateShortcutSource } from '../lib/cm-date-shortcuts'
 import { wikilinkSource, wikilinkHeadingSource } from '../lib/cm-wikilinks'
 import { hashtagSource } from '../lib/cm-hashtag-complete'
+import { frontmatterTagSource } from '../lib/cm-frontmatter-tag-complete'
 import { completionKeymapForEditor, completionNavKeymap } from '../lib/cm-completion-nav'
 import { classifyLocalAssetHref, hrefFragment, type LocalAssetKind } from '../lib/local-assets'
 import { LazyPreview as Preview } from './LazyPreview'
@@ -224,6 +225,7 @@ export function PinnedReferencePane(): JSX.Element | null {
           vimAwareMarkdownKeymap,
           markdownListIndentPlugin,
           frontmatterStyle,
+          frontmatterTagExtension,
           headingCompartment.of(
             headingFolding({ showLevelLabels: s0.showHeadingLevelLabels })
           ),
@@ -240,6 +242,7 @@ export function PinnedReferencePane(): JSX.Element | null {
               slashCommandSource,
               calloutTypeSource,
               dateShortcutSource,
+              frontmatterTagSource,
               hashtagSource,
               wikilinkSource,
               wikilinkHeadingSource

--- a/packages/app-core/src/lib/cm-frontmatter-tag-complete.test.ts
+++ b/packages/app-core/src/lib/cm-frontmatter-tag-complete.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { CompletionContext } from '@codemirror/autocomplete'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { describe, expect, it, vi } from 'vitest'
+import { frontmatterTagSource } from './cm-frontmatter-tag-complete'
+
+const meta = (path: string, folder: 'inbox' | 'trash', tags: string[]) => ({
+  path,
+  title: path.split('/').pop()!.replace(/\.md$/, ''),
+  folder,
+  siblingOrder: 0,
+  createdAt: 0,
+  updatedAt: 0,
+  size: 0,
+  tags,
+  wikilinks: [],
+  hasAttachments: false,
+  excerpt: ''
+})
+
+const storeState = vi.hoisted(() => ({
+  activeNote: { path: 'inbox/Active.md', title: 'Active', folder: 'inbox' as const, body: '' }
+})) as {
+  activeNote: { path: string; title: string; folder: 'inbox'; body: string }
+  notes: ReturnType<typeof meta>[]
+}
+storeState.notes = [
+  meta('inbox/A.md', 'inbox', ['project', 'idea', 'work/deep']),
+  meta('inbox/B.md', 'inbox', ['project', 'projectplan', 'todo']),
+  meta('trash/Old.md', 'trash', ['project', 'projecttrash'])
+]
+
+vi.mock('../store', () => {
+  const useStore = Object.assign(() => null, { getState: () => storeState })
+  return { useStore }
+})
+
+function result(doc: string, pos: number) {
+  const state = EditorState.create({ doc })
+  return frontmatterTagSource(new CompletionContext(state, pos, true))
+}
+
+describe('frontmatterTagSource', () => {
+  it('suggests tags inside an inline list', () => {
+    const doc = '---\ntags: [pro\n---\n'
+    const pos = doc.indexOf('\n---\n') // end of the tags line, before the closing fence
+    const r = result(doc, pos)
+    expect(r?.options.map((o) => o.label)).toEqual(['project', 'projectplan'])
+  })
+
+  it('suggests tags inside a scalar value', () => {
+    const doc = '---\ntags: pro\n---\n'
+    const pos = doc.indexOf('\n---\n')
+    const r = result(doc, pos)
+    expect(r?.options.map((o) => o.label)).toEqual(['project', 'projectplan'])
+  })
+
+  it('suggests tags inside a block list under a bare tags key', () => {
+    const doc = '---\ntags:\n  - pro\n---\n'
+    const pos = doc.indexOf('\n---\n')
+    const r = result(doc, pos)
+    expect(r?.options.map((o) => o.label)).toEqual(['project', 'projectplan'])
+  })
+
+  it('does not suggest outside frontmatter', () => {
+    expect(result('tags: pro', 'tags: pro'.length)).toBeNull()
+    expect(result('---\nbody\n---\ntags: pro', '---\nbody\n---\ntags: pro'.length)).toBeNull()
+  })
+
+  it('does not suggest on other frontmatter keys', () => {
+    expect(result('---\ntitle: pro\n---\n', '---\ntitle: pro'.length)).toBeNull()
+  })
+
+  it('does not suggest before the list marker', () => {
+    const doc = '---\ntags:\n  - \n---\n'
+    const pos = '---\ntags:\n  - '.length
+    expect(result(doc, pos)).toBeNull()
+  })
+
+  it('does not suggest while the cursor is still in the key', () => {
+    const doc = '---\ntags: pro\n---\n'
+    const pos = '---\ntags'.length
+    expect(result(doc, pos)).toBeNull()
+  })
+
+  it('inserts the tag without a leading hash', () => {
+    const parent = document.createElement('div')
+    document.body.append(parent)
+    const doc = '---\ntags: [pro]\n---\n'
+    const view = new EditorView({ parent, state: EditorState.create({ doc }) })
+    const pos = doc.indexOf(']')
+    const r = frontmatterTagSource(new CompletionContext(view.state, pos, true))
+    const option = r?.options.find((o) => o.label === 'project')
+    if (typeof option?.apply !== 'function') throw new Error('expected apply function')
+    option.apply(view, option, r!.from, pos)
+    expect(view.state.doc.toString()).toBe('---\ntags: [project]\n---\n')
+    view.destroy()
+    parent.remove()
+  })
+
+  it('keeps surrounding quotes intact', () => {
+    const parent = document.createElement('div')
+    document.body.append(parent)
+    const doc = '---\ntags: ["pro"]\n---\n'
+    const view = new EditorView({ parent, state: EditorState.create({ doc }) })
+    const pos = doc.indexOf('"]')
+    const r = frontmatterTagSource(new CompletionContext(view.state, pos, true))
+    const option = r?.options.find((o) => o.label === 'project')
+    if (typeof option?.apply !== 'function') throw new Error('expected apply function')
+    option.apply(view, option, r!.from, pos)
+    expect(view.state.doc.toString()).toBe('---\ntags: ["project"]\n---\n')
+    view.destroy()
+    parent.remove()
+  })
+
+  it('consumes a stray leading # when completing', () => {
+    const parent = document.createElement('div')
+    document.body.append(parent)
+    const doc = '---\ntags: [#pro]\n---\n'
+    const view = new EditorView({ parent, state: EditorState.create({ doc }) })
+    const pos = doc.indexOf(']')
+    const r = frontmatterTagSource(new CompletionContext(view.state, pos, true))
+    const option = r?.options.find((o) => o.label === 'project')
+    if (typeof option?.apply !== 'function') throw new Error('expected apply function')
+    option.apply(view, option, r!.from, pos)
+    expect(view.state.doc.toString()).toBe('---\ntags: [project]\n---\n')
+    view.destroy()
+    parent.remove()
+  })
+})

--- a/packages/app-core/src/lib/cm-frontmatter-tag-complete.ts
+++ b/packages/app-core/src/lib/cm-frontmatter-tag-complete.ts
@@ -1,0 +1,107 @@
+/**
+ * Frontmatter `tags:` autocomplete. Typing inside the value of a frontmatter
+ * `tags:` field (inline list, scalar, or block-list form) surfaces the same
+ * existing-tag suggestions as inline `#tags`, but without the leading `#`.
+ */
+import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete'
+import type { EditorState } from '@codemirror/state'
+import { collectTagCounts, rankTagCompletions } from './cm-hashtag-complete'
+import { isInsideFrontmatter } from './cm-frontmatter'
+
+/** Characters that terminate a tag token when scanning forward or backward
+ *  for the *body* of the token. A leading `#` is intentionally not a start
+ *  delimiter: if someone types `#pro` in a frontmatter value, the `#` is
+ *  consumed and replaced with the selected tag. */
+const TOKEN_BODY_DELIMITERS = /[\s,\[\]"'#]/
+const TOKEN_START_DELIMITERS = /[\s,\[\]"']/ 
+
+function tokenEndAt(state: EditorState, pos: number): number {
+  const line = state.doc.lineAt(pos)
+  const text = line.text
+  const col = pos - line.from
+  let i = col
+  while (i < text.length && !TOKEN_BODY_DELIMITERS.test(text[i] as string)) i++
+  return line.from + i
+}
+
+function tagTokenAt(
+  state: EditorState,
+  lineStart: number,
+  valueStart: number,
+  pos: number
+): { from: number; query: string } | null {
+  const line = state.doc.lineAt(lineStart)
+  const text = line.text
+  const cursor = pos - line.from
+  if (cursor < valueStart) return null
+  let i = cursor - 1
+  while (i >= valueStart && !TOKEN_START_DELIMITERS.test(text[i] as string)) i--
+  const tokenStart = i + 1
+  const token = text.slice(tokenStart, cursor)
+  if (token.length < 1) return null
+  return { from: line.from + tokenStart, query: token.replace(/^#/, '') }
+}
+
+function isUnderTagsKey(state: EditorState, lineNo: number): boolean {
+  for (let i = lineNo - 1; i >= 2; i--) {
+    const text = state.doc.line(i).text
+    const trimmed = text.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const key = text.match(/^([A-Za-z0-9_][\w-]*)\s*:\s*(.*)$/)
+    if (key) {
+      return key[1].toLowerCase() === 'tags' && key[2].trim() === ''
+    }
+    if (/^\s*-\s+/.test(text)) continue
+    return false
+  }
+  return false
+}
+
+function frontmatterTagMatch(context: CompletionContext): { from: number; query: string } | null {
+  const { state, pos } = context
+  if (!isInsideFrontmatter(state, pos)) return null
+  const line = state.doc.lineAt(pos)
+  const text = line.text
+  const col = pos - line.from
+
+  const inline = text.match(/^(\s*)tags\s*:\s*(.*)$/)
+  if (inline) {
+    const valueStart = inline[0].length - (inline[2] as string).length
+    if (col < valueStart) return null
+    return tagTokenAt(state, line.from, valueStart, pos)
+  }
+
+  const item = text.match(/^(\s*)-\s+(.*)$/)
+  if (item) {
+    if (!isUnderTagsKey(state, line.number)) return null
+    const valueStart = item[0].length - (item[2] as string).length
+    if (col < valueStart) return null
+    return tagTokenAt(state, line.from, valueStart, pos)
+  }
+
+  return null
+}
+
+export function frontmatterTagSource(context: CompletionContext): CompletionResult | null {
+  const match = frontmatterTagMatch(context)
+  if (!match || match.query.length < 1) return null
+
+  const ranked = rankTagCompletions(match.query, collectTagCounts())
+  if (ranked.length === 0) return null
+
+  const options: Completion[] = ranked.map(({ tag, count }) => ({
+    label: tag,
+    displayLabel: tag,
+    detail: count > 1 ? `${count}` : '',
+    _icon: '#',
+    apply: (view, _completion, _from, to) => {
+      const end = tokenEndAt(view.state, to)
+      view.dispatch({
+        changes: { from: match.from, to: end, insert: tag },
+        selection: { anchor: match.from + tag.length }
+      })
+    }
+  }))
+
+  return { from: match.from, options, filter: false }
+}

--- a/packages/app-core/src/lib/cm-frontmatter-tag.test.ts
+++ b/packages/app-core/src/lib/cm-frontmatter-tag.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { frontmatterTagExtension } from './cm-frontmatter'
+
+const openTagView = vi.fn()
+
+vi.mock('../store', () => {
+  const useStore = Object.assign(() => null, {
+    getState: () => ({ openTagView })
+  })
+  return { useStore }
+})
+
+const views: EditorView[] = []
+function mount(doc: string): EditorView {
+  const parent = document.createElement('div')
+  document.body.append(parent)
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({ doc, extensions: [frontmatterTagExtension] })
+  })
+  views.push(view)
+  return view
+}
+
+afterEach(() => {
+  openTagView.mockClear()
+  while (views.length) views.pop()!.destroy()
+})
+
+function tagsIn(view: EditorView): string[] {
+  return Array.from(view.dom.querySelectorAll('.cm-frontmatter-tag')).map(
+    (el) => (el as HTMLElement).dataset.tag ?? ''
+  )
+}
+
+describe('frontmatterTagExtension', () => {
+  it('marks inline list tags and strips quotes', () => {
+    const view = mount(['---', 'tags: [idea, "work/deep", \'project\']', '---', ''].join('\n'))
+    expect(tagsIn(view)).toEqual(['idea', 'work/deep', 'project'])
+  })
+
+  it('marks scalar tags split by comma or whitespace', () => {
+    const view = mount(['---', 'tags: daily, work', '---', ''].join('\n'))
+    expect(tagsIn(view)).toEqual(['daily', 'work'])
+  })
+
+  it('marks block list tags under a bare tags key', () => {
+    const view = mount(['---', 'tags:', '  - idea', '  - "project"', '---', ''].join('\n'))
+    expect(tagsIn(view)).toEqual(['idea', 'project'])
+  })
+
+  it('strips a stray leading # from frontmatter tags', () => {
+    const view = mount(['---', 'tags: [#idea]', '---', ''].join('\n'))
+    expect(tagsIn(view)).toEqual(['idea'])
+  })
+
+  it('does not mark tags on other frontmatter keys', () => {
+    const view = mount(['---', 'title: idea', '---', ''].join('\n'))
+    expect(tagsIn(view)).toEqual([])
+  })
+
+  it('does not mark tags outside frontmatter', () => {
+    const view = mount(['---', 'title: x', '---', '', 'tags: idea'].join('\n'))
+    expect(tagsIn(view)).toEqual([])
+  })
+
+  it('opens the tag view when a frontmatter tag is clicked', () => {
+    const view = mount(['---', 'tags: [idea]', '---', ''].join('\n'))
+    const el = view.dom.querySelector('.cm-frontmatter-tag') as HTMLElement | null
+    expect(el).not.toBeNull()
+    el!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }))
+    expect(openTagView).toHaveBeenCalledWith('idea')
+  })
+})

--- a/packages/app-core/src/lib/cm-frontmatter.ts
+++ b/packages/app-core/src/lib/cm-frontmatter.ts
@@ -5,7 +5,7 @@
  * database "record page" notes (whose properties live in frontmatter) read like
  * a property list rather than a wall of big text.
  */
-import { RangeSetBuilder } from '@codemirror/state'
+import { type EditorState, RangeSetBuilder } from '@codemirror/state'
 import {
   Decoration,
   type DecorationSet,
@@ -13,6 +13,27 @@ import {
   ViewPlugin,
   type ViewUpdate
 } from '@codemirror/view'
+import { useStore } from '../store'
+
+/** Range of a closed leading `---` … `---` frontmatter block, or null if the
+ *  document does not start with one. Used by autocomplete to avoid offering
+ *  inline `#tags` inside frontmatter and to offer tags inside frontmatter
+ *  `tags:` fields. */
+export function frontmatterRange(state: EditorState): { from: number; to: number } | null {
+  const doc = state.doc
+  if (doc.lines < 2 || doc.line(1).text.trim() !== '---') return null
+  for (let i = 2; i <= doc.lines; i++) {
+    if (doc.line(i).text.trim() === '---') {
+      return { from: doc.line(1).from, to: doc.line(i).to }
+    }
+  }
+  return null
+}
+
+export function isInsideFrontmatter(state: EditorState, pos: number): boolean {
+  const range = frontmatterRange(state)
+  return range != null && pos >= range.from && pos <= range.to
+}
 
 const FRONTMATTER_LINE = Decoration.line({ class: 'cm-frontmatter-line' })
 const FRONTMATTER_TOP = Decoration.line({ class: 'cm-frontmatter-line cm-frontmatter-top' })
@@ -21,27 +42,21 @@ const FRONTMATTER_KEY = Decoration.mark({ class: 'cm-frontmatter-key' })
 
 function buildFrontmatterDeco(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>()
+  const range = frontmatterRange(view.state)
+  if (!range) return builder.finish()
   const doc = view.state.doc
-  // Frontmatter must start on line 1 with an exact `---` fence.
-  if (doc.lines < 2 || doc.line(1).text.trim() !== '---') return builder.finish()
-  let endLine = -1
-  for (let i = 2; i <= doc.lines; i++) {
-    if (doc.line(i).text.trim() === '---') {
-      endLine = i
-      break
-    }
-  }
-  if (endLine === -1) return builder.finish()
-  for (let i = 1; i <= endLine; i++) {
+  const startLine = doc.lineAt(range.from).number
+  const endLine = doc.lineAt(range.to).number
+  for (let i = startLine; i <= endLine; i++) {
     const line = doc.line(i)
     // Line decoration first (its start side sorts before any mark at the same
     // offset), then the key mark for property lines.
     builder.add(
       line.from,
       line.from,
-      i === 1 ? FRONTMATTER_TOP : i === endLine ? FRONTMATTER_BOTTOM : FRONTMATTER_LINE
+      i === startLine ? FRONTMATTER_TOP : i === endLine ? FRONTMATTER_BOTTOM : FRONTMATTER_LINE
     )
-    if (i !== 1 && i !== endLine) {
+    if (i !== startLine && i !== endLine) {
       // Mark the key (text before the first `:`) so it reads as a muted label
       // next to its value — a metadata panel, not a wall of text.
       const colon = line.text.indexOf(':')
@@ -63,3 +78,109 @@ export const frontmatterStyle = ViewPlugin.fromClass(
   },
   { decorations: (v) => v.decorations }
 )
+
+const TAG_TOKEN_RE = /[^,\s\[\]"'#]+/g
+
+/** Which frontmatter lines are `- item` entries under a bare `tags:` key. */
+function tagsBlockLineNumbers(state: EditorState): Set<number> {
+  const range = frontmatterRange(state)
+  if (!range) return new Set()
+  const doc = state.doc
+  const startLine = doc.lineAt(range.from).number
+  const endLine = doc.lineAt(range.to).number
+  const lines = new Set<number>()
+  let inTags = false
+  for (let n = startLine + 1; n < endLine; n++) {
+    const text = doc.line(n).text
+    const trimmed = text.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const key = text.match(/^([A-Za-z0-9_][\w-]*)\s*:\s*(.*)$/)
+    if (key) {
+      inTags = key[1].toLowerCase() === 'tags' && key[2].trim() === ''
+      continue
+    }
+    if (inTags && /^\s*-\s+/.test(text)) {
+      lines.add(n)
+      continue
+    }
+    if (!/^\s/.test(text)) inTags = false
+  }
+  return lines
+}
+
+function addTagTokens(value: string, valueStartAbs: number, builder: RangeSetBuilder<Decoration>): void {
+  TAG_TOKEN_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = TAG_TOKEN_RE.exec(value)) !== null) {
+    const token = m[0]
+    const tag = token.replace(/^#/, '')
+    if (!tag) continue
+    const from = valueStartAbs + m.index + (token.length - tag.length)
+    const to = from + tag.length
+    builder.add(
+      from,
+      to,
+      Decoration.mark({ class: 'cm-frontmatter-tag', attributes: { 'data-tag': tag } })
+    )
+  }
+}
+
+function buildFrontmatterTagDeco(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>()
+  const range = frontmatterRange(view.state)
+  if (!range) return builder.finish()
+  const doc = view.state.doc
+  const startLine = doc.lineAt(range.from).number
+  const endLine = doc.lineAt(range.to).number
+  const blockLines = tagsBlockLineNumbers(view.state)
+  for (let n = startLine + 1; n < endLine; n++) {
+    const line = doc.line(n)
+    const text = line.text
+    const trimmed = text.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const inline = text.match(/^(\s*)tags\s*:\s*(.*)$/)
+    if (inline) {
+      const value = inline[2] as string
+      const valueStart = line.from + inline[0].length - value.length
+      addTagTokens(value, valueStart, builder)
+      continue
+    }
+    if (blockLines.has(n)) {
+      const item = text.match(/^(\s*)-\s+(.*)$/)
+      if (item) {
+        const value = item[2] as string
+        const valueStart = line.from + item[0].length - value.length
+        addTagTokens(value, valueStart, builder)
+      }
+    }
+  }
+  return builder.finish()
+}
+
+const frontmatterTagPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet
+    constructor(view: EditorView) {
+      this.decorations = buildFrontmatterTagDeco(view)
+    }
+    update(update: ViewUpdate): void {
+      if (update.docChanged) this.decorations = buildFrontmatterTagDeco(update.view)
+    }
+  },
+  { decorations: (v) => v.decorations }
+)
+
+// Clicking a frontmatter tag opens the tag view, mirroring inline hashtags.
+const frontmatterTagClick = EditorView.domEventHandlers({
+  mousedown: (event) => {
+    const target = event.target as HTMLElement | null
+    const el = target?.closest<HTMLElement>('.cm-frontmatter-tag')
+    const tag = el?.dataset.tag
+    if (!tag) return false
+    event.preventDefault()
+    void useStore.getState().openTagView(tag)
+    return true
+  }
+})
+
+export const frontmatterTagExtension = [frontmatterTagPlugin, frontmatterTagClick]

--- a/packages/app-core/src/lib/cm-hashtag-complete.test.ts
+++ b/packages/app-core/src/lib/cm-hashtag-complete.test.ts
@@ -96,6 +96,11 @@ describe('hashtagSource (#410 — hashtag autocomplete)', () => {
     expect(result('#project')?.options.map((o) => o.label)).toEqual(['projectplan'])
   })
 
+  it('does not suggest inside frontmatter', () => {
+    const doc = '---\ntags: #pro\n---\n'
+    expect(result(doc)).toBeNull()
+  })
+
   it('does not suggest inside a fenced code block', () => {
     const parent = document.createElement('div')
     document.body.append(parent)

--- a/packages/app-core/src/lib/cm-hashtag-complete.ts
+++ b/packages/app-core/src/lib/cm-hashtag-complete.ts
@@ -16,6 +16,7 @@ import { useStore } from '../store'
 import { noteTagsForCount } from './tags'
 import { resolveTypstPreambleFolder } from './typst-preamble'
 import { isTagSkippedContext } from './cm-hashtags'
+import { isInsideFrontmatter } from './cm-frontmatter'
 
 /** Completion carrying the `_icon` the shared slash renderer reads. */
 type HashtagCompletion = Completion & { _icon?: string }
@@ -43,7 +44,7 @@ function hashtagMatch(context: CompletionContext): { from: number; query: string
  * them. The active note is read live from its buffer so a tag just typed in the
  * same note is offered too. Mirrors the aggregation in `TagView`.
  */
-function collectTagCounts(): Map<string, number> {
+export function collectTagCounts(): Map<string, number> {
   const state = useStore.getState()
   const activePath = state.activeNote?.path ?? null
   const activeBody = state.activeNote?.body ?? null
@@ -61,28 +62,34 @@ function collectTagCounts(): Map<string, number> {
   return counter
 }
 
+export interface RankedTag { tag: string; count: number }
+
+/** Rank vault tags for `query` so prefix matches beat substring matches, and
+ *  more-used tags beat less-used ones. Excludes the exact tag already typed. */
+export function rankTagCompletions(query: string, counts: Map<string, number>): RankedTag[] {
+  const q = query.toLowerCase()
+  return [...counts.entries()]
+    .map(([tag, count]) => {
+      const lower = tag.toLowerCase()
+      const rank = lower.startsWith(q) ? 0 : lower.includes(q) ? 1 : 2
+      return { tag, lower, count, rank }
+    })
+    .filter((t) => t.rank < 2 && t.lower !== q)
+    .sort((a, b) => a.rank - b.rank || b.count - a.count || a.tag.localeCompare(b.tag))
+    .slice(0, MAX_SUGGESTIONS)
+    .map(({ tag, count }) => ({ tag, count }))
+}
+
 export function hashtagSource(context: CompletionContext): CompletionResult | null {
   const match = hashtagMatch(context)
   // Require at least one character after `#` so a bare `#` (headings, an empty
   // token) doesn't flash the menu; suggestions appear once a tag is being typed.
   if (!match || match.query.length < 1) return null
-  // Don't suggest where a `#` isn't a tag (code spans/blocks, headings).
+  // Don't suggest where a `#` isn't a tag (code spans/blocks, headings, frontmatter).
   if (isTagSkippedContext(context.state, context.pos)) return null
+  if (isInsideFrontmatter(context.state, context.pos)) return null
 
-  const q = match.query.toLowerCase()
-  const ranked = [...collectTagCounts().entries()]
-    .map(([tag, count]) => {
-      const lower = tag.toLowerCase()
-      // Prefix matches rank above substring matches; then by usage, then name.
-      const rank = lower.startsWith(q) ? 0 : lower.includes(q) ? 1 : 2
-      return { tag, lower, count, rank }
-    })
-    // Drop non-matches and the exact tag already typed — completing to what's
-    // on screen is a no-op, and the live buffer read would otherwise suggest the
-    // in-progress tag back to itself.
-    .filter((t) => t.rank < 2 && t.lower !== q)
-    .sort((a, b) => a.rank - b.rank || b.count - a.count || a.tag.localeCompare(b.tag))
-    .slice(0, MAX_SUGGESTIONS)
+  const ranked = rankTagCompletions(match.query, collectTagCounts())
   if (ranked.length === 0) return null
 
   const options: Completion[] = ranked.map(

--- a/packages/app-core/src/styles/index.css
+++ b/packages/app-core/src/styles/index.css
@@ -5372,6 +5372,19 @@ html[data-completed-task-style="gray-strikethrough"] .prose-zen li.task-list-ite
   background-color: rgb(var(--z-accent) / 0.2);
 }
 
+/* Frontmatter `tags:` values are also clickable chips, styled a little smaller
+   than inline hashtags so they sit comfortably in the compact metadata block. */
+.cm-wysiwyg .cm-editor .cm-frontmatter-tag {
+  color: rgb(var(--z-accent));
+  cursor: pointer;
+  border-radius: 0.35em;
+  padding: 0.05em 0.35em;
+  background-color: rgb(var(--z-accent) / 0.08);
+}
+.cm-wysiwyg .cm-editor .cm-frontmatter-tag:hover {
+  background-color: rgb(var(--z-accent) / 0.15);
+}
+
 /* Task metadata on task lines (#454): priorities, due dates, and @fields get
    the same at-a-glance cues as the Tasks view, so they stand out from the task
    text. All three are chips — a tinted background plus the coloured text — and


### PR DESCRIPTION
This change makes frontmatter `tags:` values behave more like inline `#tags`:

- Typing inside a frontmatter `tags:` field (inline list, scalar, or block list) now suggests existing vault tags.
- Frontmatter tags are now rendered as clickable chips; clicking one opens the tag view.
- Inline `#tag` autocomplete is suppressed inside frontmatter so the two sources don't clash.
- Leading `#` in frontmatter tag values is stripped for both autocomplete and click targets.

<img width="1032" height="515" alt="SCR-20260814-sgdz" src="https://github.com/user-attachments/assets/3d1ff8c4-cd29-4ef6-a4ce-75b5bf78310b" />
