### PR TITLE
nix: fix desktop wrapper GPU crash-loop and ozone flag expansion

### DIFF
--- a/packaging/nix/package-desktop.nix
+++ b/packaging/nix/package-desktop.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   autoPatchelfHook,
-  makeWrapper,
+  makeShellWrapper,
   wrapGAppsHook3,
   copyDesktopItems,
   makeDesktopItem,
@@ -24,6 +24,7 @@
   gtk3,
   libdrm,
   libGL,
+  libglvnd,
   libgbm,
   libnotify,
   libpulseaudio,
@@ -58,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    makeWrapper
+    makeShellWrapper
     wrapGAppsHook3
     copyDesktopItems
   ];
@@ -100,9 +101,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # dlopen'd at runtime (not in DT_NEEDED), so keep them on the wrapper's path.
+  # libglvnd provides libEGL.so.1, which ANGLE dlopens; without it the GPU
+  # process crash-loops and the window never maps.
   runtimeDependencies = [
     (lib.getLib systemd)
     libGL
+    libglvnd
     libnotify
     libpulseaudio
     wayland
@@ -110,7 +114,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontConfigure = true;
   dontBuild = true;
-  # We invoke makeWrapper manually and splice in gappsWrapperArgs ourselves.
+  # We invoke the wrapper manually and splice in gappsWrapperArgs ourselves.
+  # Must be makeShellWrapper: wrapGAppsHook3 propagates makeBinaryWrapper,
+  # whose binary wrapper can't expand ''${NIXOS_OZONE_WL:+…} at runtime — the
+  # flag reaches Electron as a literal string instead.
   dontWrapGApps = true;
 
   installPhase = ''
@@ -129,8 +136,9 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 "$icon" "$out/share/icons/hicolor/$size/apps/${finalAttrs.pname}.png"
     done
 
-    makeWrapper $out/share/zennotes/ZenNotes $out/bin/${finalAttrs.pname} \
+    makeShellWrapper $out/share/zennotes/ZenNotes $out/bin/${finalAttrs.pname} \
       "''${gappsWrapperArgs[@]}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libglvnd ]}" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto}}" \
       ${lib.optionalString (commandLineArgs != "") "--add-flags ${lib.escapeShellArg commandLineArgs}"}
 


### PR DESCRIPTION
## Problem

On NixOS (tested 26.05, Hyprland/Wayland, amdgpu), `zennotes-desktop` from this repo's flake starts but **never opens a window**. Two independent wrapper bugs:

### 1. GPU process crash-loop: `libEGL.so.1` not found

```
ERROR:ui/gl/angle_platform_impl.cc:47] Display.cpp:1097 (initialize): ANGLE Display::initialize error 12289: Could not dlopen native EGL: libEGL.so.1: cannot open shared object file
ERROR:components/viz/service/main/viz_main_impl.cc:189] Exiting GPU process due to errors during initialization
```

The dlopen happens inside the bundled ANGLE (`libGLESv2.so`), whose RUNPATH `autoPatchelfHook` does not extend via `runtimeDependencies` — RUNPATH is not transitive from the main binary, so adding libglvnd there alone doesn't help. Fixed by adding `libglvnd` and prefixing it on the wrapper's `LD_LIBRARY_PATH`.

### 2. Ozone flag reaches Electron as a literal string

`ps` shows the actual argv:

```
…/share/zennotes/ZenNotes ${NIXOS_OZONE_WL:+${WAYLAND_DISPLAY:+--ozone-platform-hint=auto}}
```

`wrapGAppsHook3` propagates `makeBinaryWrapper`, which overrides the `makeWrapper` shell function with a compiled wrapper that can't do runtime `${VAR:+…}` expansion. Switched to an explicit `makeShellWrapper` (the same pattern nixpkgs uses for vscode and other Electron apps), so the flag expands and the app runs native Wayland.

## Verified

Built `.#zennotes-desktop` from this branch on NixOS 26.05:
- no EGL errors, GPU process stays up, window maps normally
- argv is now `…/ZenNotes --ozone-platform-hint=auto` under a Wayland session

Side note for anyone debugging this: when launched from a compositor's `exec-once` (piped stdout that nothing drains), the pre-fix hang could wedge the main process in an uninterruptible pipe write, leaving unkillable D-state processes whose singleton lock then blocks all subsequent launches.