### PR TITLE
ZenNotes 2.31.0: large files sync for real

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/desktop",
   "productName": "ZenNotes",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "ZenNotes desktop shell",
   "private": true,
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/cloud-sync-client.test.ts
+++ b/apps/desktop/src/main/cloud-sync-client.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import type { CloudSyncUpsertMutation } from '@zennotes/bridge-contract/cloud-sync'
 import { CloudServiceRequestError, createCloudSyncClient } from './cloud-sync-client'
+import { rememberCloudSyncUploadSource } from './cloud-sync-upload-source'
+
+const INLINE_UPLOAD_LIMIT_BYTES = 5 * 1024 * 1024
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true })
+    )
+  )
+})
 
 describe('createCloudSyncClient', () => {
   it('authenticates requests without exposing the token in the URL', async () => {
@@ -117,4 +133,326 @@ describe('createCloudSyncClient', () => {
     expect(options?.body).toBeInstanceOf(FormData)
     expect(new Headers(options?.headers).has('Content-Type')).toBe(false)
   })
+
+  it('keeps files at the inline limit in the mutation request', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ acknowledged: [], conflicts: [], cursor: 0 }))
+    const client = createCloudSyncClient('https://zennotes.org', 'token', fetchImplementation)
+
+    await client.mutate('vault-1', {
+      mutations: [upsertMutation(INLINE_UPLOAD_LIMIT_BYTES, 'inline')]
+    })
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(1)
+    expect(fetchImplementation.mock.calls[0]?.[0]).toBe('https://zennotes.org/api/v1/vaults/vault-1/mutations')
+  })
+
+  it('uploads files above the inline limit directly without sending the bearer token', async () => {
+    const bytes = Buffer.alloc(INLINE_UPLOAD_LIMIT_BYTES + 1, 7)
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'zennotes-direct-upload-'))
+    temporaryDirectories.push(directory)
+    const sourcePath = path.join(directory, 'archive.zip')
+    await writeFile(sourcePath, bytes)
+    const mutation = upsertMutation(bytes.byteLength, '')
+    rememberCloudSyncUploadSource(mutation.content, sourcePath)
+    const acknowledgement = {
+      operation_id: mutation.operation_id,
+      item_id: mutation.item_id,
+      revision: 3,
+      sequence: 9
+    }
+    const uploadedBodies: Buffer[] = []
+    let completionAttempts = 0
+    const fetchImplementation = vi.fn<typeof fetch>(async (input, options) => {
+      const url = String(input)
+      if (url.endsWith('/uploads')) {
+        return jsonResponse(
+          {
+            data: {
+              id: 'upload-1',
+              operation_id: mutation.operation_id,
+              status: 'uploading',
+              expected_bytes: bytes.byteLength,
+              expires_at: '2026-08-19T18:30:00.000Z',
+              upload: {
+                method: 'PUT',
+                url: 'https://objects.example.test/upload-1?signature=signed',
+                headers: {
+                  'Content-Length': String(bytes.byteLength),
+                  'Content-Type': 'application/octet-stream',
+                  'X-Upload-Header': 'signed-value'
+                }
+              }
+            }
+          },
+          201
+        )
+      }
+      if (url.startsWith('https://objects.example.test/')) {
+        uploadedBodies.push(Buffer.from(await new Response(options?.body).arrayBuffer()))
+        return new Response(null, { status: 200 })
+      }
+      if (url.endsWith('/complete')) {
+        completionAttempts++
+        if (completionAttempts === 1) {
+          return jsonResponse(
+            {
+              error: { code: 'TEMPORARY_FAILURE', message: 'Try again.' }
+            },
+            503
+          )
+        }
+        return jsonResponse({
+          data: {
+            id: 'upload-1',
+            operation_id: mutation.operation_id,
+            status: 'completed',
+            result: {
+              acknowledged: [acknowledgement],
+              conflicts: [],
+              cursor: 9
+            }
+          }
+        })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    const client = createCloudSyncClient('https://zennotes.org/', 'secret-token', fetchImplementation)
+
+    const result = await client.mutate('vault-1', { mutations: [mutation] })
+
+    expect(result).toEqual({
+      acknowledged: [acknowledgement],
+      conflicts: [],
+      cursor: 9
+    })
+    expect(fetchImplementation).toHaveBeenCalledTimes(4)
+    expect(completionAttempts).toBe(2)
+
+    const initiation = fetchImplementation.mock.calls[0]
+    expect(initiation?.[0]).toBe('https://zennotes.org/api/v1/vaults/vault-1/uploads')
+    expect(JSON.parse(String(initiation?.[1]?.body))).toEqual({
+      operation_id: mutation.operation_id,
+      item_id: mutation.item_id,
+      base_revision: mutation.base_revision,
+      path: mutation.path,
+      kind: mutation.kind,
+      content: {
+        encoding: mutation.content.encoding,
+        sha256: mutation.content.sha256,
+        byte_length: mutation.content.byte_length,
+        media_type: mutation.content.media_type
+      }
+    })
+
+    const directUpload = fetchImplementation.mock.calls[1]
+    expect(directUpload?.[0]).toBe('https://objects.example.test/upload-1?signature=signed')
+    expect(directUpload?.[1]?.method).toBe('PUT')
+    expect(directUpload?.[1]?.redirect).toBe('error')
+    expect(new Headers(directUpload?.[1]?.headers)).toEqual(
+      new Headers({
+        'Content-Length': String(bytes.byteLength),
+        'Content-Type': 'application/octet-stream',
+        'X-Upload-Header': 'signed-value'
+      })
+    )
+    expect(new Headers(directUpload?.[1]?.headers).has('Authorization')).toBe(false)
+    expect(uploadedBodies[0]?.byteLength).toBe(bytes.byteLength)
+    expect(uploadedBodies[0]?.[0]).toBe(7)
+    expect(uploadedBodies[0]?.at(-1)).toBe(7)
+
+    const completion = fetchImplementation.mock.calls[3]
+    expect(completion?.[0]).toBe('https://zennotes.org/api/v1/vaults/vault-1/uploads/upload-1/complete')
+    expect(new Headers(completion?.[1]?.headers).get('Authorization')).toBe('Bearer secret-token')
+  })
+
+  it('aborts the upload reservation when object storage rejects the PUT', async () => {
+    const bytes = Buffer.alloc(INLINE_UPLOAD_LIMIT_BYTES + 1, 11)
+    const mutation = upsertMutation(bytes.byteLength, bytes.toString('base64'))
+    const fetchImplementation = vi.fn<typeof fetch>(async (input, options) => {
+      const url = String(input)
+      if (url.endsWith('/uploads') && options?.method === 'POST') {
+        return jsonResponse(
+          {
+            data: {
+              id: 'upload-2',
+              operation_id: mutation.operation_id,
+              status: 'uploading',
+              expected_bytes: bytes.byteLength,
+              expires_at: '2026-08-19T18:30:00.000Z',
+              upload: {
+                method: 'PUT',
+                url: 'https://objects.example.test/upload-2',
+                headers: { 'Content-Type': 'application/octet-stream' }
+              }
+            }
+          },
+          201
+        )
+      }
+      if (url === 'https://objects.example.test/upload-2') {
+        return new Response(null, { status: 503 })
+      }
+      if (url.endsWith('/uploads/upload-2') && options?.method === 'DELETE') {
+        return new Response(null, { status: 204 })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    const client = createCloudSyncClient('https://zennotes.org', 'token', fetchImplementation)
+
+    await expect(client.mutate('vault-1', { mutations: [mutation] })).rejects.toEqual(
+      expect.objectContaining<Partial<CloudServiceRequestError>>({
+        status: 503,
+        code: 'DIRECT_UPLOAD_FAILED'
+      })
+    )
+
+    expect(fetchImplementation.mock.calls.at(-1)?.[0]).toBe(
+      'https://zennotes.org/api/v1/vaults/vault-1/uploads/upload-2'
+    )
+    expect(fetchImplementation.mock.calls.at(-1)?.[1]?.method).toBe('DELETE')
+  })
+
+  it('rejects insecure non-local upload URLs and releases the reservation', async () => {
+    const bytes = Buffer.alloc(INLINE_UPLOAD_LIMIT_BYTES + 1, 12)
+    const mutation = upsertMutation(bytes.byteLength, bytes.toString('base64'))
+    const fetchImplementation = vi.fn<typeof fetch>(async (input, options) => {
+      const url = String(input)
+      if (url.endsWith('/uploads') && options?.method === 'POST') {
+        return jsonResponse({
+          data: {
+            id: 'upload-insecure',
+            operation_id: mutation.operation_id,
+            status: 'uploading',
+            expected_bytes: bytes.byteLength,
+            expires_at: '2026-08-19T18:30:00.000Z',
+            upload: {
+              method: 'PUT',
+              url: 'http://objects.example.test/upload-insecure',
+              headers: { 'Content-Type': 'application/octet-stream' }
+            }
+          }
+        }, 201)
+      }
+      if (url.endsWith('/uploads/upload-insecure') && options?.method === 'DELETE') {
+        return new Response(null, { status: 204 })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    const client = createCloudSyncClient('https://zennotes.org', 'token', fetchImplementation)
+
+    await expect(client.mutate('vault-1', { mutations: [mutation] })).rejects.toEqual(
+      expect.objectContaining<Partial<CloudServiceRequestError>>({
+        status: 0,
+        code: 'INSECURE_DIRECT_UPLOAD_URL'
+      })
+    )
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(2)
+    expect(fetchImplementation.mock.calls.at(-1)?.[1]?.method).toBe('DELETE')
+  })
+
+  it('rejects mismatched upload instructions before sending file contents', async () => {
+    const bytes = Buffer.alloc(INLINE_UPLOAD_LIMIT_BYTES + 1, 14)
+    const mutation = upsertMutation(bytes.byteLength, bytes.toString('base64'))
+    const fetchImplementation = vi.fn<typeof fetch>(async (input, options) => {
+      const url = String(input)
+      if (url.endsWith('/uploads') && options?.method === 'POST') {
+        return jsonResponse({
+          data: {
+            id: 'upload-mismatch',
+            operation_id: mutation.operation_id,
+            status: 'uploading',
+            expected_bytes: bytes.byteLength - 1,
+            expires_at: '2026-08-19T18:30:00.000Z',
+            upload: {
+              method: 'PUT',
+              url: 'https://objects.example.test/upload-mismatch',
+              headers: { 'Content-Type': 'application/octet-stream' }
+            }
+          }
+        }, 201)
+      }
+      if (url.endsWith('/uploads/upload-mismatch') && options?.method === 'DELETE') {
+        return new Response(null, { status: 204 })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    const client = createCloudSyncClient('https://zennotes.org', 'token', fetchImplementation)
+
+    await expect(client.mutate('vault-1', { mutations: [mutation] })).rejects.toEqual(
+      expect.objectContaining<Partial<CloudServiceRequestError>>({
+        status: 0,
+        code: 'INVALID_DIRECT_UPLOAD_RESPONSE'
+      })
+    )
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(2)
+    expect(fetchImplementation.mock.calls.at(-1)?.[1]?.method).toBe('DELETE')
+  })
+
+  it('returns direct-upload initiation conflicts through the normal sync response', async () => {
+    const bytes = Buffer.alloc(INLINE_UPLOAD_LIMIT_BYTES + 1, 13)
+    const mutation = upsertMutation(bytes.byteLength, bytes.toString('base64'))
+    const fetchImplementation = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input)
+      if (url.endsWith('/uploads')) {
+        return jsonResponse(
+          {
+            error: {
+              code: 'REVISION_CONFLICT',
+              message: 'The item changed before the upload could start.',
+              details: {
+                current_revision: 4,
+                current_path: 'attachments/archive.zip'
+              }
+            }
+          },
+          409
+        )
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    const client = createCloudSyncClient('https://zennotes.org', 'token', fetchImplementation)
+
+    await expect(client.mutate('vault-1', { mutations: [mutation] })).resolves.toEqual({
+      acknowledged: [],
+      conflicts: [
+        {
+          operation_id: mutation.operation_id,
+          item_id: mutation.item_id,
+          code: 'REVISION_CONFLICT',
+          current_revision: 4,
+          current_path: 'attachments/archive.zip'
+        }
+      ],
+      cursor: 0
+    })
+  })
 })
+
+function upsertMutation(byteLength: number, data: string): CloudSyncUpsertMutation {
+  return {
+    type: 'upsert',
+    operation_id: '4b66f4b4-08f9-4e5a-a300-686ed4ef7e92',
+    item_id: '9b0ff39e-7ace-4fae-82aa-9f80a7458543',
+    base_revision: 2,
+    path: 'attachments/archive.zip',
+    kind: 'binary',
+    content: {
+      encoding: 'base64',
+      data,
+      sha256: 'a'.repeat(64),
+      byte_length: byteLength,
+      media_type: 'application/octet-stream'
+    }
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}

--- a/apps/desktop/src/main/cloud-sync-client.ts
+++ b/apps/desktop/src/main/cloud-sync-client.ts
@@ -3,12 +3,40 @@ import {
   type CloudSyncHttpRequest,
   type CloudSyncHttpTransport
 } from '@zennotes/shared-domain/cloud-sync-api'
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { Readable } from 'node:stream'
+import type {
+  CloudSyncConflict,
+  CloudSyncConflictCode,
+  CloudSyncMutation,
+  CloudSyncMutationRequest,
+  CloudSyncMutationResponse,
+  CloudSyncUpsertMutation,
+  CloudSyncUploadInitiationResponse,
+  CloudSyncUploadRequest
+} from '@zennotes/bridge-contract/cloud-sync'
+import {
+  CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES,
+  cloudSyncUploadSource
+} from './cloud-sync-upload-source'
+
+const DIRECT_UPLOAD_TIMEOUT_MS = 300_000
+const DIRECT_UPLOAD_COMPLETION_ATTEMPTS = 3
+type FetchBody = NonNullable<NonNullable<Parameters<typeof fetch>[1]>['body']>
+const SYNC_CONFLICT_CODES = new Set<CloudSyncConflictCode>([
+  'REVISION_CONFLICT',
+  'PATH_CONFLICT',
+  'ITEM_DELETED',
+  'QUOTA_EXCEEDED'
+])
 
 export class CloudServiceRequestError extends Error {
   constructor(
     message: string,
     readonly status: number,
-    readonly code: string | null
+    readonly code: string | null,
+    readonly details: Record<string, unknown> | null = null
   ) {
     super(message)
     this.name = 'CloudServiceRequestError'
@@ -20,9 +48,127 @@ export function createCloudSyncClient(
   token: string,
   fetchImplementation: typeof fetch = fetch
 ): CloudSyncApiClient {
-  return new CloudSyncApiClient(
-    new BearerFetchTransport(baseUrl, token, fetchImplementation)
+  return new DesktopCloudSyncApiClient(
+    new BearerFetchTransport(baseUrl, token, fetchImplementation),
+    fetchImplementation
   )
+}
+
+class DesktopCloudSyncApiClient extends CloudSyncApiClient {
+  constructor(
+    http: CloudSyncHttpTransport,
+    private readonly fetchImplementation: typeof fetch
+  ) {
+    super(http)
+  }
+
+  override async mutate(
+    vaultId: string,
+    body: CloudSyncMutationRequest
+  ): Promise<CloudSyncMutationResponse> {
+    if (!body.mutations.some(usesDirectUpload)) return super.mutate(vaultId, body)
+
+    const responses: CloudSyncMutationResponse[] = []
+    let inlineMutations: CloudSyncMutation[] = []
+    const flushInline = async (): Promise<void> => {
+      if (inlineMutations.length === 0) return
+      responses.push(await super.mutate(vaultId, { mutations: inlineMutations }))
+      inlineMutations = []
+    }
+
+    for (const mutation of body.mutations) {
+      if (usesDirectUpload(mutation)) {
+        await flushInline()
+        responses.push(await this.directUpload(vaultId, mutation))
+      } else {
+        inlineMutations.push(mutation)
+      }
+    }
+    await flushInline()
+
+    return {
+      acknowledged: responses.flatMap((response) => response.acknowledged),
+      conflicts: responses.flatMap((response) => response.conflicts),
+      cursor: Math.max(0, ...responses.map((response) => response.cursor))
+    }
+  }
+
+  private async directUpload(
+    vaultId: string,
+    mutation: CloudSyncUpsertMutation
+  ): Promise<CloudSyncMutationResponse> {
+    const uploadBody = await prepareDirectUploadBody(mutation)
+
+    let initiation: CloudSyncUploadInitiationResponse
+    try {
+      initiation = await this.initiateUpload(vaultId, uploadRequest(mutation))
+    } catch (error) {
+      const conflict = directUploadConflict(error, mutation)
+      if (conflict) return { acknowledged: [], conflicts: [conflict], cursor: 0 }
+      throw error
+    }
+    let instruction: CloudSyncUploadInitiationResponse['data']
+    let uploadUrl: string
+    try {
+      instruction = directUploadInstruction(initiation, mutation)
+      uploadUrl = secureDirectUploadUrl(instruction.upload.url)
+    } catch (error) {
+      const uploadId = uploadSessionId(initiation)
+      if (uploadId) await this.abortQuietly(vaultId, uploadId)
+      throw error
+    }
+    const upload = instruction.upload
+    let response: Response
+
+    try {
+      response = await this.fetchImplementation(uploadUrl, {
+        method: upload.method,
+        headers: upload.headers,
+        body: uploadBody.createBody(),
+        signal: AbortSignal.timeout(DIRECT_UPLOAD_TIMEOUT_MS),
+        redirect: 'error',
+        ...(uploadBody.stream ? { duplex: 'half' } : {})
+      })
+    } catch (error) {
+      await this.abortQuietly(vaultId, instruction.id)
+      throw error
+    }
+
+    if (!response.ok) {
+      await this.abortQuietly(vaultId, instruction.id)
+      throw new CloudServiceRequestError(
+        `ZenNotes Cloud object upload failed (${response.status}).`,
+        response.status,
+        'DIRECT_UPLOAD_FAILED'
+      )
+    }
+
+    return await this.completeDirectUpload(vaultId, instruction.id, mutation)
+  }
+
+  private async abortQuietly(vaultId: string, uploadId: string): Promise<void> {
+    await this.abortUpload(vaultId, uploadId).catch(() => {})
+  }
+
+  private async completeDirectUpload(
+    vaultId: string,
+    uploadId: string,
+    mutation: CloudSyncUpsertMutation
+  ): Promise<CloudSyncMutationResponse> {
+    for (let attempt = 1; attempt <= DIRECT_UPLOAD_COMPLETION_ATTEMPTS; attempt++) {
+      try {
+        return (await this.completeUpload(vaultId, uploadId)).data.result
+      } catch (error) {
+        const conflict = directUploadConflict(error, mutation)
+        if (conflict) return { acknowledged: [], conflicts: [conflict], cursor: 0 }
+        if (attempt === DIRECT_UPLOAD_COMPLETION_ATTEMPTS || !retryableCompletionError(error)) {
+          throw error
+        }
+      }
+    }
+
+    throw new Error('ZenNotes Cloud upload completion ended unexpectedly.')
+  }
 }
 
 class BearerFetchTransport implements CloudSyncHttpTransport {
@@ -50,7 +196,7 @@ class BearerFetchTransport implements CloudSyncHttpTransport {
         : request.body instanceof FormData
           ? request.body
           : JSON.stringify(request.body),
-      signal: AbortSignal.timeout(30_000)
+      signal: AbortSignal.timeout(request.timeoutMs ?? 30_000)
     })
     const payload = await parseJson(response)
 
@@ -59,7 +205,8 @@ class BearerFetchTransport implements CloudSyncHttpTransport {
       throw new CloudServiceRequestError(
         error?.message ?? `ZenNotes Cloud request failed (${response.status}).`,
         response.status,
-        error?.code ?? null
+        error?.code ?? null,
+        error?.details ?? null
       )
     }
 
@@ -82,17 +229,22 @@ async function parseJson(response: globalThis.Response): Promise<unknown> {
   }
 }
 
-function asErrorPayload(payload: unknown): { code?: string; message?: string } | null {
+function asErrorPayload(payload: unknown): {
+  code?: string
+  message?: string
+  details?: Record<string, unknown>
+} | null {
   if (!payload || typeof payload !== 'object') return null
   const response = payload as {
     code?: unknown
+    details?: unknown
     error?: unknown
     errors?: unknown
     message?: unknown
   }
   const candidate =
     response.error && typeof response.error === 'object'
-      ? (response.error as { code?: unknown; message?: unknown })
+      ? (response.error as { code?: unknown; details?: unknown; message?: unknown })
       : response
   const validationMessage = firstValidationMessage(response.errors)
 
@@ -102,8 +254,164 @@ function asErrorPayload(payload: unknown): { code?: string; message?: string } |
       ? { message: validationMessage }
       : typeof candidate.message === 'string'
         ? { message: candidate.message }
-        : {})
+        : {}),
+    ...(candidate.details && typeof candidate.details === 'object' && !Array.isArray(candidate.details)
+      ? { details: candidate.details as Record<string, unknown> }
+      : {})
   }
+}
+
+function usesDirectUpload(mutation: CloudSyncMutation): mutation is CloudSyncUpsertMutation {
+  return mutation.type === 'upsert' &&
+    mutation.content.byte_length > CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES
+}
+
+function uploadRequest(mutation: CloudSyncUpsertMutation): CloudSyncUploadRequest {
+  return {
+    operation_id: mutation.operation_id,
+    item_id: mutation.item_id,
+    base_revision: mutation.base_revision,
+    path: mutation.path,
+    kind: mutation.kind,
+    content: {
+      encoding: mutation.content.encoding,
+      sha256: mutation.content.sha256,
+      byte_length: mutation.content.byte_length,
+      media_type: mutation.content.media_type
+    }
+  }
+}
+
+async function prepareDirectUploadBody(
+  mutation: CloudSyncUpsertMutation
+): Promise<{ createBody(): FetchBody; stream: boolean }> {
+  const sourcePath = cloudSyncUploadSource(mutation.content)
+  if (sourcePath) {
+    const sourceStats = await stat(sourcePath)
+    if (!sourceStats.isFile() || sourceStats.size !== mutation.content.byte_length) {
+      throw directUploadSizeMismatch()
+    }
+    return {
+      createBody: () => Readable.toWeb(createReadStream(sourcePath)) as unknown as FetchBody,
+      stream: true
+    }
+  }
+
+  const bytes = uploadBytes(mutation)
+  if (bytes.byteLength !== mutation.content.byte_length) throw directUploadSizeMismatch()
+  return { createBody: () => bytes as FetchBody, stream: false }
+}
+
+function uploadBytes(mutation: CloudSyncUpsertMutation): Uint8Array {
+  if (mutation.content.encoding === 'utf8') {
+    return new TextEncoder().encode(mutation.content.data)
+  }
+  return Buffer.from(mutation.content.data, 'base64')
+}
+
+function directUploadSizeMismatch(): CloudServiceRequestError {
+  return new CloudServiceRequestError(
+    'The local file changed while ZenNotes was preparing its Cloud upload.',
+    0,
+    'DIRECT_UPLOAD_SIZE_MISMATCH'
+  )
+}
+
+function secureDirectUploadUrl(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw insecureDirectUploadUrl()
+  }
+
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  const loopback = hostname === 'localhost' || hostname === '::1' || hostname.startsWith('127.')
+  if ((url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) || url.username || url.password) {
+    throw insecureDirectUploadUrl()
+  }
+
+  return url.href
+}
+
+function directUploadInstruction(
+  initiation: CloudSyncUploadInitiationResponse,
+  mutation: CloudSyncUpsertMutation
+): CloudSyncUploadInitiationResponse['data'] {
+  const candidate = initiation as unknown as { data?: unknown }
+  if (!isRecord(candidate.data)) throw invalidDirectUploadResponse()
+  const data = candidate.data
+  if (!isRecord(data.upload)) throw invalidDirectUploadResponse()
+  const upload = data.upload
+  if (
+    data.operation_id !== mutation.operation_id ||
+    data.expected_bytes !== mutation.content.byte_length ||
+    typeof data.id !== 'string' ||
+    data.id === '' ||
+    upload.method !== 'PUT' ||
+    typeof upload.url !== 'string' ||
+    !isRecord(upload.headers) ||
+    !Object.values(upload.headers).every((value) => typeof value === 'string')
+  ) {
+    throw invalidDirectUploadResponse()
+  }
+
+  return data as unknown as CloudSyncUploadInitiationResponse['data']
+}
+
+function uploadSessionId(initiation: CloudSyncUploadInitiationResponse): string | null {
+  const candidate = initiation as unknown as { data?: unknown }
+  return isRecord(candidate.data) && typeof candidate.data.id === 'string' && candidate.data.id !== ''
+    ? candidate.data.id
+    : null
+}
+
+function invalidDirectUploadResponse(): CloudServiceRequestError {
+  return new CloudServiceRequestError(
+    'ZenNotes Cloud returned an invalid object upload instruction.',
+    0,
+    'INVALID_DIRECT_UPLOAD_RESPONSE'
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function insecureDirectUploadUrl(): CloudServiceRequestError {
+  return new CloudServiceRequestError(
+    'ZenNotes Cloud returned an insecure object upload URL.',
+    0,
+    'INSECURE_DIRECT_UPLOAD_URL'
+  )
+}
+
+function directUploadConflict(
+  error: unknown,
+  mutation: CloudSyncUpsertMutation
+): CloudSyncConflict | null {
+  if (!(error instanceof CloudServiceRequestError) || error.status !== 409 || !error.code) {
+    return null
+  }
+  if (!SYNC_CONFLICT_CODES.has(error.code as CloudSyncConflictCode)) return null
+
+  return {
+    operation_id: mutation.operation_id,
+    item_id: mutation.item_id,
+    code: error.code as CloudSyncConflictCode,
+    current_revision:
+      typeof error.details?.current_revision === 'number'
+        ? error.details.current_revision
+        : null,
+    current_path:
+      typeof error.details?.current_path === 'string'
+        ? error.details.current_path
+        : null
+  }
+}
+
+function retryableCompletionError(error: unknown): boolean {
+  return !(error instanceof CloudServiceRequestError) || error.status >= 500
 }
 
 function firstValidationMessage(errors: unknown): string | null {

--- a/apps/desktop/src/main/cloud-sync-filesystem.test.ts
+++ b/apps/desktop/src/main/cloud-sync-filesystem.test.ts
@@ -7,6 +7,10 @@ import {
   DesktopCloudSyncRepository,
   DesktopCloudSyncStateStore
 } from './cloud-sync-filesystem'
+import {
+  CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES,
+  cloudSyncUploadSource
+} from './cloud-sync-upload-source'
 import type { CloudSyncChange } from '@zennotes/bridge-contract/cloud-sync'
 import type { CloudSyncTrackedItem } from '@zennotes/shared-domain/cloud-sync-engine'
 
@@ -73,6 +77,29 @@ describe('DesktopCloudSyncRepository', () => {
     expect(items.map((item) => item.path)).toEqual(['image.png', 'note.md'])
     expect(items.find((item) => item.path === 'note.md')?.content.encoding).toBe('utf8')
     expect(items.find((item) => item.path === 'image.png')?.content.encoding).toBe('base64')
+  })
+
+  it('keeps oversized file contents out of memory and records their upload source', async () => {
+    const root = await temporaryRoot()
+    const absolutePath = path.join(root, 'archive.bin')
+    const bytes = Buffer.alloc(CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES + 1, 17)
+    await writeFile(absolutePath, bytes)
+
+    const items = await new DesktopCloudSyncRepository(root).scan()
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      path: 'archive.bin',
+      kind: 'binary',
+      content: {
+        encoding: 'base64',
+        data: '',
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+        byte_length: bytes.byteLength,
+        media_type: 'application/octet-stream'
+      }
+    })
+    expect(cloudSyncUploadSource(items[0]!.content)).toBe(absolutePath)
   })
 
   it('keeps device-local workspace state out of scans and ignores remote workspace mutations', async () => {

--- a/apps/desktop/src/main/cloud-sync-filesystem.ts
+++ b/apps/desktop/src/main/cloud-sync-filesystem.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { constants as fsConstants, promises as fs } from 'node:fs'
+import { constants as fsConstants, createReadStream, promises as fs } from 'node:fs'
 import path from 'node:path'
 import type {
   CloudSyncChange,
@@ -26,6 +26,10 @@ import type {
   CloudSyncState,
   CloudSyncTrackedItem
 } from '@zennotes/shared-domain/cloud-sync-engine'
+import {
+  CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES,
+  rememberCloudSyncUploadSource
+} from './cloud-sync-upload-source'
 
 const TEXT_EXTENSIONS = new Set([
   '.base',
@@ -162,11 +166,11 @@ export class DesktopCloudSyncRepository implements CloudSyncRepository {
       if (entry.isDirectory() && shouldTraverseCloudSyncDirectory(relPath)) {
         await this.walk(absolutePath, relPath, items)
       } else if (entry.isFile() && shouldSyncVaultPath(relPath)) {
-        const bytes = await fs.readFile(absolutePath)
+        const content = await encodeFileContent(relPath, absolutePath)
         items.push({
           path: normalizeCloudSyncPath(relPath),
-          kind: isText(relPath, bytes) ? 'text' : 'binary',
-          content: encodeContent(relPath, bytes)
+          kind: content.encoding === 'utf8' ? 'text' : 'binary',
+          content
         })
       }
     }
@@ -318,6 +322,75 @@ function encodeContent(relPath: string, bytes: Buffer): CloudSyncContent {
     byte_length: bytes.byteLength,
     media_type: mediaType(relPath, text)
   }
+}
+
+async function encodeFileContent(relPath: string, absolutePath: string): Promise<CloudSyncContent> {
+  const stats = await fs.stat(absolutePath)
+  if (stats.size <= CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES) {
+    const bytes = await fs.readFile(absolutePath)
+    if (bytes.byteLength <= CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES) {
+      return encodeContent(relPath, bytes)
+    }
+    return directUploadContent(relPath, absolutePath, bytes)
+  }
+
+  const hash = createHash('sha256')
+  let byteLength = 0
+  let text = TEXT_EXTENSIONS.has(path.extname(relPath).toLowerCase())
+  const decoder = text ? new TextDecoder('utf-8', { fatal: true }) : null
+
+  for await (const chunk of createReadStream(absolutePath)) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    byteLength += bytes.byteLength
+    hash.update(bytes)
+    if (text && decoder) {
+      try {
+        decoder.decode(bytes, { stream: true })
+      } catch {
+        text = false
+      }
+    }
+  }
+
+  if (text && decoder) {
+    try {
+      decoder.decode()
+    } catch {
+      text = false
+    }
+  }
+
+  if (byteLength <= CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES) {
+    const bytes = await fs.readFile(absolutePath)
+    return bytes.byteLength <= CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES
+      ? encodeContent(relPath, bytes)
+      : directUploadContent(relPath, absolutePath, bytes)
+  }
+
+  return rememberCloudSyncUploadSource(
+    {
+      encoding: text ? 'utf8' : 'base64',
+      data: '',
+      sha256: hash.digest('hex'),
+      byte_length: byteLength,
+      media_type: mediaType(relPath, text)
+    },
+    absolutePath
+  )
+}
+
+function directUploadContent(relPath: string, absolutePath: string, bytes: Buffer): CloudSyncContent {
+  const text = isText(relPath, bytes)
+  return rememberCloudSyncUploadSource(
+    {
+      encoding: text ? 'utf8' : 'base64',
+      data: '',
+      sha256: sha256(bytes),
+      byte_length: bytes.byteLength,
+      media_type: mediaType(relPath, text)
+    },
+    absolutePath
+  )
 }
 
 function decodeContent(content: CloudSyncContent): Buffer {

--- a/apps/desktop/src/main/cloud-sync-upload-source.ts
+++ b/apps/desktop/src/main/cloud-sync-upload-source.ts
@@ -1,0 +1,14 @@
+import type { CloudSyncContent } from '@zennotes/bridge-contract/cloud-sync'
+
+export const CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES = 5 * 1024 * 1024
+
+const uploadSources = new WeakMap<CloudSyncContent, string>()
+
+export function rememberCloudSyncUploadSource(content: CloudSyncContent, absolutePath: string): CloudSyncContent {
+  uploadSources.set(content, absolutePath)
+  return content
+}
+
+export function cloudSyncUploadSource(content: CloudSyncContent): string | null {
+  return uploadSources.get(content) ?? null
+}

--- a/apps/desktop/src/main/login-shell-path.test.ts
+++ b/apps/desktop/src/main/login-shell-path.test.ts
@@ -1,8 +1,33 @@
+import { accessSync, constants as fsConstants } from 'node:fs'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
-import { describe, expect, it } from 'vitest'
-import { resolveCommandViaLoginShell } from './login-shell-path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  probeNvmInstall,
+  resetLoginShellResolutionForTests,
+  resolveCommandViaLoginShell
+} from './login-shell-path'
 
 const onPosix = process.platform !== 'win32'
+
+function shellExists(shellPath: string): boolean {
+  try {
+    accessSync(shellPath, fsConstants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// The interactive-shell test needs a real zsh or bash to source rc files.
+const interactiveShell = ['/bin/zsh', '/bin/bash'].find(shellExists) ?? null
+
+async function makeExecutable(filePath: string, body = '#!/bin/sh\nexit 0\n'): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, body)
+  await chmod(filePath, 0o755)
+}
 
 describe('resolveCommandViaLoginShell', () => {
   // The core of issue #73: GUI apps inherit a minimal PATH, so a bare command
@@ -24,5 +49,96 @@ describe('resolveCommandViaLoginShell', () => {
     expect(await resolveCommandViaLoginShell('$(touch /tmp/zen-pwned)')).toBeNull()
     expect(await resolveCommandViaLoginShell('rg fzf')).toBeNull()
     expect(await resolveCommandViaLoginShell('')).toBeNull()
+  })
+})
+
+describe('rc-file-only PATH entries (#634)', () => {
+  const savedEnv: Record<string, string | undefined> = {}
+  let tempHome: string | null = null
+
+  afterEach(async () => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    resetLoginShellResolutionForTests()
+    if (tempHome) await rm(tempHome, { recursive: true, force: true })
+    tempHome = null
+  })
+
+  function overrideEnv(overrides: Record<string, string>): void {
+    for (const [key, value] of Object.entries(overrides)) {
+      if (!(key in savedEnv)) savedEnv[key] = process.env[key]
+      process.env[key] = value
+    }
+  }
+
+  // The reported shape: node is only on PATH because ~/.zshrc (an
+  // interactive-only file for zsh) prepends nvm's bin directory. A plain
+  // login shell never reads it; the interactive pass must. The rc files also
+  // print a banner to prove marker parsing survives rc noise.
+  it.skipIf(!onPosix || !interactiveShell)(
+    'finds a command whose PATH entry only exists in interactive rc files',
+    async () => {
+      tempHome = await mkdtemp(path.join(os.tmpdir(), 'zen-login-shell-'))
+      const binDir = path.join(tempHome, 'rc-managed', 'bin')
+      const tool = 'zen-rc-only-tool'
+      await makeExecutable(path.join(binDir, tool))
+
+      const pathLine = `export PATH="${binDir}:$PATH"`
+      await writeFile(path.join(tempHome, '.zshrc'), `echo "welcome banner"\n${pathLine}\n`)
+      await writeFile(path.join(tempHome, '.bashrc'), `echo "welcome banner"\n${pathLine}\n`)
+      await writeFile(path.join(tempHome, '.bash_profile'), `. "$HOME/.bashrc"\n`)
+
+      overrideEnv({ HOME: tempHome, SHELL: interactiveShell as string })
+      resetLoginShellResolutionForTests()
+
+      expect(await resolveCommandViaLoginShell(tool)).toBe(path.join(binDir, tool))
+    }
+  )
+})
+
+describe('probeNvmInstall', () => {
+  const savedNvmDir = process.env.NVM_DIR
+  let nvmDir: string | null = null
+
+  afterEach(async () => {
+    if (savedNvmDir === undefined) delete process.env.NVM_DIR
+    else process.env.NVM_DIR = savedNvmDir
+    resetLoginShellResolutionForTests()
+    if (nvmDir) await rm(nvmDir, { recursive: true, force: true })
+    nvmDir = null
+  })
+
+  async function seedNvm(versions: string[], defaultAlias?: string): Promise<void> {
+    nvmDir = await mkdtemp(path.join(os.tmpdir(), 'zen-nvm-'))
+    for (const version of versions) {
+      await makeExecutable(path.join(nvmDir, 'versions', 'node', version, 'bin', 'node'))
+      await makeExecutable(path.join(nvmDir, 'versions', 'node', version, 'bin', 'npm'))
+    }
+    if (defaultAlias) {
+      await mkdir(path.join(nvmDir, 'alias'), { recursive: true })
+      await writeFile(path.join(nvmDir, 'alias', 'default'), `${defaultAlias}\n`)
+    }
+    process.env.NVM_DIR = nvmDir
+  }
+
+  it.skipIf(!onPosix)('prefers the default alias when it names a concrete version', async () => {
+    await seedNvm(['v22.14.0', 'v24.1.0'], 'v22.14.0')
+    expect(await probeNvmInstall('node')).toBe(
+      path.join(nvmDir as string, 'versions', 'node', 'v22.14.0', 'bin', 'node')
+    )
+  })
+
+  it.skipIf(!onPosix)('falls back to the newest install without a concrete default', async () => {
+    await seedNvm(['v22.14.0', 'v24.1.0'], 'lts/*')
+    expect(await probeNvmInstall('npm')).toBe(
+      path.join(nvmDir as string, 'versions', 'node', 'v24.1.0', 'bin', 'npm')
+    )
+  })
+
+  it.skipIf(!onPosix)('only answers for the node toolchain', async () => {
+    await seedNvm(['v24.1.0'])
+    expect(await probeNvmInstall('rg')).toBeNull()
   })
 })

--- a/apps/desktop/src/main/login-shell-path.ts
+++ b/apps/desktop/src/main/login-shell-path.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process'
 import { promises as fsp, constants as fsConstants } from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
 
@@ -12,9 +13,22 @@ const LOGIN_SHELL_TIMEOUT_MS = 5_000
 // check / search. Short enough to self-heal after a tool is installed mid-run.
 const RESOLUTION_TTL_MS = 60_000
 
-// Binary names are interpolated into a shell `command -v` invocation, so only
-// ever accept bare tokens — never anything that could break out of the word.
+// Binary names become file-path segments during PATH scanning, so only ever
+// accept bare tokens — never separators or anything shell-special.
 const SAFE_COMMAND = /^[A-Za-z0-9._-]+$/
+
+// Interactive shells are free to print from their rc files (banners, plugin
+// warnings, instant-prompt chatter), so the probe wraps its one real answer in
+// a marker and parsing reads the last marked line instead of trusting stdout.
+const OUTPUT_MARKER = '__ZENNOTES_LOGIN_SHELL__'
+
+// Interactive login (`-lic`) before plain login (`-lc`): the interactive PATH
+// is the one the user's terminal really has. zsh, the macOS default, reads
+// ~/.zshrc only when interactive, and that is where nvm and friends put their
+// init lines, so a plain login shell cannot see an nvm-managed node at all
+// (#634). `-lc` stays as the fallback for rc files that misbehave without a
+// tty; both run under the same timeout.
+const SHELL_MODES = ['-lic', '-lc'] as const
 
 const cache = new Map<string, { at: number; value: string | null }>()
 let pathDirsCache: { at: number; value: string[] } | null = null
@@ -25,9 +39,12 @@ let pathDirsCache: { at: number; value: string[] } | null = null
  * GUI apps launched from Finder/Dock on macOS (and similar elsewhere) inherit
  * only a minimal PATH (e.g. `/usr/bin:/bin:/usr/sbin:/sbin`), so tools
  * installed by Homebrew, cargo, npm, nix, etc. aren't resolvable by their bare
- * name. Spawning a *login* shell (`$SHELL -lc 'command -v <cmd>'`) queries the
- * PATH the user actually has configured — the same approach the CLI-install and
- * Raycast integrations already use to locate their tools.
+ * name. This asks the user's login shell for its PATH and scans those
+ * directories itself, which also sidesteps interactive-shell hazards like
+ * `command -v` answering with an alias definition or a lazy-loader function
+ * instead of a path. For the node toolchain there is one more fallback: nvm
+ * installs live in a well-known place but only enter PATH when the rc file
+ * runs, so `~/.nvm/versions/node` is probed directly (#634).
  *
  * Returns the absolute path, or `null` when the command can't be resolved —
  * including on Windows, where GUI apps already inherit the full PATH and the
@@ -41,7 +58,7 @@ export async function resolveCommandViaLoginShell(command: string): Promise<stri
   const cached = cache.get(command)
   if (cached && Date.now() - cached.at < RESOLUTION_TTL_MS) return cached.value
 
-  const value = await queryLoginShell(command)
+  const value = (await scanLoginShellPath(command)) ?? (await probeNvmInstall(command))
   cache.set(command, { at: Date.now(), value })
   return value
 }
@@ -56,6 +73,11 @@ export async function resolveCommandViaLoginShell(command: string): Promise<stri
  * profile, so the CLI installer told people `~/.local/bin` was missing from
  * their PATH while their shell had it all along (#528). A terminal launch DOES
  * inherit the real PATH, which is why this never shows up in development.
+ * A terminal is interactive, so the interactive PATH is queried first: rc-only
+ * additions (nvm, fnm, mise, …) count as "on the user's PATH" too (#634).
+ *
+ * Entries are returned as the shell reports them, existing or not: callers
+ * like the CLI installer ask about directories they are about to create.
  *
  * Empty on Windows (GUI apps there already have the full PATH) and whenever no
  * shell answers; callers fall back to `process.env.PATH`.
@@ -71,28 +93,79 @@ export async function resolveLoginShellPathDirs(): Promise<string[]> {
   return value
 }
 
-async function queryLoginShellPathDirs(): Promise<string[]> {
-  for (const shellPath of loginShells()) {
+/** Resolution is memoized; tests that vary HOME/SHELL/NVM_DIR reset it between cases. */
+export function resetLoginShellResolutionForTests(): void {
+  cache.clear()
+  pathDirsCache = null
+}
+
+async function scanLoginShellPath(command: string): Promise<string | null> {
+  for (const dir of await resolveLoginShellPathDirs()) {
+    if (!path.isAbsolute(dir)) continue
+    const candidate = path.join(dir, command)
     try {
-      await fsp.access(shellPath, fsConstants.X_OK)
-      // `printf` rather than `echo` so a PATH entry that looks like a flag
-      // cannot be eaten, and no trailing newline has to be trimmed off.
-      const { stdout } = await execFileAsync(shellPath, ['-lc', 'printf %s "$PATH"'], {
-        encoding: 'utf8',
-        timeout: LOGIN_SHELL_TIMEOUT_MS,
-        maxBuffer: 1024 * 1024,
-        windowsHide: true
-      })
-      const dirs = String(stdout)
-        .split(path.delimiter)
-        .map((entry) => entry.trim())
-        .filter(Boolean)
-      if (dirs.length > 0) return dirs
+      await fsp.access(candidate, fsConstants.X_OK)
+      return candidate
     } catch {
-      /* shell missing here, or it refused -lc — try the next one */
+      /* not in this dir — keep walking the PATH */
+    }
+  }
+  return null
+}
+
+async function queryLoginShellPathDirs(): Promise<string[]> {
+  for (const mode of SHELL_MODES) {
+    for (const shellPath of loginShells()) {
+      try {
+        await fsp.access(shellPath, fsConstants.X_OK)
+        // printf interprets the leading \n itself, forcing our marker onto its
+        // own line no matter what the rc files printed before it.
+        const { stdout } = await execFileAsync(
+          shellPath,
+          [mode, `printf '\\n${OUTPUT_MARKER}%s' "$PATH"`],
+          {
+            encoding: 'utf8',
+            timeout: LOGIN_SHELL_TIMEOUT_MS,
+            maxBuffer: 1024 * 1024,
+            windowsHide: true
+          }
+        )
+        const dirs = (extractMarkedLine(String(stdout)) ?? '')
+          .split(path.delimiter)
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+        // Sanity gate before trusting the answer: fish expands "$PATH" as
+        // space-joined list elements, which colon-splitting turns into one
+        // garbage entry. A believable POSIX PATH names at least one existing
+        // absolute directory; anything else means try the next shell.
+        if (dirs.length > 0 && (await anyExistingDirectory(dirs))) return dirs
+      } catch {
+        /* shell missing here, or it refused these flags — try the next one */
+      }
     }
   }
   return []
+}
+
+async function anyExistingDirectory(dirs: string[]): Promise<boolean> {
+  for (const dir of dirs) {
+    if (!path.isAbsolute(dir)) continue
+    try {
+      if ((await fsp.stat(dir)).isDirectory()) return true
+    } catch {
+      /* keep looking */
+    }
+  }
+  return false
+}
+
+function extractMarkedLine(stdout: string): string | null {
+  const lines = stdout.split(/\r?\n/)
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const at = lines[i].lastIndexOf(OUTPUT_MARKER)
+    if (at >= 0) return lines[i].slice(at + OUTPUT_MARKER.length).trim()
+  }
+  return null
 }
 
 /** The user's own shell first, then the standard POSIX ones. Those still pick
@@ -104,21 +177,68 @@ function loginShells(): string[] {
   ) as string[]
 }
 
-async function queryLoginShell(command: string): Promise<string | null> {
-  for (const shellPath of loginShells()) {
+/**
+ * nvm keeps every install under `$NVM_DIR/versions/node/<version>/bin` and
+ * only prepends the active one to PATH from an rc file, so a setup that
+ * lazy-loads nvm (a common startup-time tweak) is invisible even to an
+ * interactive shell. The layout itself is stable, so when the shells come up
+ * empty for the node toolchain, read it directly: the `default` alias wins
+ * when it names a concrete version, newest install otherwise.
+ *
+ * Exported for tests; production goes through resolveCommandViaLoginShell.
+ */
+export async function probeNvmInstall(command: string): Promise<string | null> {
+  if (command !== 'node' && command !== 'npm' && command !== 'npx') return null
+
+  const nvmDir = process.env.NVM_DIR?.trim() || path.join(os.homedir(), '.nvm')
+  const versionsDir = path.join(nvmDir, 'versions', 'node')
+  let entries: string[]
+  try {
+    entries = await fsp.readdir(versionsDir)
+  } catch {
+    return null
+  }
+
+  const versions = entries
+    .filter((entry) => /^v\d+\.\d+\.\d+$/.test(entry))
+    .sort(compareVersionsDescending)
+  const preferred = await nvmDefaultAliasVersion(nvmDir)
+  const ordered =
+    preferred && versions.includes(preferred)
+      ? [preferred, ...versions.filter((version) => version !== preferred)]
+      : versions
+
+  for (const version of ordered) {
+    const candidate = path.join(versionsDir, version, 'bin', command)
     try {
-      await fsp.access(shellPath, fsConstants.X_OK)
-      const { stdout } = await execFileAsync(shellPath, ['-lc', `command -v ${command}`], {
-        encoding: 'utf8',
-        timeout: LOGIN_SHELL_TIMEOUT_MS,
-        maxBuffer: 1024 * 1024,
-        windowsHide: true
-      })
-      const resolved = String(stdout).trim().split(/\r?\n/)[0]?.trim()
-      if (resolved && path.isAbsolute(resolved)) return resolved
+      await fsp.access(candidate, fsConstants.X_OK)
+      return candidate
     } catch {
-      /* shell missing here, or command not found in it — try the next one */
+      /* this install lacks the binary — try the next version */
     }
   }
   return null
+}
+
+async function nvmDefaultAliasVersion(nvmDir: string): Promise<string | null> {
+  try {
+    const raw = (await fsp.readFile(path.join(nvmDir, 'alias', 'default'), 'utf8')).trim()
+    const normalized = raw.startsWith('v') ? raw : `v${raw}`
+    // Aliases may also name chains like `lts/*` or `node`; resolving those
+    // means reimplementing nvm, so anything but a concrete version falls back
+    // to newest-install ordering.
+    return /^v\d+\.\d+\.\d+$/.test(normalized) ? normalized : null
+  } catch {
+    return null
+  }
+}
+
+function compareVersionsDescending(a: string, b: string): number {
+  const parse = (version: string): number[] =>
+    version.replace(/^v/, '').split('.').map((part) => Number.parseInt(part, 10))
+  const [aMajor, aMinor, aPatch] = parse(a)
+  const [bMajor, bMinor, bPatch] = parse(b)
+  if (aMajor !== bMajor) return bMajor - aMajor
+  if (aMinor !== bMinor) return bMinor - aMinor
+  return bPatch - aPatch
 }

--- a/apps/desktop/src/main/raycast-integration.ts
+++ b/apps/desktop/src/main/raycast-integration.ts
@@ -1,11 +1,12 @@
 import { app, shell } from 'electron'
 import { execFile, spawn } from 'node:child_process'
-import fs, { promises as fsp } from 'node:fs'
+import { promises as fsp } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import type { RaycastExtensionStatus } from '@shared/ipc'
+import { resolveCommandViaLoginShell } from './login-shell-path'
 
 const execFileAsync = promisify(execFile)
 
@@ -106,8 +107,11 @@ async function raycastAppInstalled(): Promise<boolean> {
 }
 
 async function resolveToolchain(): Promise<Toolchain> {
-  const nodePath = await resolveLoginShellCommand('node')
-  const npmPath = await resolveLoginShellCommand('npm')
+  // The shared resolver, not a private login-shell query: it reads the
+  // interactive shell's PATH (where nvm and friends initialize, #634) and
+  // falls back to probing nvm's install directory directly.
+  const nodePath = await resolveCommandViaLoginShell('node')
+  const npmPath = await resolveCommandViaLoginShell('npm')
   const env = buildCommandEnv({ nodePath, npmPath })
   const nodeVersion = nodePath ? await readVersion(nodePath, env) : null
   const npmVersion = npmPath ? await readVersion(npmPath, env) : null
@@ -120,29 +124,6 @@ async function resolveToolchain(): Promise<Toolchain> {
     nodeMeetsMinimum: versionAtLeast(nodeVersion, MIN_NODE_VERSION),
     npmMeetsMinimum: versionAtLeast(npmVersion, MIN_NPM_VERSION)
   }
-}
-
-async function resolveLoginShellCommand(command: 'node' | 'npm'): Promise<string | null> {
-  const shells = Array.from(
-    new Set([process.env.SHELL, '/bin/zsh', '/bin/bash', '/bin/sh'].filter(Boolean))
-  ) as string[]
-
-  for (const shellPath of shells) {
-    try {
-      await fsp.access(shellPath, fs.constants.X_OK)
-      const { stdout } = await execFileAsync(shellPath, ['-lc', `command -v ${command}`], {
-        encoding: 'utf8',
-        timeout: 10000,
-        maxBuffer: 1024 * 1024
-      })
-      const resolved = String(stdout).trim().split(/\r?\n/)[0]
-      if (resolved) return resolved
-    } catch {
-      /* keep trying */
-    }
-  }
-
-  return null
 }
 
 async function readVersion(commandPath: string, env: NodeJS.ProcessEnv): Promise<string | null> {
@@ -205,7 +186,7 @@ function unavailableReason(input: {
     return 'Raycast is not installed on this Mac.'
   }
   if (!input.toolchain.nodePath) {
-    return 'Node.js 22.14 or newer is required to install a local Raycast extension.'
+    return 'Node.js 22.14 or newer is required to install a local Raycast extension. ZenNotes looks for it on your shell PATH and in nvm installs.'
   }
   if (!input.toolchain.nodeMeetsMinimum) {
     return `Raycast extension tooling requires Node.js 22.14 or newer. Found ${input.toolchain.nodeVersion ?? 'an unknown version'}.`

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/server",
   "private": true,
-  "version": "2.30.0",
+  "version": "2.31.0",
   "scripts": {
     "dev": "node ../../tooling/scripts/run-go-server-dev.mjs",
     "prepare-web": "node ../../tooling/scripts/prepare-server-web-dist.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/web",
   "private": true,
-  "version": "2.30.0",
+  "version": "2.31.0",
   "type": "module",
   "description": "ZenNotes web client for self-hosted and hosted deployments",
   "homepage": "https://zennotes.org",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zennotes-monorepo",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zennotes-monorepo",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "@zennotes/desktop",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
@@ -99,11 +99,11 @@
     },
     "apps/server": {
       "name": "@zennotes/server",
-      "version": "2.30.0"
+      "version": "2.31.0"
     },
     "apps/web": {
       "name": "@zennotes/web",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -17123,7 +17123,7 @@
     },
     "packages/app-core": {
       "name": "@zennotes/app-core",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -17187,11 +17187,11 @@
     },
     "packages/bridge-contract": {
       "name": "@zennotes/bridge-contract",
-      "version": "2.30.0"
+      "version": "2.31.0"
     },
     "packages/shared-domain": {
       "name": "@zennotes/shared-domain",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "dependencies": {
         "@zennotes/bridge-contract": "*",
         "lz-string": "^1.5.0"
@@ -17199,7 +17199,7 @@
     },
     "packages/shared-ui": {
       "name": "@zennotes/shared-ui",
-      "version": "2.30.0"
+      "version": "2.31.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zennotes-monorepo",
   "private": true,
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "ZenNotes monorepo for desktop, web, and self-hosted server builds",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/app-core",
   "private": true,
-  "version": "2.30.0",
+  "version": "2.31.0",
   "type": "module",
   "exports": {
     "./main": "./src/main.tsx"

--- a/packages/app-core/src/components/BufferPalette.tsx
+++ b/packages/app-core/src/components/BufferPalette.tsx
@@ -47,6 +47,14 @@ function fallbackTitle(path: string): string {
   return filename.replace(/\.md$/i, '') || path
 }
 
+/** The row's secondary column: the note's folder, not the full path — the
+ *  filename part would just repeat the title, and it was crowding the title
+ *  out of the row (#635). The full path stays searchable via keywords. */
+function parentDir(path: string): string {
+  const idx = path.lastIndexOf('/')
+  return idx > 0 ? path.slice(0, idx) : ''
+}
+
 interface BuildDeps {
   paneLayout: ReturnType<typeof useStore.getState>['paneLayout']
   activePaneId: string
@@ -193,7 +201,7 @@ function buildEntries(deps: BuildDeps): BufferEntry[] {
     entries.push({
       path,
       title,
-      subtitle: path,
+      subtitle: parentDir(path),
       keywords: [title, path, meta?.folder].filter(Boolean).join(' '),
       badge,
       current: isCurrent,
@@ -352,7 +360,11 @@ export function BufferPalette(): JSX.Element {
                   i === active ? 'bg-paper-200' : 'hover:bg-paper-200/70'
                 ].join(' ')}
               >
-                <span className="min-w-0 flex-1 truncate text-sm font-medium text-ink-900">
+                {/* The title is what the user is switching by, so it wins the
+                    space fight: natural width, truncating only when it alone
+                    overflows the row. The folder column takes whatever is
+                    left (flex-1, basis 0) and collapses first. (#635) */}
+                <span className="min-w-0 truncate text-sm font-medium text-ink-900">
                   {entry.title}
                   {entry.dirty && (
                     <span
@@ -363,8 +375,12 @@ export function BufferPalette(): JSX.Element {
                     </span>
                   )}
                 </span>
-                <span className="shrink-0 truncate text-xs text-ink-400">
-                  {entry.virtual ? 'virtual' : entry.subtitle}
+                {/* dir="rtl" moves the ellipsis to the left edge, so a folder
+                    that no longer fits keeps its distinguishing tail visible
+                    (…ZenNotes/Enhancements). The LRE/PDF bidi embedding keeps
+                    the path itself rendering left-to-right inside it. */}
+                <span dir="rtl" className="min-w-0 flex-1 truncate text-xs text-ink-400">
+                  {`\u202A${entry.virtual ? 'virtual' : entry.subtitle}\u202C`}
                 </span>
                 <span className="shrink-0 text-xs uppercase tracking-wide text-ink-400">
                   {entry.badge}

--- a/packages/app-core/src/components/WhichKeyOverlay.tsx
+++ b/packages/app-core/src/components/WhichKeyOverlay.tsx
@@ -23,8 +23,11 @@ export function WhichKeyOverlay({
 
   return createPortal(
     <div className="pointer-events-none fixed inset-x-0 bottom-5 z-[100] flex justify-center px-4">
-      <div className="w-[min(640px,calc(100vw-2rem))] overflow-hidden rounded-xl border border-paper-300/70 bg-paper-100 shadow-float backdrop-blur-md">
-        <div className="flex items-center justify-between gap-3 border-b border-paper-300/60 px-3.5 py-2.5">
+      {/* Bottom-anchored, so on short windows (tiled WMs, high zoom) an uncapped
+          card grows past the top edge and clips the header first (#636). Cap it
+          to the viewport and let the item grid scroll under a pinned header. */}
+      <div className="pointer-events-auto flex max-h-[calc(100vh-2.5rem)] w-[min(640px,calc(100vw-2rem))] flex-col overflow-hidden rounded-xl border border-paper-300/70 bg-paper-100 shadow-float backdrop-blur-md">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-paper-300/60 px-3.5 py-2.5">
           <div className="flex min-w-0 items-center gap-2.5">
             <span className="rounded-md border border-accent/35 bg-paper-200 px-2 py-1 text-2xs font-semibold uppercase tracking-[0.18em] text-accent">
               {prefix}
@@ -36,7 +39,12 @@ export function WhichKeyOverlay({
           </div>
         </div>
 
-        <div className={['grid bg-paper-100', twoColumn ? 'sm:grid-cols-2' : 'grid-cols-1'].join(' ')}>
+        <div
+          className={[
+            'grid min-h-0 overflow-y-auto overscroll-contain bg-paper-100',
+            twoColumn ? 'sm:grid-cols-2' : 'grid-cols-1'
+          ].join(' ')}
+        >
           {items.map((item, index) => (
             <div
               key={`${prefix}-${item.keyLabel}`}

--- a/packages/app-core/src/store.test.ts
+++ b/packages/app-core/src/store.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TASKS_TAB_PATH, type VaultTask } from '@shared/tasks'
+import { TAGS_TAB_PATH } from '@shared/tags'
 import { WORKFLOWS_TAB_PATH } from '@shared/workflows-view'
 import { databaseTabPath, type DatabaseDoc } from '@shared/databases'
 import { assetTabPath } from './lib/asset-tabs'
@@ -981,6 +982,59 @@ describe('note jump history with database tabs', () => {
     // Ctrl+O → jump back to the grid.
     await useStore.getState().jumpToPreviousNote()
     expect(useStore.getState().selectedPath).toBe(dbTab)
+  })
+})
+
+describe('note jump history with the Tasks and Tags views (#633)', () => {
+  // The panels are destinations the user navigates to on purpose, so the
+  // jumplist must both return TO them and record the note they were opened
+  // FROM. Before #633 they were excluded on both sides: Ctrl+O skipped the
+  // panel, and the origin note never entered the backstack.
+  it('Ctrl+O returns to the Tasks view, then to the note it was opened from', async () => {
+    installZen({
+      readNote: vi
+        .fn()
+        .mockImplementation(async (path: string) => makeNote('body text', path))
+    })
+    const { useStore } = await loadStore()
+
+    await useStore.getState().selectNote('inbox/From.md')
+    await useStore.getState().openTasksView()
+    expect(useStore.getState().selectedPath).toBe(TASKS_TAB_PATH)
+    expect(useStore.getState().noteBackstack.map((l) => l.path)).toContain('inbox/From.md')
+
+    await useStore.getState().selectNote('inbox/Other.md')
+    expect(useStore.getState().noteBackstack.map((l) => l.path)).toContain(TASKS_TAB_PATH)
+
+    await useStore.getState().jumpToPreviousNote()
+    expect(useStore.getState().selectedPath).toBe(TASKS_TAB_PATH)
+    await useStore.getState().jumpToPreviousNote()
+    expect(useStore.getState().selectedPath).toBe('inbox/From.md')
+
+    // And Ctrl+I walks forward through the panel again.
+    await useStore.getState().jumpToNextNote()
+    expect(useStore.getState().selectedPath).toBe(TASKS_TAB_PATH)
+    await useStore.getState().jumpToNextNote()
+    expect(useStore.getState().selectedPath).toBe('inbox/Other.md')
+  })
+
+  it('the Tags view round-trips the same way', async () => {
+    installZen({
+      readNote: vi
+        .fn()
+        .mockImplementation(async (path: string) => makeNote('body text', path))
+    })
+    const { useStore } = await loadStore()
+
+    await useStore.getState().selectNote('inbox/From.md')
+    await useStore.getState().openTagView('demo')
+    expect(useStore.getState().selectedPath).toBe(TAGS_TAB_PATH)
+
+    await useStore.getState().selectNote('inbox/Other.md')
+    await useStore.getState().jumpToPreviousNote()
+    expect(useStore.getState().selectedPath).toBe(TAGS_TAB_PATH)
+    await useStore.getState().jumpToPreviousNote()
+    expect(useStore.getState().selectedPath).toBe('inbox/From.md')
   })
 })
 

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -1613,12 +1613,15 @@ function isDatabaseSurfaceTabPath(path: string | null | undefined): path is stri
 
 /**
  * Tabs worth recording in the note jump history (Ctrl+O / Ctrl+I): real notes,
- * plus database surfaces — so opening a row's record page and pressing Ctrl+O
- * jumps back to the grid. Other virtual tabs (tasks, tags, plain assets…) stay
- * excluded.
+ * database surfaces — so opening a row's record page and pressing Ctrl+O jumps
+ * back to the grid — and the Tasks and Tags views, which are destinations the
+ * user navigates to on purpose and expects the jumplist to return to (#633).
+ * Other virtual tabs (plain assets, help, trash…) stay excluded.
  */
 function isJumpHistoryTabPath(path: string | null | undefined): path is string {
-  return !!path && (!isWorkspaceVirtualTabPath(path) || isDatabaseSurfaceTabPath(path))
+  if (!path) return false
+  if (!isWorkspaceVirtualTabPath(path)) return true
+  return isDatabaseSurfaceTabPath(path) || isTasksTabPath(path) || isTagsTabPath(path)
 }
 
 function captureNoteJumpLocation(state: {
@@ -1626,6 +1629,20 @@ function captureNoteJumpLocation(state: {
   editorViewRef: EditorView | null
 }): NoteJumpLocation | null {
   if (!isJumpHistoryTabPath(state.selectedPath)) return null
+  // Panel surfaces (Tasks, Tags, a database grid) render no editor, so a
+  // lingering editorViewRef belongs to some other note; capturing its scroll
+  // would smuggle meaningless numbers into the entry and defeat the
+  // consecutive-duplicate dedup. Only the place itself is worth recording.
+  if (isWorkspaceVirtualTabPath(state.selectedPath)) {
+    return {
+      path: state.selectedPath,
+      editorSelectionAnchor: 0,
+      editorSelectionHead: 0,
+      editorScrollTop: 0,
+      previewScrollTop: 0,
+      editorScrollMode: 'preserve'
+    }
+  }
   const selection = state.editorViewRef?.state.selection.main
   return {
     path: state.selectedPath,
@@ -4204,17 +4221,14 @@ export const useStore = create<Store>((set, get) => {
     set({ loadingNote: true })
     while (source.length > 0) {
       const target = source.pop() ?? null
-      if (
-        !target ||
-        target.path === get().selectedPath ||
-        (isWorkspaceVirtualTabPath(target.path) && !isDatabaseSurfaceTabPath(target.path))
-      ) {
+      if (!target || target.path === get().selectedPath || !isJumpHistoryTabPath(target.path)) {
         continue
       }
-      // A database surface in the history — e.g. the grid a record page was
-      // opened from. Reopen the tab instead of loading note content, and record
-      // the current location on the opposite stack so the jump stays reversible.
-      if (isDatabaseSurfaceTabPath(target.path)) {
+      // A virtual surface in the history — a database grid a record page was
+      // opened from, or the Tasks/Tags view (#633). Reopen the tab instead of
+      // loading note content, and record the current location on the opposite
+      // stack so the jump stays reversible.
+      if (isWorkspaceVirtualTabPath(target.path)) {
         const latest = get()
         const opposite =
           direction === 'back' ? latest.noteForwardstack : latest.noteBackstack
@@ -4225,7 +4239,14 @@ export const useStore = create<Store>((set, get) => {
           noteBackstack: direction === 'back' ? source : nextOpposite,
           noteForwardstack: direction === 'back' ? nextOpposite : source
         })
-        await selectNoteImpl(target.path, 'preserve')
+        // Tasks/Tags go through focusTabInPane, which carries each panel's
+        // reopen semantics (focus claim, task refresh) and records no history
+        // of its own; database surfaces keep their selectNote path.
+        if (isDatabaseSurfaceTabPath(target.path)) {
+          await selectNoteImpl(target.path, 'preserve')
+        } else {
+          await get().focusTabInPane(latest.activePaneId, target.path)
+        }
         return
       }
       try {
@@ -4721,8 +4742,11 @@ export const useStore = create<Store>((set, get) => {
   openTasksView: async () => {
     const state = get()
     // Reset the panel's session state every time we open it — stale cursor/
-    // filter from a prior visit would feel weird.
-    set({ tasksFilter: '', taskCursorIndex: 0 })
+    // filter from a prior visit would feel weird. Opening the panel is also a
+    // jump worth undoing: record where the user came from so Ctrl+O returns
+    // there, and the panel itself joins the trail (#633). `openNoteInPane`
+    // below is the raw tab primitive and keeps no history of its own.
+    set({ tasksFilter: '', taskCursorIndex: 0, ...noteHistoryAfterJump(state, TASKS_TAB_PATH) })
     // Add (or focus) the virtual Tasks tab in the currently active pane.
     await get().openNoteInPane(state.activePaneId, TASKS_TAB_PATH)
     // Hand keyboard focus to the Tasks panel so vim-style navigation works
@@ -4785,6 +4809,9 @@ export const useStore = create<Store>((set, get) => {
       }
     }
 
+    // Same as openTasksView: opening the panel is a jump, record the origin
+    // so Ctrl+O returns to it and the panel joins the trail (#633).
+    set(noteHistoryAfterJump(get(), TAGS_TAB_PATH))
     await get().openNoteInPane(state.activePaneId, TAGS_TAB_PATH)
     ;(document.activeElement as HTMLElement | null)?.blur?.()
     set({ focusedPanel: 'tags' })

--- a/packages/bridge-contract/package.json
+++ b/packages/bridge-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/bridge-contract",
   "private": true,
-  "version": "2.30.0",
+  "version": "2.31.0",
   "type": "module",
   "exports": {
     "./bridge": "./src/bridge.ts",

--- a/packages/bridge-contract/src/cloud-sync.ts
+++ b/packages/bridge-contract/src/cloud-sync.ts
@@ -67,6 +67,42 @@ export interface CloudSyncMutationResponse {
   cursor: number;
 }
 
+export interface CloudSyncUploadRequest {
+  operation_id: string;
+  item_id: string;
+  base_revision: number | null;
+  path: string;
+  kind: CloudSyncItemKind;
+  content: Pick<
+    CloudSyncContent,
+    "encoding" | "sha256" | "byte_length" | "media_type"
+  >;
+}
+
+export interface CloudSyncUploadInitiationResponse {
+  data: {
+    id: string;
+    operation_id: string;
+    status: "initiated" | "uploading";
+    expected_bytes: number;
+    expires_at: string;
+    upload: {
+      method: "PUT";
+      url: string;
+      headers: Record<string, string>;
+    };
+  };
+}
+
+export interface CloudSyncUploadCompletionResponse {
+  data: {
+    id: string;
+    operation_id: string;
+    status: "completed";
+    result: CloudSyncMutationResponse;
+  };
+}
+
 export interface CloudSyncManifestItem {
   item_id: string;
   path: string;

--- a/packages/shared-domain/package.json
+++ b/packages/shared-domain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-domain",
   "private": true,
-  "version": "2.30.0",
+  "version": "2.31.0",
   "type": "module",
   "exports": {
     "./*": "./src/*.ts"

--- a/packages/shared-domain/src/cloud-sync-api.test.ts
+++ b/packages/shared-domain/src/cloud-sync-api.test.ts
@@ -57,6 +57,50 @@ describe('CloudSyncApiClient', () => {
     ])
   })
 
+  it('initiates, completes, and aborts direct sync uploads', async () => {
+    const requests: CloudSyncHttpRequest[] = []
+    const client = new CloudSyncApiClient({
+      async request<Response>(request: CloudSyncHttpRequest): Promise<Response> {
+        requests.push(request)
+        return {} as Response
+      }
+    })
+    const upload = {
+      operation_id: '4b66f4b4-08f9-4e5a-a300-686ed4ef7e92',
+      item_id: '9b0ff39e-7ace-4fae-82aa-9f80a7458543',
+      base_revision: 2,
+      path: 'attachments/archive.zip',
+      kind: 'binary' as const,
+      content: {
+        encoding: 'base64' as const,
+        sha256: 'a'.repeat(64),
+        byte_length: 6_000_000,
+        media_type: 'application/zip'
+      }
+    }
+
+    await client.initiateUpload('vault/1', upload)
+    await client.completeUpload('vault/1', 'upload/1')
+    await client.abortUpload('vault/1', 'upload/1')
+
+    expect(requests).toEqual([
+      {
+        method: 'POST',
+        path: '/api/v1/vaults/vault%2F1/uploads',
+        body: upload
+      },
+      {
+        method: 'POST',
+        path: '/api/v1/vaults/vault%2F1/uploads/upload%2F1/complete',
+        timeoutMs: 300_000
+      },
+      {
+        method: 'DELETE',
+        path: '/api/v1/vaults/vault%2F1/uploads/upload%2F1'
+      }
+    ])
+  })
+
   it('addresses backup deletion, download, and idempotent restores', async () => {
     const requests: CloudSyncHttpRequest[] = []
     const client = new CloudSyncApiClient({

--- a/packages/shared-domain/src/cloud-sync-api.ts
+++ b/packages/shared-domain/src/cloud-sync-api.ts
@@ -15,6 +15,9 @@ import type {
   CloudSyncManifestResponse,
   CloudSyncMutationRequest,
   CloudSyncMutationResponse,
+  CloudSyncUploadCompletionResponse,
+  CloudSyncUploadInitiationResponse,
+  CloudSyncUploadRequest,
   CloudSyncVaultCollection,
   CloudSyncVaultResponse
 } from '@zennotes/bridge-contract/cloud-sync'
@@ -23,6 +26,7 @@ export interface CloudSyncHttpRequest {
   method: 'GET' | 'POST' | 'PUT' | 'DELETE'
   path: string
   body?: unknown
+  timeoutMs?: number
 }
 
 export interface CloudSyncHttpTransport {
@@ -109,6 +113,35 @@ export class CloudSyncApiClient {
       method: 'POST',
       path: `/api/v1/vaults/${encodeURIComponent(vaultId)}/mutations`,
       body
+    })
+  }
+
+  async initiateUpload(
+    vaultId: string,
+    body: CloudSyncUploadRequest
+  ): Promise<CloudSyncUploadInitiationResponse> {
+    return this.http.request({
+      method: 'POST',
+      path: `/api/v1/vaults/${encodeURIComponent(vaultId)}/uploads`,
+      body
+    })
+  }
+
+  async completeUpload(
+    vaultId: string,
+    uploadId: string
+  ): Promise<CloudSyncUploadCompletionResponse> {
+    return this.http.request({
+      method: 'POST',
+      path: `${this.uploadPath(vaultId, uploadId)}/complete`,
+      timeoutMs: 300_000
+    })
+  }
+
+  async abortUpload(vaultId: string, uploadId: string): Promise<void> {
+    await this.http.request({
+      method: 'DELETE',
+      path: this.uploadPath(vaultId, uploadId)
     })
   }
 
@@ -204,6 +237,10 @@ export class CloudSyncApiClient {
 
   private backupPath(vaultId: string, backupId: string): string {
     return `/api/v1/vaults/${encodeURIComponent(vaultId)}/backups/${encodeURIComponent(backupId)}`
+  }
+
+  private uploadPath(vaultId: string, uploadId: string): string {
+    return `/api/v1/vaults/${encodeURIComponent(vaultId)}/uploads/${encodeURIComponent(uploadId)}`
   }
 }
 

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-ui",
   "private": true,
-  "version": "2.30.0",
+  "version": "2.31.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
The 2.31.0 release branch. The headline is direct uploads for ZenNotes Cloud: large files stream from disk to storage instead of traveling inline through the sync request. Around it, a four-issue community sweep, three of them reported by @uNyanda.

## Large files sync for real

Sync used to inline every file into the mutation JSON, so a big PDF or video buffered whole in memory and pushed against server limits. Files over 5 MB now travel through an upload session: the client asks the cloud for a signed destination, streams the bytes straight from disk, and completes the session, which folds the result back into the ordinary mutation response, conflicts included. Batch order is preserved around direct uploads, failed uploads abort their session server-side, completion retries transient errors, and revision/path/quota conflicts surface as normal sync conflicts rather than transport failures. Local scans hash oversized files in a stream, and the signed URL must be https.

## The issue sweep

- [#636](https://github.com/ZenNotes/zennotes/issues/636) the leader hints card stays inside short windows: the bottom-anchored which-key card had no height cap, so tiled WMs (Niri) and high zoom clipped the header, the only part naming the menu, off the top. It now caps at the viewport, pins the header, and scrolls the shortcut list, wheel included.
- [#634](https://github.com/ZenNotes/zennotes/issues/634) the Raycast installer finds nvm-managed node: zsh reads `~/.zshrc` only when interactive, which is exactly where nvm initializes, so the non-interactive login-shell lookup never saw it. The shared resolver now reads the interactive shell's PATH and scans it directly, with a `~/.nvm/versions/node` probe for lazy-loaded setups; ripgrep/fzf detection and the CLI installer's PATH check inherit the same fidelity.
- [#633](https://github.com/ZenNotes/zennotes/issues/633) Ctrl+O and Ctrl+I walk through the Tasks and Tags tabs: the jumplist shut the panels out twice over (never recorded as destinations, and opening one recorded no origin), so a panel mid-path could kill the trail entirely. Both panels now ride the jumplist like any note; help/trash/asset tabs stay excluded on purpose, and tab-strip clicks remain non-jumps.
- [#635](https://github.com/ZenNotes/zennotes/issues/635) the buffer switcher leads with the title: rows used to sacrifice the note title to the full file path. They now show the full title with the note's folder dimmed beside it, and a folder that runs out of room truncates from the left so the distinguishing tail stays readable.

Every fix was verified in the built app over CDP against the reporter's repro, alongside the unit suites (new store tests cover the #633 round-trips; the direct-upload work lands with its own client, filesystem, and API tests) and repo typecheck.

Full release notes land on the GitHub release when CI finishes the installers.

https://claude.ai/code/session_011wnqvUakYs9Me5kyRgsUw2