### PR TITLE
ZenNotes 2.32.0: wrapped Vim motions, your way

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/desktop",
   "productName": "ZenNotes",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "description": "ZenNotes desktop shell",
   "private": true,
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/app-config.test.ts
+++ b/apps/desktop/src/main/app-config.test.ts
@@ -94,6 +94,7 @@ describe('TOML serialization', () => {
   it('round-trips portable prefs, including nullable and map fields', () => {
     const portable: AppConfigPortable = {
       vimMode: false,
+      vimWrappedLineMotions: 'logical',
       editorFontSize: 18,
       editorLineHeight: 1.6,
       themeFamily: 'nord',
@@ -120,6 +121,7 @@ describe('TOML serialization', () => {
     const { version, portable: round } = deserializeConfig(text)
     expect(version).toBe(CONFIG_VERSION)
     expect(round.vimMode).toBe(false)
+    expect(round.vimWrappedLineMotions).toBe('logical')
     expect(round.editorFontSize).toBe(18)
     expect(round.editorLineHeight).toBeCloseTo(1.6)
     expect(round.themeFamily).toBe('nord')
@@ -154,6 +156,9 @@ describe('TOML serialization', () => {
       'auto_pair_quotes_in_prose = false  # also auto-insert matching quotes outside Markdown code'
     )
     expect(text).toContain('[vim]')
+    expect(text).toContain(
+      'wrapped_line_motions = "display"  # display | logical — how $, I, A and dependent operators treat soft-wrapped lines'
+    )
     expect(text).toContain('[view]')
     // Keymaps: every action listed as a commented, grouped default reference.
     expect(text).toContain('[keymaps]')

--- a/apps/desktop/src/main/app-config.ts
+++ b/apps/desktop/src/main/app-config.ts
@@ -56,6 +56,11 @@ const SCALAR_FIELDS: Partial<Record<PortablePrefKey, ScalarFieldMap>> = {
     tomlKey: 'yank_to_clipboard',
     comment: 'sync the system clipboard with Vim yank/delete/change and p/P paste'
   },
+  vimWrappedLineMotions: {
+    section: 'vim',
+    tomlKey: 'wrapped_line_motions',
+    comment: 'display | logical — how $, I, A and dependent operators treat soft-wrapped lines'
+  },
   whichKeyHints: {
     section: 'vim',
     tomlKey: 'which_key_hints',

--- a/apps/server/internal/vault/parse.go
+++ b/apps/server/internal/vault/parse.go
@@ -254,6 +254,7 @@ var (
 	inlineDueRe     = regexp.MustCompile(`(?i)(?:^|\s)due:\s*(\S+)`)
 	inlinePriority  = regexp.MustCompile(`(?i)(?:^|\s)!(high|med|medium|low|h|m|l)\b`)
 	inlineWaitingRe = regexp.MustCompile(`(?i)(?:^|\s)@waiting\b`)
+	inlineFieldRe   = regexp.MustCompile(`(?i)(?:^|\s)@([a-z][a-z0-9_-]*):([\p{L}\d][\p{L}\d/_-]*)`)
 	inlineTagRe     = regexp.MustCompile(`(?:^|\s)#([\p{L}\d][\p{L}\d/_\-]*)`)
 	isoDateRe       = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
 )
@@ -504,6 +505,8 @@ func parseTaskFile(path, title string, folder NoteFolder, body string) (Task, bo
 		Due:           normalizeDueDate(firstScalar(fm["due"])),
 		Priority:      normalizePriority(firstScalar(fm["priority"])),
 		Waiting:       status == "waiting",
+		Fields:        map[string]string{"status": status},
+		Status:        status,
 		Tags:          tags,
 		Kind:          "file",
 		Scheduled:     normalizeDueDate(firstScalar(fm["scheduled"])),
@@ -586,6 +589,7 @@ func ParseTasksWith(path, title string, folder NoteFolder, body string, opts Par
 		due := ""
 		priority := ""
 		waiting := false
+		fields := map[string]string{}
 		tags := []string{}
 		stripped := tail
 
@@ -602,6 +606,18 @@ func ParseTasksWith(path, title string, folder NoteFolder, body string, opts Par
 		if inlineWaitingRe.MatchString(stripped) {
 			waiting = true
 			stripped = inlineWaitingRe.ReplaceAllString(stripped, " ")
+		}
+		for _, fm := range inlineFieldRe.FindAllStringSubmatch(stripped, -1) {
+			if len(fm) < 3 {
+				continue
+			}
+			key := strings.ToLower(fm[1])
+			if _, exists := fields[key]; !exists {
+				fields[key] = strings.ToLower(fm[2])
+			}
+		}
+		if len(fields) > 0 {
+			stripped = inlineFieldRe.ReplaceAllString(stripped, " ")
 		}
 		for _, tm := range inlineTagRe.FindAllStringSubmatch(tail, -1) {
 			if len(tm) >= 2 {
@@ -630,6 +646,9 @@ func ParseTasksWith(path, title string, folder NoteFolder, body string, opts Par
 		if priority == "" {
 			priority = defaults.Priority
 		}
+		if _, hasStatus := fields["status"]; !hasStatus && defaults.Status != "" {
+			fields["status"] = defaults.Status
+		}
 
 		task := Task{
 			ID:         fmtTaskID(path, taskIndex),
@@ -647,6 +666,8 @@ func ParseTasksWith(path, title string, folder NoteFolder, body string, opts Par
 			Due:        due,
 			Priority:   priority,
 			Waiting:    waiting,
+			Fields:     fields,
+			Status:     fields["status"],
 			Tags:       tags,
 		}
 		out = append(out, task)

--- a/apps/server/internal/vault/parse_test.go
+++ b/apps/server/internal/vault/parse_test.go
@@ -193,6 +193,46 @@ func TestParseTaskFileInProgressStatus(t *testing.T) {
 	}
 }
 
+// #643: a server-backed board must receive the same custom-status fields as
+// the desktop parser. Otherwise the optimistic move sticks until the watcher
+// rescan replaces it with a task that appears to have no status.
+func TestParseTaskFileIncludesCustomStatusField(t *testing.T) {
+	body := "---\ntags: [task]\ntitle: Rewrite\nstatus: A\n---\n\nDetails.\n"
+	task, ok := parseTaskFile("inbox/x.md", "x", FolderInbox, body)
+	if !ok {
+		t.Fatal("expected a file task")
+	}
+	if task.Status != "a" {
+		t.Errorf("Status=%q, want %q", task.Status, "a")
+	}
+	if got := task.Fields["status"]; got != "a" {
+		t.Errorf("Fields[status]=%q, want %q", got, "a")
+	}
+}
+
+func TestParseTasksIncludesCustomFields(t *testing.T) {
+	body := "---\nstatus: Backlog\n---\n- [ ] inherits\n- [ ] override @status:Review @sprint:24 @area:Backend\n"
+	tasks := ParseTasks("inbox/t.md", "t", FolderInbox, body)
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].Status != "backlog" || tasks[0].Fields["status"] != "backlog" {
+		t.Errorf("inherited task fields=%#v status=%q, want status=backlog", tasks[0].Fields, tasks[0].Status)
+	}
+	want := map[string]string{"status": "review", "sprint": "24", "area": "backend"}
+	for key, value := range want {
+		if got := tasks[1].Fields[key]; got != value {
+			t.Errorf("Fields[%s]=%q, want %q", key, got, value)
+		}
+	}
+	if tasks[1].Status != "review" {
+		t.Errorf("Status=%q, want review", tasks[1].Status)
+	}
+	if tasks[1].Content != "override" {
+		t.Errorf("Content=%q, want custom-field tokens stripped", tasks[1].Content)
+	}
+}
+
 // #458: the frontmatter `tasks:` key turns a note's checkboxes back into plain
 // checkboxes. The server mirrors noteTasksMode in shared-domain; the accepted
 // values must stay byte-identical across runtimes.

--- a/apps/server/internal/vault/types.go
+++ b/apps/server/internal/vault/types.go
@@ -420,11 +420,16 @@ type Task struct {
 	// Forwarded is true for a `[>]` record: the task moved to another note
 	// and a live copy exists there (#316). Without it, a web client read
 	// carried tasks as open twice, record and copy alike (#611 review).
-	Forwarded bool     `json:"forwarded,omitempty"`
-	Due        string   `json:"due,omitempty"`
-	Priority   string   `json:"priority,omitempty"`
-	Waiting    bool     `json:"waiting"`
-	Tags       []string `json:"tags"`
+	Forwarded bool   `json:"forwarded,omitempty"`
+	Due       string `json:"due,omitempty"`
+	Priority  string `json:"priority,omitempty"`
+	Waiting   bool   `json:"waiting"`
+	// Fields contains inline @key:value metadata (or a file task's
+	// frontmatter status) so remote Kanban boards group tasks exactly like the
+	// desktop parser. Status mirrors Fields["status"] for convenience (#643).
+	Fields map[string]string `json:"fields"`
+	Status string            `json:"status,omitempty"`
+	Tags   []string          `json:"tags"`
 	// Kind is how the task is stored: "file" for a whole-note task
 	// (TaskNotes-style, tagged `task` with metadata in frontmatter) or
 	// empty/"inline" for a classic `- [ ]` checkbox line. The renderer

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/server",
   "private": true,
-  "version": "2.31.0",
+  "version": "2.32.0",
   "scripts": {
     "dev": "node ../../tooling/scripts/run-go-server-dev.mjs",
     "prepare-web": "node ../../tooling/scripts/prepare-server-web-dist.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/web",
   "private": true,
-  "version": "2.31.0",
+  "version": "2.32.0",
   "type": "module",
   "description": "ZenNotes web client for self-hosted and hosted deployments",
   "homepage": "https://zennotes.org",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zennotes-monorepo",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zennotes-monorepo",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "@zennotes/desktop",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
@@ -99,11 +99,11 @@
     },
     "apps/server": {
       "name": "@zennotes/server",
-      "version": "2.31.0"
+      "version": "2.32.0"
     },
     "apps/web": {
       "name": "@zennotes/web",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -17123,7 +17123,7 @@
     },
     "packages/app-core": {
       "name": "@zennotes/app-core",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -17187,11 +17187,11 @@
     },
     "packages/bridge-contract": {
       "name": "@zennotes/bridge-contract",
-      "version": "2.31.0"
+      "version": "2.32.0"
     },
     "packages/shared-domain": {
       "name": "@zennotes/shared-domain",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "dependencies": {
         "@zennotes/bridge-contract": "*",
         "lz-string": "^1.5.0"
@@ -17199,7 +17199,7 @@
     },
     "packages/shared-ui": {
       "name": "@zennotes/shared-ui",
-      "version": "2.31.0"
+      "version": "2.32.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zennotes-monorepo",
   "private": true,
-  "version": "2.31.0",
+  "version": "2.32.0",
   "description": "ZenNotes monorepo for desktop, web, and self-hosted server builds",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/app-core",
   "private": true,
-  "version": "2.31.0",
+  "version": "2.32.0",
   "type": "module",
   "exports": {
     "./main": "./src/main.tsx"

--- a/packages/app-core/src/components/BufferPalette.test.ts
+++ b/packages/app-core/src/components/BufferPalette.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { findLeaf, type PaneLeaf } from '../lib/pane-layout'
+import { useStore } from '../store'
+import { BufferPalette } from './BufferPalette'
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('BufferPalette (#641)', () => {
+  let host: HTMLDivElement
+  let root: Root
+  let originalState: ReturnType<typeof useStore.getState>
+  let originalScrollIntoView: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    originalState = useStore.getState()
+    host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+    originalScrollIntoView = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView')
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn()
+    })
+
+    const pane: PaneLeaf = {
+      kind: 'leaf',
+      id: 'pane-a',
+      tabs: ['inbox/A.md', 'inbox/B.md', 'inbox/C.md'],
+      pinnedTabs: [],
+      activeTab: 'inbox/A.md'
+    }
+    useStore.setState({
+      paneLayout: pane,
+      activePaneId: pane.id,
+      selectedPath: pane.activeTab,
+      noteContents: {},
+      noteDirty: {},
+      notes: [],
+      bufferPaletteOpen: true
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    document.body.innerHTML = ''
+    if (originalScrollIntoView) {
+      Object.defineProperty(Element.prototype, 'scrollIntoView', originalScrollIntoView)
+    } else {
+      delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
+    }
+    vi.restoreAllMocks()
+    useStore.setState(originalState, true)
+  })
+
+  it('closes the highlighted buffer with Ctrl+D while keeping the palette open', async () => {
+    act(() => root.render(createElement(BufferPalette)))
+    const input = document.querySelector<HTMLInputElement>('input[placeholder="Switch buffer…"]')
+    expect(input).not.toBeNull()
+
+    // Natural order is B, C, then the current buffer A. Select C.
+    act(() => {
+      input!.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+      )
+    })
+
+    await act(async () => {
+      input!.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'd',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+      await Promise.resolve()
+    })
+
+    expect(findLeaf(useStore.getState().paneLayout, 'pane-a')?.tabs).toEqual([
+      'inbox/A.md',
+      'inbox/B.md'
+    ])
+    expect(useStore.getState().bufferPaletteOpen).toBe(true)
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+
+    // The row after C stays highlighted. Closing it again exercises the
+    // end-of-list clamp: A disappears and selection moves back to B.
+    await act(async () => {
+      input!.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'd',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+      await Promise.resolve()
+    })
+
+    expect(findLeaf(useStore.getState().paneLayout, 'pane-a')?.tabs).toEqual(['inbox/B.md'])
+    expect(useStore.getState().bufferPaletteOpen).toBe(true)
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+    expect(document.querySelector<HTMLButtonElement>('[data-buf-idx="0"]')?.textContent).toContain(
+      'B'
+    )
+  })
+})

--- a/packages/app-core/src/components/BufferPalette.tsx
+++ b/packages/app-core/src/components/BufferPalette.tsx
@@ -236,6 +236,7 @@ export function BufferPalette(): JSX.Element {
   const setOpen = useStore((s) => s.setBufferPaletteOpen)
   const setActivePane = useStore((s) => s.setActivePane)
   const focusTabInPane = useStore((s) => s.focusTabInPane)
+  const closeTab = useStore((s) => s.closeTab)
 
   // Select primitives separately so each selector returns a stable
   // reference; compute the derived entries list with useMemo. Returning
@@ -285,6 +286,10 @@ export function BufferPalette(): JSX.Element {
   useEffect(() => setActive(0), [query])
 
   useEffect(() => {
+    setActive((index) => Math.max(0, Math.min(index, results.length - 1)))
+  }, [results.length])
+
+  useEffect(() => {
     const el = listRef.current?.querySelector<HTMLElement>(`[data-buf-idx="${active}"]`)
     el?.scrollIntoView({ block: 'nearest' })
   }, [active])
@@ -311,6 +316,13 @@ export function BufferPalette(): JSX.Element {
     focusEditorNormalMode()
   }
 
+  const closeSelected = async (): Promise<void> => {
+    const entry = results[active]
+    if (!entry) return
+    await closeTab(entry.path)
+    inputRef.current?.focus()
+  }
+
   return (
     <Modal size="md" layer="palette" onClose={close} closeOnEsc={false}>
       <div className="border-b border-paper-300/70 px-4 py-3">
@@ -334,6 +346,16 @@ export function BufferPalette(): JSX.Element {
                 e.preventDefault()
                 const entry = results[active]
                 if (entry) void open(entry)
+              } else if (
+                e.ctrlKey &&
+                !e.metaKey &&
+                !e.altKey &&
+                !e.shiftKey &&
+                e.key.toLowerCase() === 'd'
+              ) {
+                e.preventDefault()
+                e.stopPropagation()
+                void closeSelected()
               } else if (e.key === 'Escape') {
                 e.preventDefault()
                 e.stopPropagation()
@@ -398,7 +420,10 @@ export function BufferPalette(): JSX.Element {
             <kbd className="rounded bg-paper-200 px-1">↵</kbd> switch
           </span>
           <span>
-            <kbd className="rounded bg-paper-200 px-1">esc</kbd> close
+            <kbd className="rounded bg-paper-200 px-1">Ctrl+D</kbd> close buffer
+          </span>
+          <span>
+            <kbd className="rounded bg-paper-200 px-1">esc</kbd> dismiss
           </span>
         </div>
     </Modal>

--- a/packages/app-core/src/components/Editor.tsx
+++ b/packages/app-core/src/components/Editor.tsx
@@ -429,7 +429,9 @@ function registerVimCommands(): void {
 
   // #290/#312: make j/k move by display line through soft-wrapped content.
   // Shared with the Quick Note window (QuickCaptureApp) via the same helper.
-  registerDisplayLineMotion();
+  registerDisplayLineMotion(
+    () => useStore.getState().vimWrappedLineMotions,
+  );
   registerHeadingMotion();
 
   Vim.defineEx("write", "w", () => {

--- a/packages/app-core/src/components/FloatingNoteApp.tsx
+++ b/packages/app-core/src/components/FloatingNoteApp.tsx
@@ -41,6 +41,7 @@ import { syntaxHighlighting, HighlightStyle, defaultHighlightStyle } from '@code
 import { tags as t } from '@lezer/highlight'
 import { searchKeymap } from '@codemirror/search'
 import type { NoteContent, VaultChangeEvent } from '@shared/ipc'
+import type { VimWrappedLineMotionMode } from '@shared/app-config'
 import type { LineNumberMode } from '../store'
 import { livePreviewPlugin } from '../lib/cm-live-preview'
 import { headingFolding } from '../lib/cm-heading-fold'
@@ -98,6 +99,7 @@ export const paperHighlight = HighlightStyle.define([
 export interface FloatingPrefs {
   vimMode: boolean
   vimInsertEscape: string
+  vimWrappedLineMotions: VimWrappedLineMotionMode
   livePreview: boolean
   themeId: string
   themeFamily: ThemeFamily
@@ -117,6 +119,7 @@ export function loadFloatingPrefs(): FloatingPrefs {
   const fallback: FloatingPrefs = {
     vimMode: true,
     vimInsertEscape: '',
+    vimWrappedLineMotions: 'display',
     livePreview: true,
     themeId: DEFAULT_THEME_ID,
     themeFamily: 'gruvbox',
@@ -144,6 +147,8 @@ export function loadFloatingPrefs(): FloatingPrefs {
     return {
       ...fallback,
       ...parsed,
+      vimWrappedLineMotions:
+        parsed.vimWrappedLineMotions === 'logical' ? 'logical' : 'display',
       themeFamily: (parsed.themeFamily as ThemeFamily) ?? fallback.themeFamily,
       themeMode: (parsed.themeMode as ThemeMode) ?? fallback.themeMode,
       lineNumberMode,
@@ -430,9 +435,9 @@ export function FloatingNoteApp({ notePath }: { notePath: string }): JSX.Element
     floatingHandlers.close = (): void => {
       window.zen.windowClose()
     }
-    registerFloatingVimCommands()
+    registerFloatingVimCommands(() => prefs.vimWrappedLineMotions)
     applyVimInsertEscape(prefs.vimInsertEscape)
-  }, [persist, prefs.vimInsertEscape])
+  }, [persist, prefs.vimInsertEscape, prefs.vimWrappedLineMotions])
 
   const title = useMemo(() => {
     if (content?.title) return content.title
@@ -546,11 +551,13 @@ function deferredClose(): void {
   setTimeout(() => floatingHandlers.close?.(), 0)
 }
 
-function registerFloatingVimCommands(): void {
+function registerFloatingVimCommands(
+  getWrappedLineMotionMode: () => VimWrappedLineMotionMode
+): void {
+  registerDisplayLineMotion(getWrappedLineMotionMode)
   if (floatingVimRegistered) return
   floatingVimRegistered = true
 
-  registerDisplayLineMotion()
   registerHeadingMotion()
 
   Vim.defineEx('write', 'w', () => {

--- a/packages/app-core/src/components/QuickCaptureApp.tsx
+++ b/packages/app-core/src/components/QuickCaptureApp.tsx
@@ -63,6 +63,7 @@ import { completionKeymapForEditor, completionNavKeymap } from '../lib/cm-comple
 import { slashCommandRender, templateSlashCommandSource } from '../lib/cm-slash-commands'
 import { calloutTypeSource } from '../lib/cm-callouts'
 import type { NoteMeta } from '@shared/ipc'
+import type { VimWrappedLineMotionMode } from '@shared/app-config'
 import {
   DEFAULT_THEME_ID,
   THEMES,
@@ -87,6 +88,7 @@ const PREFS_KEY = 'zen:prefs:v2'
 interface QuickCapturePrefs {
   vimMode: boolean
   vimInsertEscape: string
+  vimWrappedLineMotions: VimWrappedLineMotionMode
   themeId: string
   themeFamily: ThemeFamily
   themeMode: ThemeMode
@@ -103,6 +105,7 @@ function loadPrefs(): QuickCapturePrefs {
   const fallback: QuickCapturePrefs = {
     vimMode: true,
     vimInsertEscape: '',
+    vimWrappedLineMotions: 'display',
     themeId: DEFAULT_THEME_ID,
     themeFamily: 'gruvbox',
     themeMode: 'dark',
@@ -121,6 +124,8 @@ function loadPrefs(): QuickCapturePrefs {
     return {
       ...fallback,
       ...parsed,
+      vimWrappedLineMotions:
+        parsed.vimWrappedLineMotions === 'logical' ? 'logical' : 'display',
       themeFamily: (parsed.themeFamily as ThemeFamily) ?? fallback.themeFamily,
       themeMode: (parsed.themeMode as ThemeMode) ?? fallback.themeMode,
       editorTabSize: normalizeEditorTabSize(parsed.editorTabSize)
@@ -203,13 +208,15 @@ let vimRegistered = false
  *  `windowClose` synchronously inside the ex callback occasionally
  *  surfaces as "Object has been destroyed" / dropped saves — exactly
  *  the same hazard documented on the floating-note window. */
-function registerCaptureVimCommands(): void {
+function registerCaptureVimCommands(
+  getWrappedLineMotionMode: () => VimWrappedLineMotionMode
+): void {
+  registerDisplayLineMotion(getWrappedLineMotionMode)
   if (vimRegistered) return
   vimRegistered = true
 
   // #312: this window is a separate Electron renderer with its own Vim, so it
   // needs its own registration to get the main editor's j/k display-line motion.
-  registerDisplayLineMotion()
   registerHeadingMotion()
 
   Vim.defineEx('write', 'w', () => {
@@ -532,9 +539,9 @@ export function QuickCaptureApp(): JSX.Element {
     vimHandlers.close = () => window.zen.windowClose()
     vimHandlers.newNote = resetToNew
     vimHandlers.openPicker = () => setOverlay('search')
-    registerCaptureVimCommands()
+    registerCaptureVimCommands(() => prefs.vimWrappedLineMotions)
     applyVimInsertEscape(prefs.vimInsertEscape)
-  }, [resetToNew, save, submitAndClose, prefs.vimInsertEscape])
+  }, [resetToNew, save, submitAndClose, prefs.vimInsertEscape, prefs.vimWrappedLineMotions])
 
   // Window-level chord handlers. We attach the listener exactly once
   // and read state through refs so the handler is never operating on a

--- a/packages/app-core/src/components/SettingsModal.test.ts
+++ b/packages/app-core/src/components/SettingsModal.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => {
       darkSidebar: false,
       editorFontSize: 16,
       editorLineHeight: 1.6,
+      editorScrollOff: 0,
       fzfBinaryPath: null,
       hiddenWorkflowPresets: [],
       hideBuiltinTemplates: false,
@@ -57,6 +58,8 @@ const mocks = vi.hoisted(() => {
       vaultTextSearchBackend: "auto",
       vimInsertEscape: "",
       vimMode: false,
+      vimWrappedLineMotions: "logical",
+      setVimWrappedLineMotions: vi.fn(),
       whichKeyHintMode: "timed",
       whichKeyHintTimeoutMs: 1200,
       whichKeyHints: true,
@@ -127,6 +130,8 @@ describe("SettingsModal date note directories", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.state.vimMode = false;
+    mocks.state.vimWrappedLineMotions = "logical";
     (
       globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
     ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -253,6 +258,32 @@ describe("SettingsModal date note directories", () => {
     expect(mocks.state.setTextReplacements).toHaveBeenCalledWith({
       "(c)": "→",
     });
+  });
+
+  it("offers display-row and logical-line Vim motion behavior", async () => {
+    mocks.state.vimMode = true;
+    await act(async () => {
+      root.render(createElement(SettingsModal));
+    });
+
+    const search = [...host.querySelectorAll<HTMLInputElement>("input")].find(
+      (input) => input.placeholder === "Search settings…",
+    );
+    await act(async () => changeInput(search!, "wrapped line motions"));
+
+    const displayRow = [
+      ...host.querySelectorAll<HTMLButtonElement>("button"),
+    ].find((button) => button.textContent?.trim() === "Display row");
+    const logicalLine = [
+      ...host.querySelectorAll<HTMLButtonElement>("button"),
+    ].find((button) => button.textContent?.trim() === "Logical line");
+    expect(displayRow).toBeTruthy();
+    expect(logicalLine).toBeTruthy();
+
+    await act(async () => displayRow!.click());
+    expect(mocks.state.setVimWrappedLineMotions).toHaveBeenCalledWith(
+      "display",
+    );
   });
 
   it("opens directly to ZenNotes Cloud when requested by the app shell", async () => {

--- a/packages/app-core/src/components/SettingsModal.tsx
+++ b/packages/app-core/src/components/SettingsModal.tsx
@@ -18,6 +18,7 @@ import {
   DEFAULT_MONTHLY_NOTE_TITLE_PATTERN,
   DEFAULT_MONTHLY_NOTES_DIRECTORY,
 } from "@shared/ipc";
+import type { VimWrappedLineMotionMode } from "@shared/app-config";
 import type {
   AppUpdateState,
   CliInstallStatus,
@@ -442,6 +443,10 @@ export function SettingsModal(): JSX.Element {
   const setVimInsertEscape = useStore((s) => s.setVimInsertEscape);
   const vimYankToClipboard = useStore((s) => s.vimYankToClipboard);
   const setVimYankToClipboard = useStore((s) => s.setVimYankToClipboard);
+  const vimWrappedLineMotions = useStore((s) => s.vimWrappedLineMotions);
+  const setVimWrappedLineMotions = useStore(
+    (s) => s.setVimWrappedLineMotions,
+  );
   const keymapOverrides = useStore((s) => s.keymapOverrides);
   const setKeymapBinding = useStore((s) => s.setKeymapBinding);
   const resetAllKeymaps = useStore((s) => s.resetAllKeymaps);
@@ -1262,6 +1267,9 @@ export function SettingsModal(): JSX.Element {
   }, []);
 
   const leaderKeyHintsTargetId = vimMode ? "leader-key-hints" : "vim-mode";
+  const wrappedLineMotionsTargetId = vimMode
+    ? "wrapped-line-motions"
+    : "vim-mode";
   const leaderHintBehaviorTargetId =
     vimMode && whichKeyHints ? "leader-hint-behavior" : leaderKeyHintsTargetId;
   const leaderHintDurationTargetId =
@@ -1787,6 +1795,14 @@ export function SettingsModal(): JSX.Element {
           keywords: ["vim", "motions"],
         },
         {
+          id: "wrapped-line-motions",
+          title: "Wrapped line motions",
+          description:
+            "Choose whether $, I, A, and dependent operators follow a visible display row or the complete logical line.",
+          keywords: ["vim", "word wrap", "display row", "logical line", "$", "I", "A"],
+          targetId: wrappedLineMotionsTargetId,
+        },
+        {
           id: "vim-insert-escape",
           title: "Exit insert mode with",
           description:
@@ -2146,6 +2162,7 @@ export function SettingsModal(): JSX.Element {
           title: "Vim",
           searchIds: [
             "vim-mode",
+            "wrapped-line-motions",
             "vim-insert-escape",
             "leader-key-hints",
             "leader-hint-behavior",
@@ -2167,6 +2184,21 @@ export function SettingsModal(): JSX.Element {
                 />
                 {vimMode ? (
                   <>
+                    <SegmentedRow
+                      label="Wrapped line motions"
+                      description="Display row keeps $, I, A, v$, y$, d$, and c$ on the visible wrapped row. Logical line restores traditional Vim behavior; g0, g^, and g$ still target the display row."
+                      value={vimWrappedLineMotions}
+                      settingId="wrapped-line-motions"
+                      options={[
+                        { value: "display", label: "Display row" },
+                        { value: "logical", label: "Logical line" },
+                      ]}
+                      onChange={(next) =>
+                        setVimWrappedLineMotions(
+                          next as VimWrappedLineMotionMode,
+                        )
+                      }
+                    />
                     <TextInputRow
                       label="Exit insert mode with"
                       description="Type this key sequence in insert mode to act as Escape, e.g. jk or jj. Leave empty to disable."

--- a/packages/app-core/src/lib/cm-vim-display-line.test.ts
+++ b/packages/app-core/src/lib/cm-vim-display-line.test.ts
@@ -3,6 +3,7 @@ import { EditorState } from '@codemirror/state'
 import type { EditorView } from '@codemirror/view'
 import { mathRenderExtension } from './cm-math-render'
 import {
+  zenEnterInsertAtLineBoundary,
   zenMoveByDisplayLine,
   zenMoveToDisplayLineBoundary,
   zenMoveToViewportEdge
@@ -330,6 +331,70 @@ describe('wrapped display-row boundaries (#536)', () => {
     expect(
       zenMoveToDisplayLineBoundary(cm, { line: 4, ch: 7 }, { forward: true, repeat: 3 })
     ).toEqual({ line: 6, ch: Infinity })
+    expect(cm.execCommand).not.toHaveBeenCalled()
+  })
+})
+
+describe('configurable wrapped-line boundaries (#638)', () => {
+  it('moves a bare $ to the logical line end without measuring the display row', () => {
+    const cm = {
+      execCommand: vi.fn(),
+      getCursor: vi.fn()
+    }
+
+    expect(
+      zenMoveToDisplayLineBoundary(cm, { line: 4, ch: 7 }, {
+        forward: true,
+        repeat: 1,
+        lineMode: 'logical'
+      })
+    ).toEqual({ line: 4, ch: Infinity })
+    expect(cm.execCommand).not.toHaveBeenCalled()
+  })
+
+  it('enters insert mode at the first non-blank character of the logical line for I', () => {
+    const enterInsertMode = vi.fn()
+    const cm = {
+      execCommand: vi.fn(),
+      getCursor: () => ({ line: 4, ch: 30 }),
+      getLine: () => '    logical line'
+    }
+
+    zenEnterInsertAtLineBoundary.call(
+      { enterInsertMode },
+      cm,
+      { forward: false, lineMode: 'logical' },
+      { insertMode: false }
+    )
+
+    expect(enterInsertMode).toHaveBeenCalledWith(
+      cm,
+      { head: { line: 4, ch: 4 }, insertAt: 'inplace', repeat: undefined },
+      { insertMode: false }
+    )
+    expect(cm.execCommand).not.toHaveBeenCalled()
+  })
+
+  it('enters insert mode at the logical line end for A', () => {
+    const enterInsertMode = vi.fn()
+    const cm = {
+      execCommand: vi.fn(),
+      getCursor: () => ({ line: 4, ch: 7 }),
+      getLine: () => 'complete logical line'
+    }
+
+    zenEnterInsertAtLineBoundary.call(
+      { enterInsertMode },
+      cm,
+      { forward: true, lineMode: 'logical' },
+      { insertMode: false }
+    )
+
+    expect(enterInsertMode).toHaveBeenCalledWith(
+      cm,
+      { head: { line: 4, ch: 21 }, insertAt: 'inplace', repeat: undefined },
+      { insertMode: false }
+    )
     expect(cm.execCommand).not.toHaveBeenCalled()
   })
 })

--- a/packages/app-core/src/lib/cm-vim-display-line.ts
+++ b/packages/app-core/src/lib/cm-vim-display-line.ts
@@ -1,5 +1,6 @@
 import { CodeMirror, Vim } from '@replit/codemirror-vim'
 import type { EditorView } from '@codemirror/view'
+import type { VimWrappedLineMotionMode } from '@shared/app-config'
 import { displayRowEdge } from './cm-display-row'
 import { mathBlockLineRanges } from './cm-math-render'
 import { embedBlockLineRanges } from './cm-embed-render'
@@ -26,6 +27,7 @@ type VimDisplayBoundaryCm = {
   lastLine?: () => number
   execCommand: (command: string) => void
   getCursor: () => { line: number; ch: number; sticky?: string }
+  getLine?: (line: number) => string
   charCoords?: (
     position: { line: number; ch: number },
     mode: string
@@ -60,6 +62,38 @@ type VimMotionState = {
   lastHSPos?: number
   lastHPos?: number
   inputState?: { operator?: unknown }
+}
+
+type VimBoundaryMotionArgs = {
+  forward?: boolean
+  repeat?: number
+  /** Explicit display mode keeps g0 independent of the user's $/I/A choice. */
+  lineMode?: VimWrappedLineMotionMode
+}
+
+type VimActionTable = {
+  enterInsertMode: (
+    cm: unknown,
+    args: {
+      head: { line: number; ch: number }
+      insertAt: 'inplace'
+      repeat?: number
+    },
+    vim: unknown
+  ) => void
+}
+
+let readWrappedLineMotionMode: () => VimWrappedLineMotionMode = () => 'display'
+
+function wrappedLineMotionMode(
+  explicit?: VimWrappedLineMotionMode
+): VimWrappedLineMotionMode {
+  if (explicit) return explicit
+  try {
+    return readWrappedLineMotionMode() === 'logical' ? 'logical' : 'display'
+  } catch {
+    return 'display'
+  }
 }
 
 let pixelMotionFailureWarned = false
@@ -263,9 +297,17 @@ export function zenMoveByDisplayLine(
 export function zenMoveToDisplayLineBoundary(
   cm: VimDisplayBoundaryCm,
   head: { line: number; ch: number },
-  motionArgs: { forward?: boolean; repeat?: number }
+  motionArgs: VimBoundaryMotionArgs
 ): { line: number; ch: number } {
   const repeat = motionArgs.repeat || 1
+  if (wrappedLineMotionMode(motionArgs.lineMode) === 'logical') {
+    const first = cm.firstLine?.() ?? 0
+    const last = cm.lastLine?.() ?? head.line + repeat - 1
+    const line = Math.max(first, Math.min(last, head.line + repeat - 1))
+    if (motionArgs.forward) return new CodeMirror.Pos(line, Infinity)
+    const text = logicalLineText(cm, head.line)
+    return new CodeMirror.Pos(head.line, text == null ? 0 : firstNonWhitespace(text))
+  }
   if (motionArgs.forward && repeat > 1) {
     const first = cm.firstLine?.() ?? 0
     const last = cm.lastLine?.() ?? head.line + repeat - 1
@@ -335,6 +377,63 @@ function firstNonWhitespace(text: string): number {
   return index < 0 ? text.length : index
 }
 
+function logicalLineText(cm: VimDisplayBoundaryCm, lineNumber: number): string | null {
+  const fromAdapter = cm.getLine?.(lineNumber)
+  if (typeof fromAdapter === 'string') return fromAdapter
+  const doc = cm.cm6?.state.doc
+  if (!doc || lineNumber + 1 > doc.lines) return null
+  return doc.line(lineNumber + 1).text
+}
+
+/** Enter insert mode at either the visible display-row edge or logical line edge. */
+export function zenEnterInsertAtLineBoundary(
+  this: VimActionTable,
+  cm: VimDisplayBoundaryCm,
+  actionArgs: VimBoundaryMotionArgs,
+  vim: unknown
+): void {
+  const cursor = cm.getCursor()
+  let target: { line: number; ch: number }
+  if (wrappedLineMotionMode(actionArgs.lineMode) === 'logical') {
+    const text = logicalLineText(cm, cursor.line)
+    target = new CodeMirror.Pos(
+      cursor.line,
+      actionArgs.forward ? (text?.length ?? Infinity) : firstNonWhitespace(text ?? '')
+    )
+  } else if (actionArgs.forward) {
+    // Insert at the raw display boundary. The normal-mode `$` motion backs up
+    // to the last visible character, but `A` belongs after it.
+    target = pixelMotionFallback(
+      () => {
+        const view = cm.cm6
+        if (view && cursor.line + 1 <= view.state.doc.lines) {
+          const line = view.state.doc.line(cursor.line + 1)
+          const pos = Math.min(line.to, line.from + Math.max(0, cursor.ch))
+          const edge = displayRowEdge(view, pos, true)
+          if (edge != null) return new CodeMirror.Pos(cursor.line, edge - line.from)
+          // No usable coordinates: append at the LOGICAL line end, like plain
+          // Vim, rather than goLineRight's rightmost visible glyph, which live
+          // preview's hidden closing tokens pull short (#582).
+          return new CodeMirror.Pos(cursor.line, line.length)
+        }
+        cm.execCommand('goLineRight')
+        return cm.getCursor()
+      },
+      () => cm.getCursor()
+    )
+  } else {
+    target = zenMoveToDisplayLineBoundary(cm, cursor, {
+      forward: false,
+      lineMode: 'display'
+    })
+  }
+  this.enterInsertMode(
+    cm,
+    { head: target, insertAt: 'inplace', repeat: actionArgs.repeat },
+    vim
+  )
+}
+
 /**
  * Preserve Vim's first press of H/L, then let another press at the same edge
  * step beyond the viewport. CodeMirror scrolls that returned position into
@@ -381,7 +480,10 @@ let displayLineMotionRegistered = false
  * normal + visual contexts, so operator-pending motions (dj/yj/cj) keep Vim's
  * default logical movement. Idempotent — safe to call once per renderer / on HMR.
  */
-export function registerDisplayLineMotion(): void {
+export function registerDisplayLineMotion(
+  getWrappedLineMotionMode?: () => VimWrappedLineMotionMode
+): void {
+  if (getWrappedLineMotionMode) readWrappedLineMotionMode = getWrappedLineMotionMode
   if (displayLineMotionRegistered) return
   displayLineMotionRegistered = true
   // The package's MotionFn type is looser/different than our precise params; the
@@ -398,57 +500,9 @@ export function registerDisplayLineMotion(): void {
     'zenMoveToViewportEdge',
     zenMoveToViewportEdge as unknown as Parameters<typeof Vim.defineMotion>[1]
   )
-  type VimActionTable = {
-    enterInsertMode: (
-      cm: unknown,
-      args: {
-        head: { line: number; ch: number }
-        insertAt: 'inplace'
-        repeat?: number
-      },
-      vim: unknown
-    ) => void
-  }
   Vim.defineAction(
     'zenEnterInsertAtDisplayLineBoundary',
-    function (
-      this: VimActionTable,
-      cm: VimDisplayBoundaryCm,
-      actionArgs: { forward?: boolean; repeat?: number },
-      vim: unknown
-    ) {
-      let target: { line: number; ch: number }
-      if (actionArgs.forward) {
-        // Insert at the raw display boundary. The normal-mode `$` motion
-        // backs up to the last visible character, but `A` belongs after it.
-        target = pixelMotionFallback(
-          () => {
-            const view = cm.cm6
-            const cursor = cm.getCursor()
-            if (view && cursor.line + 1 <= view.state.doc.lines) {
-              const line = view.state.doc.line(cursor.line + 1)
-              const pos = Math.min(line.to, line.from + Math.max(0, cursor.ch))
-              const edge = displayRowEdge(view, pos, true)
-              if (edge != null) return new CodeMirror.Pos(cursor.line, edge - line.from)
-              // No usable coordinates: append at the LOGICAL line end, like
-              // plain Vim, rather than goLineRight's rightmost visible glyph,
-              // which live preview's hidden closing tokens pull short (#582).
-              return new CodeMirror.Pos(cursor.line, line.length)
-            }
-            cm.execCommand('goLineRight')
-            return cm.getCursor()
-          },
-          () => cm.getCursor()
-        )
-      } else {
-        target = zenMoveToDisplayLineBoundary(cm, cm.getCursor(), { forward: false })
-      }
-      this.enterInsertMode(
-        cm,
-        { head: target, insertAt: 'inplace', repeat: actionArgs.repeat },
-        vim
-      )
-    } as unknown as Parameters<typeof Vim.defineAction>[1]
+    zenEnterInsertAtLineBoundary as unknown as Parameters<typeof Vim.defineAction>[1]
   )
   for (const context of ['normal', 'visual'] as const) {
     Vim.mapCommand(
@@ -492,7 +546,7 @@ export function registerDisplayLineMotion(): void {
       'g0',
       'motion',
       'zenMoveToDisplayLineBoundary',
-      { forward: false },
+      { forward: false, lineMode: 'display' },
       { context }
     )
   }

--- a/packages/app-core/src/lib/help.ts
+++ b/packages/app-core/src/lib/help.ts
@@ -992,6 +992,7 @@ export const HELP_SETTINGS: HelpSettingsSection[] = [
     title: 'Editor behavior',
     items: [
       { label: 'Vim mode', detail: 'Turn CodeMirror Vim bindings on or off for the editor and reference pane.' },
+      { label: 'Wrapped line motions', detail: 'Choose whether Vim $, I, A, and dependent operators such as v$, y$, d$, and c$ stop at the current visible display row or the full logical line when Word wrap is on. Explicit display-row motions g0, g^, and g$ stay display-row based in either mode.' },
       { label: 'Sync clipboard with Vim registers', detail: 'Mirror Vim and the system clipboard in both directions (like Vim\'s clipboard=unnamed): yank, delete, and change (y/d/c/x) copy to the clipboard, and p / P paste whatever is on the clipboard, so you can move text between ZenNotes and other apps without leaving normal mode. Only available when Vim mode is enabled.' },
       { label: 'Leader key hints', detail: 'Show a which-key style guide after pressing the configured Leader key so available leader actions stay visible while you decide. This setting is only available when Vim mode is enabled.' },
       { label: 'Leader hint behavior', detail: 'Choose whether leader hints auto-hide after a timeout or stay open until you dismiss them with the Leader key or Esc. These controls only appear when Vim mode is enabled.' },

--- a/packages/app-core/src/lib/help.ts
+++ b/packages/app-core/src/lib/help.ts
@@ -513,7 +513,7 @@ export const HELP_SHORTCUT_SECTIONS: HelpShortcutSection[] = [
       { keys: 'Ctrl-w v', action: 'Split right', detail: 'Clone the current tab into a pane to the right.' },
       { keys: 'Ctrl-w s', action: 'Split down', detail: 'Clone the current tab into a pane below.' },
       { keys: '[b / ]b', action: 'Previous / next buffer', detail: 'Move across open buffers, falling back to recent notes when only one buffer is open. Both take a count: `3]b` jumps three buffers forward, wrapping around the ring.' },
-      { keys: 'Space o', action: 'Open buffers', detail: 'Show a searchable list of every open buffer across every pane.' },
+      { keys: 'Space o', action: 'Open buffers', detail: 'Show a searchable list of every open buffer across every pane. Press Ctrl+D to close the highlighted buffer without leaving the list.' },
       { keys: 'Space f', action: 'Search notes', detail: 'Open the vault-wide note search palette.' },
       { keys: 'Space s t', action: 'Search vault text', detail: 'Fuzzy-search matching text lines across notes in Inbox, Quick Notes, and Archive.' },
       { keys: 'Space e', action: 'Toggle left sidebar', detail: 'Show or hide the folder/tag sidebar without touching the mouse.' },

--- a/packages/app-core/src/store.test.ts
+++ b/packages/app-core/src/store.test.ts
@@ -1406,6 +1406,33 @@ describe('pdfExportUseTheme — theme in PDF export', () => {
   })
 })
 
+describe('vimWrappedLineMotions (#638)', () => {
+  it('defaults to display rows and round-trips the logical-line preference', async () => {
+    installZen()
+    const { useStore } = await loadStore()
+    expect(useStore.getState().vimWrappedLineMotions).toBe('display')
+
+    useStore.getState().setVimWrappedLineMotions('logical')
+    expect(useStore.getState().vimWrappedLineMotions).toBe('logical')
+    const saved = JSON.parse(localStorage.getItem('zen:prefs:v2') ?? '{}')
+    expect(saved.vimWrappedLineMotions).toBe('logical')
+
+    vi.resetModules()
+    const reloaded = await import('./store')
+    expect(reloaded.useStore.getState().vimWrappedLineMotions).toBe('logical')
+  })
+
+  it('normalizes an unknown stored value to display rows', async () => {
+    installZen()
+    localStorage.setItem(
+      'zen:prefs:v2',
+      JSON.stringify({ vimWrappedLineMotions: 'somewhere-else' })
+    )
+    const { useStore } = await loadStore()
+    expect(useStore.getState().vimWrappedLineMotions).toBe('display')
+  })
+})
+
 describe('workflowsEnabled (Workflows feature switch)', () => {
   it('defaults off and round-trips the opt-in through persistence', async () => {
     installZen()

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -118,7 +118,8 @@ import {
   type AppConfigPortable,
   type CompletedTaskStyle,
   type MathRenderer,
-  type TimeFormat
+  type TimeFormat,
+  type VimWrappedLineMotionMode
 } from '@shared/app-config'
 import {
   type LabelKey,
@@ -486,6 +487,9 @@ interface Prefs {
   /** When true, Vim yank/delete/change also copy to the system clipboard and
    *  `p` / `P` paste from it (like `set clipboard=unnamed`). */
   vimYankToClipboard: boolean
+  /** Whether unprefixed Vim line-boundary motions follow visible display rows
+   *  or the complete logical line when word wrap is enabled. */
+  vimWrappedLineMotions: VimWrappedLineMotionMode
   keymapOverrides: KeymapOverrides
   /** Enabled CSS overrides, keyed by filename (e.g. `"focus.css": "on"`). Persisted. */
   enabledOverrides: Record<string, string>
@@ -956,6 +960,7 @@ export const DEFAULT_PREFS: Prefs = {
   vimMode: true,
   vimInsertEscape: '',
   vimYankToClipboard: false,
+  vimWrappedLineMotions: 'display',
   keymapOverrides: {},
   whichKeyHints: true,
   whichKeyHintMode: 'timed',
@@ -1076,6 +1081,10 @@ function normalizePrefs(p: Partial<Prefs>): Prefs {
       typeof p.vimYankToClipboard === 'boolean'
         ? p.vimYankToClipboard
         : DEFAULT_PREFS.vimYankToClipboard,
+    vimWrappedLineMotions:
+      p.vimWrappedLineMotions === 'logical' || p.vimWrappedLineMotions === 'display'
+        ? p.vimWrappedLineMotions
+        : DEFAULT_PREFS.vimWrappedLineMotions,
     keymapOverrides: normalizeKeymapOverrides(p.keymapOverrides),
     enabledOverrides: normalizeEnabledOverrides(p.enabledOverrides),
     themeTweaks: normalizeThemeTweaks(p.themeTweaks),
@@ -2118,6 +2127,7 @@ function collectPrefs(s: {
   vimMode: boolean
   vimInsertEscape: string
   vimYankToClipboard: boolean
+  vimWrappedLineMotions: VimWrappedLineMotionMode
   keymapOverrides: KeymapOverrides
   enabledOverrides: Record<string, string>
   themeTweaks: Record<string, string>
@@ -2211,6 +2221,7 @@ function collectPrefs(s: {
     vimMode: s.vimMode,
     vimInsertEscape: s.vimInsertEscape,
     vimYankToClipboard: s.vimYankToClipboard,
+    vimWrappedLineMotions: s.vimWrappedLineMotions,
     keymapOverrides: s.keymapOverrides,
     enabledOverrides: s.enabledOverrides,
     themeTweaks: s.themeTweaks,
@@ -2713,6 +2724,8 @@ interface Store {
   vimInsertEscape: string
   /** When true, Vim yank/delete/change also copy to the system clipboard. Persisted. */
   vimYankToClipboard: boolean
+  /** Display-row or logical-line semantics for $, I, A and dependent operators. */
+  vimWrappedLineMotions: VimWrappedLineMotionMode
   keymapOverrides: KeymapOverrides
   /** Enabled CSS overrides, keyed by filename. Persisted to config [overrides]. */
   enabledOverrides: Record<string, string>
@@ -3207,6 +3220,7 @@ interface Store {
   setVimMode: (on: boolean) => void
   setVimInsertEscape: (sequence: string) => void
   setVimYankToClipboard: (on: boolean) => void
+  setVimWrappedLineMotions: (mode: VimWrappedLineMotionMode) => void
   setKeymapBinding: (id: KeymapId, binding: string | null) => void
   resetAllKeymaps: () => void
   setWhichKeyHints: (on: boolean) => void
@@ -4503,6 +4517,7 @@ export const useStore = create<Store>((set, get) => {
   vimMode: loadPrefs().vimMode,
   vimInsertEscape: loadPrefs().vimInsertEscape,
   vimYankToClipboard: loadPrefs().vimYankToClipboard,
+  vimWrappedLineMotions: loadPrefs().vimWrappedLineMotions,
   keymapOverrides: loadPrefs().keymapOverrides,
   enabledOverrides: loadPrefs().enabledOverrides,
   themeTweaks: loadPrefs().themeTweaks,
@@ -7043,6 +7058,10 @@ export const useStore = create<Store>((set, get) => {
   },
   setVimYankToClipboard: (on) => {
     set({ vimYankToClipboard: on })
+    savePrefs(collectPrefs(get()))
+  },
+  setVimWrappedLineMotions: (mode) => {
+    set({ vimWrappedLineMotions: mode })
     savePrefs(collectPrefs(get()))
   },
   setKeymapBinding: (id, binding) => {

--- a/packages/bridge-contract/package.json
+++ b/packages/bridge-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/bridge-contract",
   "private": true,
-  "version": "2.31.0",
+  "version": "2.32.0",
   "type": "module",
   "exports": {
     "./bridge": "./src/bridge.ts",

--- a/packages/shared-domain/package.json
+++ b/packages/shared-domain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-domain",
   "private": true,
-  "version": "2.31.0",
+  "version": "2.32.0",
   "type": "module",
   "exports": {
     "./*": "./src/*.ts"

--- a/packages/shared-domain/src/app-config.ts
+++ b/packages/shared-domain/src/app-config.ts
@@ -30,6 +30,9 @@ export type CompletedTaskStyle = 'none' | 'strikethrough' | 'gray' | 'gray-strik
  */
 export type MathRenderer = 'katex' | 'typst'
 
+/** How Vim's unprefixed line-boundary motions treat soft-wrapped lines. */
+export type VimWrappedLineMotionMode = 'display' | 'logical'
+
 /**
  * The host locale's 12/24-hour convention, used as the `timeFormat` default so a
  * fresh install matches the operating system out of the box. Reads only the
@@ -59,6 +62,7 @@ export const PORTABLE_PREF_KEYS = [
   'vimMode',
   'vimInsertEscape',
   'vimYankToClipboard',
+  'vimWrappedLineMotions',
   'whichKeyHints',
   'whichKeyHintMode',
   'whichKeyHintTimeoutMs',
@@ -178,6 +182,7 @@ export const PORTABLE_DEFAULTS: Record<PortablePrefKey, unknown> = {
   vimMode: true,
   vimInsertEscape: '',
   vimYankToClipboard: false,
+  vimWrappedLineMotions: 'display',
   whichKeyHints: true,
   whichKeyHintMode: 'timed',
   whichKeyHintTimeoutMs: 900,

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-ui",
   "private": true,
-  "version": "2.31.0",
+  "version": "2.32.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## Summary

- make wrapped Vim motions configurable between display-row and logical-line behavior (#638)
- add Ctrl+D selective cleanup to Open Buffers while keeping the picker open (#641)
- preserve custom task status and inline fields across server watcher rescans and refreshes (#643)
- bump all workspace manifests to 2.32.0

## Verification

- npm run build:prod
  - all workspace typechecks passed
  - all unit and integration test tasks passed (only existing performance skips)
  - desktop, web, and server production builds passed
- recorded captioned demos for all three changes in the local v2.32.0 release docs

## Release

Release notes and social copy are prepared locally. After merge, tag the merge commit as v2.32.0, wait for the signed release assets, then refresh the Nix packaging hashes and downstream package.