### PR TITLE
packaging: publish 2.32.0 channels

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zennotes-bin
 	pkgdesc = Keyboard-first, local-first Markdown notes with vim motions and live preview
-	pkgver = 2.31.0
+	pkgver = 2.32.0
 	pkgrel = 1
 	url = https://github.com/ZenNotes/zennotes
 	arch = x86_64
@@ -13,7 +13,7 @@ pkgbase = zennotes-bin
 	provides = zennotes
 	conflicts = zennotes
 	options = !strip
-	source = ZenNotes-2.31.0-linux-x64.tar.gz::https://github.com/ZenNotes/zennotes/releases/download/v2.31.0/ZenNotes-2.31.0-linux-x64.tar.gz
-	sha256sums = 406659437b1a379831f98515bea6ba15153605f5ee0fd06e77caa98e9ec4d839
+	source = ZenNotes-2.32.0-linux-x64.tar.gz::https://github.com/ZenNotes/zennotes/releases/download/v2.32.0/ZenNotes-2.32.0-linux-x64.tar.gz
+	sha256sums = 6bf79fee4184c620b49466b60d74d23947430297060014936faffe54f16d22ad
 
 pkgname = zennotes-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -10,7 +10,7 @@
 
 pkgname=zennotes-bin
 _appname=ZenNotes
-pkgver=2.31.0
+pkgver=2.32.0
 pkgrel=1
 pkgdesc="Keyboard-first, local-first Markdown notes with vim motions and live preview"
 arch=('x86_64')
@@ -30,7 +30,7 @@ source=(
 
 # sha256 of the uploaded ZenNotes-${pkgver}-linux-x64.tar.gz release asset
 # (GitHub's authoritative asset digest; no Arch tooling needed).
-sha256sums=('406659437b1a379831f98515bea6ba15153605f5ee0fd06e77caa98e9ec4d839')
+sha256sums=('6bf79fee4184c620b49466b60d74d23947430297060014936faffe54f16d22ad')
 
 package() {
   cd "${srcdir}"

--- a/packaging/homebrew/Casks/zennotes.rb
+++ b/packaging/homebrew/Casks/zennotes.rb
@@ -1,9 +1,9 @@
 cask "zennotes" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.31.0"
-  sha256 arm:   "5e6ae9bb1633bf2ffb03c47db0288e8af3be4e5d81297e099d1aa42a39263b76",
-         intel: "9dbe0914f96cdc9945dfbeff98452964e73a36137b4844a34891be4171155397"
+  version "2.32.0"
+  sha256 arm:   "e702168c3c8c693c28fe805d3e04621392e108fd4f3496e287e93cb3934c4874",
+         intel: "b7a8c60fe71c7eddaf8cb21ce9a0d12d2353be121725876427492d03d69aa9ef"
 
   url "https://github.com/ZenNotes/zennotes/releases/download/v#{version}/ZenNotes-#{version}-mac-#{arch}.dmg"
   name "ZenNotes"


### PR DESCRIPTION
## Summary

- publish zennotes-bin 2.32.0 metadata with the verified Linux tarball digest
- publish the Homebrew cask with both signed macOS DMG digests
- keep canonical packaging metadata aligned with the live AUR and Homebrew tap repositories

## Verification

- GitHub Release workflow: all macOS, Windows, Linux x64, and Linux ARM64 jobs passed
- Homebrew cask style: passed
- Homebrew online audit: passed
- AUR PKGBUILD shell syntax and metadata parity: passed
- release asset digests were read from the GitHub Releases API