### PR TITLE
Fix(cloud): honest sync status, clearer usage, and Cloud vault deletion

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/desktop",
   "productName": "ZenNotes",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "ZenNotes desktop shell",
   "private": true,
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/cloud-sync-client.test.ts
+++ b/apps/desktop/src/main/cloud-sync-client.test.ts
@@ -11,9 +11,9 @@ const temporaryDirectories: string[] = []
 
 afterEach(async () => {
   await Promise.all(
-    temporaryDirectories.splice(0).map((directory) =>
-      rm(directory, { recursive: true, force: true })
-    )
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
   )
 })
 
@@ -36,7 +36,9 @@ describe('createCloudSyncClient', () => {
     expect(fetchImplementation).toHaveBeenCalledWith(
       'https://zennotes.org/api/v1/vaults',
       expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: 'Bearer secret-token' })
+        headers: expect.objectContaining({
+          Authorization: 'Bearer secret-token'
+        })
       })
     )
     expect(fetchImplementation.mock.calls[0]?.[0]).not.toContain('secret-token')
@@ -67,7 +69,9 @@ describe('createCloudSyncClient', () => {
       new Response(
         JSON.stringify({
           message: 'The mutations.0.path field is required.',
-          errors: { 'mutations.0.path': ['The mutations.0.path field is required.'] }
+          errors: {
+            'mutations.0.path': ['The mutations.0.path field is required.']
+          }
         }),
         { status: 422, headers: { 'Content-Type': 'application/json' } }
       )
@@ -100,11 +104,13 @@ describe('createCloudSyncClient', () => {
     )
     const client = createCloudSyncClient('https://zennotes.org', 'token', fetchImplementation)
 
-    await expect(client.publishNote({
-      note_path: 'Empty.md',
-      title: 'Empty',
-      markdown: ''
-    })).rejects.toEqual(
+    await expect(
+      client.publishNote({
+        note_path: 'Empty.md',
+        title: 'Empty',
+        markdown: ''
+      })
+    ).rejects.toEqual(
       expect.objectContaining<Partial<CloudServiceRequestError>>({
         status: 422,
         code: 'VALIDATION_FAILED',
@@ -115,10 +121,17 @@ describe('createCloudSyncClient', () => {
 
   it('lets fetch set the multipart boundary for published-note assets', async () => {
     const fetchImplementation = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(JSON.stringify({ id: 42, slug: 'photo', url: 'https://zennotes.org/s/photo' }), {
-        status: 201,
-        headers: { 'Content-Type': 'application/json' }
-      })
+      new Response(
+        JSON.stringify({
+          id: 42,
+          slug: 'photo',
+          url: 'https://zennotes.org/s/photo'
+        }),
+        {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
     )
     const client = createCloudSyncClient('https://zennotes.org', 'token', fetchImplementation)
 
@@ -126,7 +139,14 @@ describe('createCloudSyncClient', () => {
       note_path: 'Photo.md',
       title: 'Photo',
       markdown: '![Photo](photo.png)',
-      assets: [{ ref: 'photo.png', name: 'photo.png', mime: 'image/png', base64: 'AQID' }]
+      assets: [
+        {
+          ref: 'photo.png',
+          name: 'photo.png',
+          mime: 'image/png',
+          base64: 'AQID'
+        }
+      ]
     })
 
     const options = fetchImplementation.mock.calls[0]?.[1]
@@ -145,7 +165,9 @@ describe('createCloudSyncClient', () => {
     })
 
     expect(fetchImplementation).toHaveBeenCalledTimes(1)
-    expect(fetchImplementation.mock.calls[0]?.[0]).toBe('https://zennotes.org/api/v1/vaults/vault-1/mutations')
+    expect(fetchImplementation.mock.calls[0]?.[0]).toBe(
+      'https://zennotes.org/api/v1/vaults/vault-1/mutations'
+    )
   })
 
   it('uploads files above the inline limit directly without sending the bearer token', async () => {
@@ -218,7 +240,11 @@ describe('createCloudSyncClient', () => {
       }
       throw new Error(`Unexpected request: ${url}`)
     })
-    const client = createCloudSyncClient('https://zennotes.org/', 'secret-token', fetchImplementation)
+    const client = createCloudSyncClient(
+      'https://zennotes.org/',
+      'secret-token',
+      fetchImplementation
+    )
 
     const result = await client.mutate('vault-1', { mutations: [mutation] })
 
@@ -263,7 +289,9 @@ describe('createCloudSyncClient', () => {
     expect(uploadedBodies[0]?.at(-1)).toBe(7)
 
     const completion = fetchImplementation.mock.calls[3]
-    expect(completion?.[0]).toBe('https://zennotes.org/api/v1/vaults/vault-1/uploads/upload-1/complete')
+    expect(completion?.[0]).toBe(
+      'https://zennotes.org/api/v1/vaults/vault-1/uploads/upload-1/complete'
+    )
     expect(new Headers(completion?.[1]?.headers).get('Authorization')).toBe('Bearer secret-token')
   })
 
@@ -320,20 +348,23 @@ describe('createCloudSyncClient', () => {
     const fetchImplementation = vi.fn<typeof fetch>(async (input, options) => {
       const url = String(input)
       if (url.endsWith('/uploads') && options?.method === 'POST') {
-        return jsonResponse({
-          data: {
-            id: 'upload-insecure',
-            operation_id: mutation.operation_id,
-            status: 'uploading',
-            expected_bytes: bytes.byteLength,
-            expires_at: '2026-08-19T18:30:00.000Z',
-            upload: {
-              method: 'PUT',
-              url: 'http://objects.example.test/upload-insecure',
-              headers: { 'Content-Type': 'application/octet-stream' }
+        return jsonResponse(
+          {
+            data: {
+              id: 'upload-insecure',
+              operation_id: mutation.operation_id,
+              status: 'uploading',
+              expected_bytes: bytes.byteLength,
+              expires_at: '2026-08-19T18:30:00.000Z',
+              upload: {
+                method: 'PUT',
+                url: 'http://objects.example.test/upload-insecure',
+                headers: { 'Content-Type': 'application/octet-stream' }
+              }
             }
-          }
-        }, 201)
+          },
+          201
+        )
       }
       if (url.endsWith('/uploads/upload-insecure') && options?.method === 'DELETE') {
         return new Response(null, { status: 204 })
@@ -359,20 +390,23 @@ describe('createCloudSyncClient', () => {
     const fetchImplementation = vi.fn<typeof fetch>(async (input, options) => {
       const url = String(input)
       if (url.endsWith('/uploads') && options?.method === 'POST') {
-        return jsonResponse({
-          data: {
-            id: 'upload-mismatch',
-            operation_id: mutation.operation_id,
-            status: 'uploading',
-            expected_bytes: bytes.byteLength - 1,
-            expires_at: '2026-08-19T18:30:00.000Z',
-            upload: {
-              method: 'PUT',
-              url: 'https://objects.example.test/upload-mismatch',
-              headers: { 'Content-Type': 'application/octet-stream' }
+        return jsonResponse(
+          {
+            data: {
+              id: 'upload-mismatch',
+              operation_id: mutation.operation_id,
+              status: 'uploading',
+              expected_bytes: bytes.byteLength - 1,
+              expires_at: '2026-08-19T18:30:00.000Z',
+              upload: {
+                method: 'PUT',
+                url: 'https://objects.example.test/upload-mismatch',
+                headers: { 'Content-Type': 'application/octet-stream' }
+              }
             }
-          }
-        }, 201)
+          },
+          201
+        )
       }
       if (url.endsWith('/uploads/upload-mismatch') && options?.method === 'DELETE') {
         return new Response(null, { status: 204 })
@@ -425,6 +459,57 @@ describe('createCloudSyncClient', () => {
           code: 'REVISION_CONFLICT',
           current_revision: 4,
           current_path: 'attachments/archive.zip'
+        }
+      ],
+      cursor: 0
+    })
+  })
+
+  it('preserves structured capacity details from a direct-upload conflict', async () => {
+    const bytes = Buffer.alloc(INLINE_UPLOAD_LIMIT_BYTES + 1, 15)
+    const mutation = upsertMutation(bytes.byteLength, bytes.toString('base64'))
+    const fetchImplementation = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input)
+      if (url.endsWith('/uploads')) {
+        return jsonResponse(
+          {
+            error: {
+              code: 'CAPACITY_EXCEEDED',
+              message: 'This upload would exceed the current Cloud capacity.',
+              details: {
+                dimension: 'sync_active_items',
+                used: 100,
+                reserved: 0,
+                limit: 100,
+                projected: 101,
+                can_retry_after_reduction: true
+              }
+            }
+          },
+          409
+        )
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    const client = createCloudSyncClient('https://zennotes.org', 'token', fetchImplementation)
+
+    await expect(client.mutate('vault-1', { mutations: [mutation] })).resolves.toEqual({
+      acknowledged: [],
+      conflicts: [
+        {
+          operation_id: mutation.operation_id,
+          item_id: mutation.item_id,
+          code: 'CAPACITY_EXCEEDED',
+          current_revision: null,
+          current_path: null,
+          capacity: {
+            dimension: 'sync_active_items',
+            used: 100,
+            reserved: 0,
+            limit: 100,
+            projected: 101,
+            can_retry_after_reduction: true
+          }
         }
       ],
       cursor: 0

--- a/apps/desktop/src/main/cloud-sync-client.ts
+++ b/apps/desktop/src/main/cloud-sync-client.ts
@@ -7,6 +7,7 @@ import { createReadStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import { Readable } from 'node:stream'
 import type {
+  CloudSyncCapacityConflict,
   CloudSyncConflict,
   CloudSyncConflictCode,
   CloudSyncMutation,
@@ -28,7 +29,9 @@ const SYNC_CONFLICT_CODES = new Set<CloudSyncConflictCode>([
   'REVISION_CONFLICT',
   'PATH_CONFLICT',
   'ITEM_DELETED',
-  'QUOTA_EXCEEDED'
+  'QUOTA_EXCEEDED',
+  'CAPACITY_EXCEEDED',
+  'FILE_SIZE_LIMIT_EXCEEDED'
 ])
 
 export class CloudServiceRequestError extends Error {
@@ -191,11 +194,12 @@ class BearerFetchTransport implements CloudSyncHttpTransport {
         Authorization: `Bearer ${this.token}`,
         ...(request.body === undefined || multipart ? {} : { 'Content-Type': 'application/json' })
       },
-      body: request.body === undefined
-        ? undefined
-        : request.body instanceof FormData
-          ? request.body
-          : JSON.stringify(request.body),
+      body:
+        request.body === undefined
+          ? undefined
+          : request.body instanceof FormData
+            ? request.body
+            : JSON.stringify(request.body),
       signal: AbortSignal.timeout(request.timeoutMs ?? 30_000)
     })
     const payload = await parseJson(response)
@@ -244,7 +248,11 @@ function asErrorPayload(payload: unknown): {
   }
   const candidate =
     response.error && typeof response.error === 'object'
-      ? (response.error as { code?: unknown; details?: unknown; message?: unknown })
+      ? (response.error as {
+          code?: unknown
+          details?: unknown
+          message?: unknown
+        })
       : response
   const validationMessage = firstValidationMessage(response.errors)
 
@@ -255,15 +263,19 @@ function asErrorPayload(payload: unknown): {
       : typeof candidate.message === 'string'
         ? { message: candidate.message }
         : {}),
-    ...(candidate.details && typeof candidate.details === 'object' && !Array.isArray(candidate.details)
+    ...(candidate.details &&
+    typeof candidate.details === 'object' &&
+    !Array.isArray(candidate.details)
       ? { details: candidate.details as Record<string, unknown> }
       : {})
   }
 }
 
 function usesDirectUpload(mutation: CloudSyncMutation): mutation is CloudSyncUpsertMutation {
-  return mutation.type === 'upsert' &&
+  return (
+    mutation.type === 'upsert' &&
     mutation.content.byte_length > CLOUD_SYNC_INLINE_UPLOAD_LIMIT_BYTES
+  )
 }
 
 function uploadRequest(mutation: CloudSyncUpsertMutation): CloudSyncUploadRequest {
@@ -327,7 +339,11 @@ function secureDirectUploadUrl(value: string): string {
 
   const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '')
   const loopback = hostname === 'localhost' || hostname === '::1' || hostname.startsWith('127.')
-  if ((url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) || url.username || url.password) {
+  if (
+    (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) ||
+    url.username ||
+    url.password
+  ) {
     throw insecureDirectUploadUrl()
   }
 
@@ -361,7 +377,9 @@ function directUploadInstruction(
 
 function uploadSessionId(initiation: CloudSyncUploadInitiationResponse): string | null {
   const candidate = initiation as unknown as { data?: unknown }
-  return isRecord(candidate.data) && typeof candidate.data.id === 'string' && candidate.data.id !== ''
+  return isRecord(candidate.data) &&
+    typeof candidate.data.id === 'string' &&
+    candidate.data.id !== ''
     ? candidate.data.id
     : null
 }
@@ -395,18 +413,42 @@ function directUploadConflict(
   }
   if (!SYNC_CONFLICT_CODES.has(error.code as CloudSyncConflictCode)) return null
 
+  const capacity = capacityConflictDetails(error.details)
+
   return {
     operation_id: mutation.operation_id,
     item_id: mutation.item_id,
     code: error.code as CloudSyncConflictCode,
     current_revision:
-      typeof error.details?.current_revision === 'number'
-        ? error.details.current_revision
-        : null,
+      typeof error.details?.current_revision === 'number' ? error.details.current_revision : null,
     current_path:
-      typeof error.details?.current_path === 'string'
-        ? error.details.current_path
-        : null
+      typeof error.details?.current_path === 'string' ? error.details.current_path : null,
+    ...(capacity ? { capacity } : {})
+  }
+}
+
+function capacityConflictDetails(
+  details: Record<string, unknown> | null
+): CloudSyncCapacityConflict | null {
+  if (
+    !details ||
+    typeof details.dimension !== 'string' ||
+    typeof details.used !== 'number' ||
+    typeof details.reserved !== 'number' ||
+    typeof details.limit !== 'number' ||
+    typeof details.projected !== 'number' ||
+    typeof details.can_retry_after_reduction !== 'boolean'
+  ) {
+    return null
+  }
+
+  return {
+    dimension: details.dimension,
+    used: details.used,
+    reserved: details.reserved,
+    limit: details.limit,
+    projected: details.projected,
+    can_retry_after_reduction: details.can_retry_after_reduction
   }
 }
 
@@ -419,7 +461,9 @@ function firstValidationMessage(errors: unknown): string | null {
 
   for (const messages of Object.values(errors)) {
     if (Array.isArray(messages)) {
-      const message = messages.find((candidate): candidate is string => typeof candidate === 'string')
+      const message = messages.find(
+        (candidate): candidate is string => typeof candidate === 'string'
+      )
       if (message) return message
     }
   }

--- a/apps/desktop/src/main/cloud-sync-service.test.ts
+++ b/apps/desktop/src/main/cloud-sync-service.test.ts
@@ -2,10 +2,12 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import type {
+  CloudAccountStatus,
   CloudSyncMutationRequest,
   CloudSyncVault
 } from '@zennotes/bridge-contract/cloud-sync'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CloudServiceRequestError } from './cloud-sync-client'
 import { DesktopCloudSyncService } from './cloud-sync-service'
 
 const temporaryDirectories: string[] = []
@@ -20,7 +22,8 @@ afterEach(async () => {
 
 async function setup(
   vaults: CloudSyncVault[] = [],
-  fetchImplementation?: typeof fetch
+  fetchImplementation?: typeof fetch,
+  accountStatus?: () => Promise<CloudAccountStatus>
 ) {
   const localRoot = await mkdtemp(path.join(os.tmpdir(), 'zennotes-local-vault-'))
   const storageDirectory = await mkdtemp(path.join(os.tmpdir(), 'zennotes-cloud-state-'))
@@ -64,6 +67,7 @@ async function setup(
         updated_at: '2026-08-10T12:00:00.000Z'
       }
     })),
+    deleteVault: vi.fn(async () => {}),
     manifest: vi.fn(async () => ({ data: [], cursor: 0, next_page: null })),
     changes: vi.fn(async () => ({ data: [], cursor: 0, has_more: false })),
     mutate: vi.fn(async (_vaultId: string, body: CloudSyncMutationRequest) => ({
@@ -144,15 +148,17 @@ async function setup(
   }
   const service = new DesktopCloudSyncService({
     storageDirectory,
-    accountStatus: async () => ({
-      state: 'connected',
-      account: {
-        base_url: 'https://zennotes.org',
-        user: { name: 'Ada', email: 'ada@example.com' },
-        device: { id: 'device-1', name: 'Test Mac', platform: 'desktop' },
-        connected_at: '2026-08-10T12:00:00.000Z'
-      }
-    }),
+    accountStatus:
+      accountStatus ??
+      (async () => ({
+        state: 'connected',
+        account: {
+          base_url: 'https://zennotes.org',
+          user: { name: 'Ada', email: 'ada@example.com' },
+          device: { id: 'device-1', name: 'Test Mac', platform: 'desktop' },
+          connected_at: '2026-08-10T12:00:00.000Z'
+        }
+      })),
     getSecret: async () => 'secret-token',
     createClient: () => client,
     fetchImplementation,
@@ -254,6 +260,30 @@ describe('DesktopCloudSyncService', () => {
     expect(client.unpublishNote).toHaveBeenCalledWith(42)
   })
 
+  it('treats the optional published-note list as empty when publishing is unavailable', async () => {
+    const disconnected = await setup([], undefined, async () => ({
+      state: 'disconnected',
+      account: null
+    }))
+
+    await expect(disconnected.service.listPublishedNotes()).resolves.toEqual([])
+    expect(disconnected.client.listPublishedNotes).not.toHaveBeenCalled()
+
+    const connected = await setup()
+    connected.client.listPublishedNotes.mockRejectedValueOnce(
+      new CloudServiceRequestError('Publishing is not included.', 403, 'FEATURE_NOT_ENTITLED')
+    )
+
+    await expect(connected.service.listPublishedNotes()).resolves.toEqual([])
+  })
+
+  it('still surfaces unexpected failures while listing published notes', async () => {
+    const { service, client } = await setup()
+    client.listPublishedNotes.mockRejectedValueOnce(new Error('Network unavailable'))
+
+    await expect(service.listPublishedNotes()).rejects.toThrow('Network unavailable')
+  })
+
   it('creates, links, and uploads an untracked local vault', async () => {
     const { service, client, localRoot } = await setup()
     await writeFile(path.join(localRoot, 'Note.md'), '# Local note')
@@ -264,6 +294,23 @@ describe('DesktopCloudSyncService', () => {
     expect(client.createVault).toHaveBeenCalledWith('My Notes')
     expect(client.mutate).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ pulled: 0, pushed: 1, conflicts: [] })
+  })
+
+  it('deletes the remote vault before removing the local device link', async () => {
+    const remoteVault: CloudSyncVault = {
+      id: 'vault-1',
+      name: 'Notes',
+      cursor: 0,
+      created_at: '2026-08-10T12:00:00.000Z',
+      updated_at: '2026-08-10T12:00:00.000Z'
+    }
+    const { service, client, localRoot } = await setup([remoteVault])
+    await service.link(localRoot, remoteVault.id)
+
+    await expect(service.deleteLinkedVault(localRoot)).resolves.toBeUndefined()
+
+    expect(client.deleteVault).toHaveBeenCalledWith(remoteVault.id)
+    await expect(service.linkedVault(localRoot)).resolves.toBeNull()
   })
 
   it('coalesces overlapping sync runs for the same local vault', async () => {

--- a/apps/desktop/src/main/cloud-sync-service.ts
+++ b/apps/desktop/src/main/cloud-sync-service.ts
@@ -25,6 +25,7 @@ import {
 } from '@zennotes/shared-domain/cloud-sync'
 import { setVaultSettings } from './vault'
 import type { CloudSyncApiClient } from '@zennotes/shared-domain/cloud-sync-api'
+import { CloudServiceRequestError } from './cloud-sync-client'
 import { createDesktopCloudSyncCoordinator } from './cloud-sync-filesystem'
 
 type SyncClient = Pick<
@@ -36,6 +37,7 @@ type SyncClient = Pick<
   | 'unpublishNote'
   | 'listVaults'
   | 'createVault'
+  | 'deleteVault'
   | 'manifest'
   | 'changes'
   | 'mutate'
@@ -82,8 +84,17 @@ export class DesktopCloudSyncService {
   }
 
   async listPublishedNotes(): Promise<CloudPublishedNote[]> {
-    const { client } = await this.connection()
-    return (await client.listPublishedNotes()).data
+    const connection = await this.optionalConnection()
+    if (!connection) return []
+
+    try {
+      return (await connection.client.listPublishedNotes()).data
+    } catch (error) {
+      if (error instanceof CloudServiceRequestError && error.code === 'FEATURE_NOT_ENTITLED') {
+        return []
+      }
+      throw error
+    }
   }
 
   async publishNote(input: CloudPublishNoteInput): Promise<CloudPublishedNoteResult> {
@@ -140,6 +151,12 @@ export class DesktopCloudSyncService {
 
   async unlink(localRoot: string): Promise<void> {
     await fs.rm(this.linkPath(localRoot), { force: true })
+  }
+
+  async deleteLinkedVault(localRoot: string): Promise<void> {
+    const { client, link } = await this.linkedConnection(localRoot)
+    await client.deleteVault(link.vault_id)
+    await this.unlink(localRoot)
   }
 
   async listBackups(localRoot: string): Promise<CloudBackupSnapshot[]> {
@@ -354,10 +371,18 @@ export class DesktopCloudSyncService {
     client: SyncClient
     token: string
   }> {
+    const connection = await this.optionalConnection()
+    if (!connection) throw new Error('Connect ZenNotes Cloud before using sync.')
+    return connection
+  }
+
+  private async optionalConnection(): Promise<{
+    account: NonNullable<CloudAccountStatus['account']>
+    client: SyncClient
+    token: string
+  } | null> {
     const status = await this.dependencies.accountStatus()
-    if (status.state !== 'connected' || !status.account) {
-      throw new Error('Connect ZenNotes Cloud before using sync.')
-    }
+    if (status.state !== 'connected' || !status.account) return null
     const token = await this.dependencies.getSecret(status.account.base_url)
     if (!token) throw new Error('The ZenNotes Cloud credential is unavailable. Sign in again.')
     return {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2630,6 +2630,9 @@ function registerIpc(): void {
   handle(IPC.CLOUD_VAULT_LINK_DELETE, () =>
     getCloudSyncService().unlink(requireLocalCloudVaultRoot()),
   );
+  handle(IPC.CLOUD_VAULT_DELETE, () =>
+    getCloudSyncService().deleteLinkedVault(requireLocalCloudVaultRoot()),
+  );
   handle(IPC.CLOUD_VAULT_SYNC, () =>
     getCloudSyncService().sync(requireLocalCloudVaultRoot()),
   );

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -247,6 +247,7 @@ const api: ZenBridge = {
   createAndLinkCloudVault: (name: string): Promise<CloudVaultLink> =>
     ipcRenderer.invoke(IPC.CLOUD_VAULT_LINK_CREATE, name),
   unlinkCloudVault: (): Promise<void> => ipcRenderer.invoke(IPC.CLOUD_VAULT_LINK_DELETE),
+  deleteCloudVault: (): Promise<void> => ipcRenderer.invoke(IPC.CLOUD_VAULT_DELETE),
   syncCloudVault: (): Promise<CloudSyncRunSummary> => ipcRenderer.invoke(IPC.CLOUD_VAULT_SYNC),
   getCloudSettingsConflict: (): Promise<CloudSyncSettingsConflict | null> =>
     ipcRenderer.invoke(IPC.CLOUD_VAULT_SETTINGS_CONFLICT_GET),

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/server",
   "private": true,
-  "version": "2.32.0",
+  "version": "2.33.0",
   "scripts": {
     "dev": "node ../../tooling/scripts/run-go-server-dev.mjs",
     "prepare-web": "node ../../tooling/scripts/prepare-server-web-dist.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/web",
   "private": true,
-  "version": "2.32.0",
+  "version": "2.33.0",
   "type": "module",
   "description": "ZenNotes web client for self-hosted and hosted deployments",
   "homepage": "https://zennotes.org",

--- a/apps/web/src/bridge/http-bridge.ts
+++ b/apps/web/src/bridge/http-bridge.ts
@@ -1397,6 +1397,7 @@ export const httpBridge: ZenBridge = {
   linkCloudVault: async () => notImplemented('linkCloudVault'),
   createAndLinkCloudVault: async () => notImplemented('createAndLinkCloudVault'),
   unlinkCloudVault: async () => notImplemented('unlinkCloudVault'),
+  deleteCloudVault: async () => notImplemented('deleteCloudVault'),
   syncCloudVault: async () => notImplemented('syncCloudVault'),
   getCloudSettingsConflict: async () => null,
   resolveCloudSettingsConflict: async () => notImplemented('resolveCloudSettingsConflict'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zennotes-monorepo",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zennotes-monorepo",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "@zennotes/desktop",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
@@ -99,11 +99,11 @@
     },
     "apps/server": {
       "name": "@zennotes/server",
-      "version": "2.32.0"
+      "version": "2.33.0"
     },
     "apps/web": {
       "name": "@zennotes/web",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -17123,7 +17123,7 @@
     },
     "packages/app-core": {
       "name": "@zennotes/app-core",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -17187,11 +17187,11 @@
     },
     "packages/bridge-contract": {
       "name": "@zennotes/bridge-contract",
-      "version": "2.32.0"
+      "version": "2.33.0"
     },
     "packages/shared-domain": {
       "name": "@zennotes/shared-domain",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "dependencies": {
         "@zennotes/bridge-contract": "*",
         "lz-string": "^1.5.0"
@@ -17199,7 +17199,7 @@
     },
     "packages/shared-ui": {
       "name": "@zennotes/shared-ui",
-      "version": "2.32.0"
+      "version": "2.33.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zennotes-monorepo",
   "private": true,
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "ZenNotes monorepo for desktop, web, and self-hosted server builds",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/app-core",
   "private": true,
-  "version": "2.32.0",
+  "version": "2.33.0",
   "type": "module",
   "exports": {
     "./main": "./src/main.tsx"

--- a/packages/app-core/src/components/CloudSettings.test.ts
+++ b/packages/app-core/src/components/CloudSettings.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   linkCloudVault: vi.fn(),
   createAndLinkCloudVault: vi.fn(),
   unlinkCloudVault: vi.fn(),
+  deleteCloudVault: vi.fn(),
   syncCloudVault: vi.fn(),
   getCloudSettingsConflict: vi.fn(),
   resolveCloudSettingsConflict: vi.fn(),
@@ -50,7 +51,8 @@ vi.mock("../lib/confirm-requests", () => ({
   confirmApp: mocks.confirmApp,
 }));
 
-vi.mock("../lib/cloud-auto-sync", () => ({
+vi.mock("../lib/cloud-auto-sync", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/cloud-auto-sync")>()),
   requestCloudAutoSync: mocks.requestCloudAutoSync,
   syncCloudVaultWithStatus: mocks.syncCloudVaultWithStatus,
 }));
@@ -95,7 +97,14 @@ const serviceAccount: CloudServiceAccount = {
       backup_bytes: 1_024,
       publish_bytes: 0,
     },
-    sync: { vaults: 2, items: 38 },
+    sync: {
+      vaults: 2,
+      items: 38,
+      markdown_items: 30,
+      binary_items: 5,
+      other_items: 2,
+      metadata_items: 1,
+    },
     backup: {
       snapshots: 1,
       ready_snapshots: 1,
@@ -196,7 +205,10 @@ describe("CloudSettings", () => {
     expect(host.textContent).toContain("PublishIncluded");
     expect(host.textContent).toContain("Cloud storage");
     expect(host.textContent).toContain("1.5 MB of 1.0 GB");
-    expect(host.textContent).toContain("38 synced notes across 2 vaults");
+    expect(host.textContent).toContain("38 synced files across 2 vaults");
+    expect(host.textContent).toContain(
+      "30 Markdown · 5 binary · 2 other · 1 ZenNotes metadata",
+    );
     expect(host.textContent).toContain("1 backup · 30-day retention");
     expect(host.textContent).toContain("1 published note");
     expect(host.textContent).not.toContain("views");
@@ -285,7 +297,8 @@ describe("CloudSettings", () => {
       pulled: 2,
       pushed: 3,
       conflicts: [],
-      bootstrap_conflicts: [], local_conflicts: [],
+      bootstrap_conflicts: [],
+      local_conflicts: [],
     };
     mocks.syncCloudVault.mockResolvedValue(summary);
 
@@ -326,6 +339,149 @@ describe("CloudSettings", () => {
     expect(host.textContent).not.toContain("Cursor 7");
   });
 
+  it("separates unlinking this device from permanently deleting the cloud vault", async () => {
+    mocks.getCloudAccountStatus.mockResolvedValue(connected);
+    mocks.getCloudServiceAccount.mockResolvedValue(serviceAccount);
+    mocks.listCloudVaults.mockResolvedValue([]);
+    mocks.getCloudVaultLink.mockResolvedValue({
+      base_url: "https://zennotes.org",
+      vault_id: "vault-1",
+      vault_name: "Cloud Notes",
+      linked_at: "2026-08-10T12:00:00.000Z",
+    });
+    mocks.unlinkCloudVault.mockResolvedValue(undefined);
+    mocks.deleteCloudVault.mockResolvedValue(undefined);
+
+    await act(async () =>
+      root.render(
+        createElement(CloudSettings, {
+          localVaultAvailable: true,
+          localVaultName: "Notes",
+        }),
+      ),
+    );
+
+    const unlink = [...host.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Unlink this device",
+    );
+    const remove = [...host.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Delete Cloud vault",
+    );
+
+    expect(unlink).toBeTruthy();
+    expect(remove).toBeTruthy();
+    await act(async () => remove!.click());
+
+    expect(mocks.confirmApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        danger: true,
+        confirmLabel: "Delete Cloud vault",
+        title: "Delete Cloud Notes from ZenNotes Cloud?",
+      }),
+    );
+    expect(mocks.deleteCloudVault).toHaveBeenCalledOnce();
+    expect(mocks.unlinkCloudVault).not.toHaveBeenCalled();
+    expect(host.textContent).not.toContain("Linked to Cloud Notes");
+  });
+
+  it("presents capacity rejections as queued uploads instead of reviewable conflicts", async () => {
+    mocks.getCloudAccountStatus.mockResolvedValue(connected);
+    mocks.getCloudServiceAccount.mockResolvedValue(serviceAccount);
+    mocks.listCloudVaults.mockResolvedValue([]);
+    mocks.getCloudVaultLink.mockResolvedValue({
+      base_url: "https://zennotes.org",
+      vault_id: "vault-1",
+      vault_name: "Cloud Notes",
+      linked_at: "2026-08-10T12:00:00.000Z",
+    });
+    mocks.syncCloudVault.mockResolvedValue({
+      cursor: 7,
+      pulled: 0,
+      pushed: 0,
+      conflicts: Array.from({ length: 107 }, (_, index) => ({
+        operation_id: `operation-${index}`,
+        item_id: `item-${index}`,
+        code: "QUOTA_EXCEEDED" as const,
+        current_revision: null,
+        current_path: null,
+        capacity: {
+          dimension: "sync_active_items",
+          used: 100,
+          reserved: 0,
+          limit: 100,
+          projected: 101,
+          can_retry_after_reduction: true,
+        },
+      })),
+      bootstrap_conflicts: [],
+      local_conflicts: [],
+    });
+
+    await act(async () =>
+      root.render(
+        createElement(CloudSettings, {
+          localVaultAvailable: true,
+          localVaultName: "Notes",
+        }),
+      ),
+    );
+
+    const sync = [...host.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Sync now",
+    );
+    await act(async () => sync!.click());
+
+    expect(host.textContent).toContain("Sync incomplete");
+    expect(host.textContent).toContain(
+      "Cloud active-item limit reached (100 of 100)",
+    );
+    expect(host.textContent).toContain("107 changes are waiting to upload");
+    expect(host.textContent).not.toContain("Everything is up to date");
+    expect(host.textContent).not.toContain("conflicts need review");
+  });
+
+  it("clears a stale successful summary when a later manual sync times out", async () => {
+    mocks.getCloudAccountStatus.mockResolvedValue(connected);
+    mocks.getCloudServiceAccount.mockResolvedValue(serviceAccount);
+    mocks.listCloudVaults.mockResolvedValue([]);
+    mocks.getCloudVaultLink.mockResolvedValue({
+      base_url: "https://zennotes.org",
+      vault_id: "vault-1",
+      vault_name: "Cloud Notes",
+      linked_at: "2026-08-10T12:00:00.000Z",
+    });
+    mocks.syncCloudVault
+      .mockResolvedValueOnce({
+        cursor: 7,
+        pulled: 0,
+        pushed: 0,
+        conflicts: [],
+        bootstrap_conflicts: [],
+        local_conflicts: [],
+      })
+      .mockRejectedValueOnce(new Error("Cloud sync timed out."));
+
+    await act(async () =>
+      root.render(
+        createElement(CloudSettings, {
+          localVaultAvailable: true,
+          localVaultName: "Notes",
+        }),
+      ),
+    );
+
+    const sync = [...host.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Sync now",
+    );
+    await act(async () => sync!.click());
+    expect(host.textContent).toContain("Everything is up to date");
+
+    await act(async () => sync!.click());
+
+    expect(host.textContent).toContain("Cloud sync timed out.");
+    expect(host.textContent).not.toContain("Everything is up to date");
+  });
+
   // Settings that differ between devices are a question, not a silent merge.
   // Doing nothing keeps this device's settings, so the local choice leads.
   it("asks which vault settings to keep and applies the answer", async () => {
@@ -353,7 +509,9 @@ describe("CloudSettings", () => {
     );
 
     expect(host.textContent).toContain("Vault settings differ from the cloud");
-    expect(host.textContent).toContain("This device’s settings are the ones in use.");
+    expect(host.textContent).toContain(
+      "This device’s settings are the ones in use.",
+    );
 
     const keepLocal = [...host.querySelectorAll("button")].find(
       (button) => button.textContent?.trim() === "Keep this device's",
@@ -369,7 +527,9 @@ describe("CloudSettings", () => {
 
     expect(mocks.resolveCloudSettingsConflict).toHaveBeenCalledWith("cloud");
     // Answered, so the question stops being asked.
-    expect(host.textContent).not.toContain("Vault settings differ from the cloud");
+    expect(host.textContent).not.toContain(
+      "Vault settings differ from the cloud",
+    );
   });
 
   it("does not request vault data when sync is not included", async () => {
@@ -599,7 +759,8 @@ describe("CloudSettings", () => {
         pulled: 10,
         pushed: 0,
         conflicts: [],
-        bootstrap_conflicts: [], local_conflicts: [],
+        bootstrap_conflicts: [],
+        local_conflicts: [],
       },
     });
     mocks.updateCloudBackupSchedule.mockResolvedValue({
@@ -646,7 +807,8 @@ describe("CloudSettings", () => {
         pulled: 1,
         pushed: 0,
         conflicts: [],
-        bootstrap_conflicts: [], local_conflicts: [],
+        bootstrap_conflicts: [],
+        local_conflicts: [],
       },
     });
 

--- a/packages/app-core/src/components/CloudSettings.tsx
+++ b/packages/app-core/src/components/CloudSettings.tsx
@@ -18,6 +18,7 @@ import type {
 import { getZenBridge } from "@zennotes/bridge-contract/bridge";
 import { confirmApp } from "../lib/confirm-requests";
 import {
+  cloudSyncAttentionMessage,
   requestCloudAutoSync,
   syncCloudVaultWithStatus,
 } from "../lib/cloud-auto-sync";
@@ -30,6 +31,7 @@ type CloudAction =
   | "logout"
   | "link"
   | "unlink"
+  | "vault-delete"
   | "sync"
   | "backup-create"
   | "backup-schedule"
@@ -287,17 +289,59 @@ export function CloudSettings({
       requestCloudAutoSync("vault-link");
     });
 
-  const unlinkVault = (): Promise<void> =>
-    runAction("unlink", async () => {
-      await bridge.unlinkCloudVault();
-      setLink(null);
-      setSummary(null);
-      setBackups([]);
-      setBackupSchedule(null);
-      setExpandedBackupId(null);
-      setBackupItems([]);
-      setRestoreResult(null);
+  const clearLinkedVaultState = (): void => {
+    setLink(null);
+    setSummary(null);
+    setBackups([]);
+    setBackupSchedule(null);
+    setExpandedBackupId(null);
+    setBackupItems([]);
+    setRestoreResult(null);
+  };
+
+  const unlinkVault = async (): Promise<void> => {
+    const confirmed = await confirmApp({
+      title: "Unlink this device?",
+      description:
+        "Automatic sync stops on this device. The Cloud vault and its backups remain available to your other devices.",
+      confirmLabel: "Unlink this device",
+      danger: false,
     });
+    if (!confirmed) return;
+
+    await runAction("unlink", async () => {
+      await bridge.unlinkCloudVault();
+      clearLinkedVaultState();
+    });
+  };
+
+  const deleteVault = async (): Promise<void> => {
+    if (!link) return;
+    const deletedVault = link;
+    const confirmed = await confirmApp({
+      title: `Delete ${deletedVault.vault_name} from ZenNotes Cloud?`,
+      description:
+        "This permanently deletes the Cloud copy, its backups, and its exports. Local files on your devices stay in place, but this cannot be undone.",
+      confirmLabel: "Delete Cloud vault",
+      danger: true,
+    });
+    if (!confirmed) return;
+
+    await runAction("vault-delete", async () => {
+      await bridge.deleteCloudVault();
+      setCloudVaults((current) =>
+        current.filter((vault) => vault.id !== deletedVault.vault_id),
+      );
+      clearLinkedVaultState();
+      await refreshServiceAccount();
+      useToastStore
+        .getState()
+        .addToast(
+          `${deletedVault.vault_name} was deleted from ZenNotes Cloud.`,
+          "success",
+        );
+    });
+  };
 
   const loadSettingsConflict = useCallback(async (): Promise<void> => {
     try {
@@ -312,11 +356,14 @@ export function CloudSettings({
     void loadSettingsConflict();
   }, [loadSettingsConflict]);
 
-  const syncVault = (): Promise<void> =>
-    runAction("sync", async () => {
+  const syncVault = (): Promise<void> => {
+    setSummary(null);
+    return runAction("sync", async () => {
       setSummary(await syncCloudVaultWithStatus(bridge, link?.vault_name));
       await loadSettingsConflict();
+      await refreshServiceAccount();
     });
+  };
 
   const resolveSettingsConflict = (
     choice: CloudSyncSettingsChoice,
@@ -537,6 +584,7 @@ export function CloudSettings({
                 onSelectedVaultChange={setSelectedVaultId}
                 onSync={() => void syncVault()}
                 onUnlink={() => void unlinkVault()}
+                onDelete={() => void deleteVault()}
                 onUseAnotherAccount={() => void logout()}
                 settingsConflict={settingsConflict}
                 onResolveSettingsConflict={(choice) =>
@@ -852,20 +900,21 @@ function CloudUsageSummary({
           Cloud storage
         </h3>
         <p className="mt-1 text-sm leading-6 text-ink-500">
-          {formatBytes(usage.storage.total_bytes)} stored across synced notes,
-          backup archives, and published assets.
+          {formatBytes(usage.storage.total_bytes)} stored across synced vault
+          files, backup archives, and published content.
         </p>
       </div>
 
       <div className="grid gap-px overflow-hidden rounded-2xl border border-paper-300/60 bg-paper-300/60 sm:grid-cols-3">
         <CloudUsageCard
-          label="Synced notes"
+          label="Synced files"
           value={
             syncLimit
               ? `${formatBytes(usage.storage.sync_bytes)} of ${formatBytes(syncLimit)}`
               : formatBytes(usage.storage.sync_bytes)
           }
-          detail={`${pluralize(usage.sync.items, "synced note")} across ${pluralize(usage.sync.vaults, "vault")}`}
+          detail={`${pluralize(usage.sync.items, "synced file")} across ${pluralize(usage.sync.vaults, "vault")}`}
+          secondaryDetail={`${usage.sync.markdown_items ?? 0} Markdown · ${usage.sync.binary_items ?? 0} binary · ${usage.sync.other_items ?? 0} other · ${usage.sync.metadata_items ?? 0} ZenNotes metadata`}
           percent={syncPercent}
         />
         <CloudUsageCard
@@ -887,11 +936,13 @@ function CloudUsageCard({
   detail,
   label,
   percent,
+  secondaryDetail,
   value,
 }: {
   detail: string;
   label: string;
   percent?: number | null;
+  secondaryDetail?: string;
   value: string;
 }): JSX.Element {
   return (
@@ -914,6 +965,11 @@ function CloudUsageCard({
         </div>
       )}
       <div className="mt-2 text-xs leading-5 text-ink-500">{detail}</div>
+      {secondaryDetail && (
+        <div className="mt-1 text-xs leading-5 text-ink-400">
+          {secondaryDetail}
+        </div>
+      )}
     </div>
   );
 }
@@ -937,6 +993,7 @@ function CloudVaultPanel({
   onSelectedVaultChange,
   onSync,
   onUnlink,
+  onDelete,
   onUseAnotherAccount,
 }: {
   action: CloudAction;
@@ -957,6 +1014,7 @@ function CloudVaultPanel({
   onSelectedVaultChange: (value: string) => void;
   onSync: () => void;
   onUnlink: () => void;
+  onDelete: () => void;
   onUseAnotherAccount: () => void;
 }): JSX.Element {
   if (!syncIncluded) {
@@ -1052,7 +1110,16 @@ function CloudVaultPanel({
                   disabled={action !== null}
                   onClick={onUnlink}
                 >
-                  {action === "unlink" ? "Unlinking…" : "Unlink"}
+                  {action === "unlink" ? "Unlinking…" : "Unlink this device"}
+                </Button>
+                <Button
+                  variant="danger"
+                  disabled={action !== null}
+                  onClick={onDelete}
+                >
+                  {action === "vault-delete"
+                    ? "Deleting…"
+                    : "Delete Cloud vault"}
                 </Button>
                 <Button
                   variant="primary"
@@ -1802,30 +1869,40 @@ function CloudSyncSummary({
 }: {
   summary: CloudSyncRunSummary;
 }): JSX.Element {
-  // A host on an older build sends no local_conflicts at all.
-  const conflictCount =
-    summary.conflicts.length +
-    summary.bootstrap_conflicts.length +
-    (summary.local_conflicts?.length ?? 0);
+  const attention = cloudSyncAttentionMessage(summary);
+  const capacityConflictCount = summary.conflicts.filter((conflict) =>
+    [
+      "QUOTA_EXCEEDED",
+      "CAPACITY_EXCEEDED",
+      "FILE_SIZE_LIMIT_EXCEEDED",
+    ].includes(conflict.code),
+  ).length;
   return (
     <div
       role="status"
       className={
-        conflictCount > 0
+        attention
           ? "rounded-xl border border-warning/35 bg-warning/10 px-4 py-3 text-sm text-ink-700"
           : "rounded-xl border border-accent/25 bg-accent/5 px-4 py-3 text-sm text-ink-700"
       }
     >
       <div className="font-medium">
-        {summary.pulled === 0 && summary.pushed === 0
-          ? "Everything is up to date"
-          : `Downloaded ${summary.pulled} · Uploaded ${summary.pushed}`}
+        {attention
+          ? "Sync incomplete"
+          : summary.pulled === 0 && summary.pushed === 0
+            ? "Everything is up to date"
+            : `Downloaded ${summary.pulled} · Uploaded ${summary.pushed}`}
       </div>
       <div className="mt-1 text-xs text-ink-500">
-        {conflictCount === 0
-          ? "All changes are synced."
-          : `${conflictCount} conflict${conflictCount === 1 ? " needs" : "s need"} review.`}
+        {attention ?? "All changes are synced."}
       </div>
+      {capacityConflictCount > 0 && (
+        <div className="mt-1 text-xs text-ink-500">
+          {capacityConflictCount}{" "}
+          {capacityConflictCount === 1 ? "change is" : "changes are"} waiting to
+          upload and will retry automatically.
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/app-core/src/components/StatusBar.test.ts
+++ b/packages/app-core/src/components/StatusBar.test.ts
@@ -69,4 +69,30 @@ describe("cloud sync status time", () => {
     act(() => root.unmount());
     host.remove();
   });
+
+  it("shows conflicted syncs as incomplete and offers a review action", () => {
+    useCloudSyncStatusStore.setState({
+      phase: "attention",
+      vaultName: "Notes",
+      lastSyncedAt: null,
+      error: "Cloud active-item limit reached (100 of 100).",
+    });
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+
+    act(() => root.render(createElement(StatusBar, { note: null })));
+
+    const status = host.querySelector<HTMLElement>("[data-cloud-sync-status]");
+    const action = host.querySelector<HTMLButtonElement>(
+      "[data-cloud-sync-action]",
+    );
+    expect(status?.textContent).toContain("Sync incomplete");
+    expect(status?.className).toContain("text-warning");
+    expect(status?.title).toBe("Cloud active-item limit reached (100 of 100).");
+    expect(action?.textContent).toBe("Review");
+
+    act(() => root.unmount());
+    host.remove();
+  });
 });

--- a/packages/app-core/src/components/StatusBar.tsx
+++ b/packages/app-core/src/components/StatusBar.tsx
@@ -107,11 +107,13 @@ function CloudSyncStatus({
           ? "Cloud connected"
           : phase === "syncing"
             ? "Syncing…"
-            : phase === "error"
-              ? "Sync failed"
-              : lastSyncedAt === null
-                ? "Cloud ready"
-                : `Synced ${formatRelativeSyncTime(lastSyncedAt, now)}`;
+            : phase === "attention"
+              ? "Sync incomplete"
+              : phase === "error"
+                ? "Sync failed"
+                : lastSyncedAt === null
+                  ? "Cloud ready"
+                  : `Synced ${formatRelativeSyncTime(lastSyncedAt, now)}`;
   const title =
     phase === "disconnected"
       ? (error ?? "Connect this vault to ZenNotes Cloud.")
@@ -119,19 +121,23 @@ function CloudSyncStatus({
         ? "Finish signing in in your browser."
         : phase === "unlinked"
           ? "Choose the cloud vault this device should use."
-          : phase === "error"
-            ? `${error ?? "Sync could not finish."} Click to retry.`
-            : phase === "syncing"
-              ? `Syncing ${vaultName ?? "this vault"}`
-              : `${vaultName ?? "Cloud vault"} is connected. Click to sync now.`;
+          : phase === "attention"
+            ? (error ?? "Some Cloud changes could not be synchronized.")
+            : phase === "error"
+              ? `${error ?? "Sync could not finish."} Click to retry.`
+              : phase === "syncing"
+                ? `Syncing ${vaultName ?? "this vault"}`
+                : `${vaultName ?? "Cloud vault"} is connected. Click to sync now.`;
   const statusTone =
     phase === "error"
       ? "text-danger"
-      : phase === "ready" || phase === "unlinked"
-        ? "text-success"
-        : phase === "disconnected"
-          ? "text-ink-500"
-          : "text-accent";
+      : phase === "attention"
+        ? "text-warning"
+        : phase === "ready" || phase === "unlinked"
+          ? "text-success"
+          : phase === "disconnected"
+            ? "text-ink-500"
+            : "text-accent";
   const actionLabel =
     phase === "disconnected"
       ? error
@@ -139,9 +145,11 @@ function CloudSyncStatus({
         : "Connect"
       : phase === "unlinked"
         ? "Set up"
-        : phase === "error"
-          ? "Retry"
-          : "Sync now";
+        : phase === "attention"
+          ? "Review"
+          : phase === "error"
+            ? "Retry"
+            : "Sync now";
 
   const runCloudAction = (): void => {
     if (phase === "disconnected") {
@@ -149,6 +157,11 @@ function CloudSyncStatus({
       return;
     }
     if (phase === "unlinked") {
+      requestSettingsTarget("cloud");
+      setSettingsOpen(true);
+      return;
+    }
+    if (phase === "attention") {
       requestSettingsTarget("cloud");
       setSettingsOpen(true);
       return;
@@ -219,7 +232,7 @@ function CloudStatusIcon({
     );
   }
 
-  if (phase === "error") {
+  if (phase === "error" || phase === "attention") {
     return (
       <svg
         aria-hidden="true"

--- a/packages/app-core/src/lib/cloud-auto-sync.test.ts
+++ b/packages/app-core/src/lib/cloud-auto-sync.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { CloudAccountStatus } from "@zennotes/bridge-contract/cloud-sync";
+import type {
+  CloudAccountStatus,
+  CloudSyncRunSummary,
+} from "@zennotes/bridge-contract/cloud-sync";
 import type { VaultChangeEvent } from "@shared/ipc";
 import {
   clearCloudSyncStatus,
@@ -31,13 +34,16 @@ function setup(
   let linkBaseUrl = "https://zennotes.org";
   let online = true;
   let active = true;
-  const syncCloudVault = vi.fn(async () => ({
-    cursor: 1,
-    pulled: 0,
-    pushed: 0,
-    conflicts: [],
-    bootstrap_conflicts: [], local_conflicts: [],
-  }));
+  const syncCloudVault = vi.fn(
+    async (): Promise<CloudSyncRunSummary> => ({
+      cursor: 1,
+      pulled: 0,
+      pushed: 0,
+      conflicts: [],
+      bootstrap_conflicts: [],
+      local_conflicts: [],
+    }),
+  );
   const logoutCloudAccount = vi.fn(async (): Promise<CloudAccountStatus> => {
     const disconnected: CloudAccountStatus = {
       state: "disconnected",
@@ -199,7 +205,8 @@ describe("cloud auto sync host wiring", () => {
               pulled: 1,
               pushed: 0,
               conflicts: [],
-              bootstrap_conflicts: [], local_conflicts: [],
+              bootstrap_conflicts: [],
+              local_conflicts: [],
             });
         }),
     );
@@ -220,6 +227,72 @@ describe("cloud auto sync host wiring", () => {
       error: null,
     });
     expect(useCloudSyncStatusStore.getState().lastSyncedAt).not.toBeNull();
+  });
+
+  it("does not report a quota-conflicted sync as successful", async () => {
+    const host = setup();
+    host.syncCloudVault.mockResolvedValue({
+      cursor: 2,
+      pulled: 0,
+      pushed: 0,
+      conflicts: [
+        {
+          operation_id: "operation-1",
+          item_id: "item-1",
+          code: "QUOTA_EXCEEDED",
+          current_revision: null,
+          current_path: null,
+        },
+      ],
+      bootstrap_conflicts: [],
+      local_conflicts: [],
+    });
+
+    await syncCloudVaultWithStatus(host.bridge, "Notes");
+
+    expect(useCloudSyncStatusStore.getState()).toMatchObject({
+      phase: "attention",
+      vaultName: "Notes",
+      lastSyncedAt: null,
+      error:
+        "Cloud capacity reached. Remove files or increase your Cloud capacity.",
+    });
+  });
+
+  it("shows the active item usage returned with a quota conflict", async () => {
+    const host = setup();
+    host.syncCloudVault.mockResolvedValue({
+      cursor: 2,
+      pulled: 0,
+      pushed: 0,
+      conflicts: [
+        {
+          operation_id: "operation-1",
+          item_id: "item-1",
+          code: "QUOTA_EXCEEDED",
+          current_revision: null,
+          current_path: null,
+          capacity: {
+            dimension: "sync_active_items",
+            used: 100,
+            reserved: 0,
+            limit: 100,
+            projected: 101,
+            can_retry_after_reduction: true,
+          },
+        },
+      ],
+      bootstrap_conflicts: [],
+      local_conflicts: [],
+    });
+
+    await syncCloudVaultWithStatus(host.bridge, "Notes");
+
+    expect(useCloudSyncStatusStore.getState()).toMatchObject({
+      phase: "attention",
+      error:
+        "Cloud active-item limit reached (100 of 100). Remove files or increase your Cloud capacity.",
+    });
   });
 
   it("starts cloud sign-in from the status bar", async () => {
@@ -267,7 +340,8 @@ describe("cloud auto sync host wiring", () => {
         pulled: 0,
         pushed: 0,
         conflicts: [],
-        bootstrap_conflicts: [], local_conflicts: [],
+        bootstrap_conflicts: [],
+        local_conflicts: [],
       };
     });
     const runtime = startCloudAutoSync(host.bridge, host.environment, {

--- a/packages/app-core/src/lib/cloud-auto-sync.ts
+++ b/packages/app-core/src/lib/cloud-auto-sync.ts
@@ -40,6 +40,7 @@ export type CloudSyncPhase =
   | "unlinked"
   | "ready"
   | "syncing"
+  | "attention"
   | "error";
 
 interface CloudSyncStatusStore {
@@ -181,6 +182,16 @@ export async function syncCloudVaultWithStatus(
 
   try {
     const summary = await bridge.syncCloudVault();
+    const attention = cloudSyncAttentionMessage(summary);
+    if (attention !== null) {
+      useCloudSyncStatusStore.setState({
+        phase: "attention",
+        vaultName: nextVaultName,
+        lastSyncedAt: current.lastSyncedAt,
+        error: attention,
+      });
+      return summary;
+    }
     useCloudSyncStatusStore.setState({
       phase: "ready",
       vaultName: nextVaultName,
@@ -307,4 +318,57 @@ function logAutomaticSyncError(error: unknown, retryInMs: number): void {
 
 function cloudSyncErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+export function cloudSyncAttentionMessage(
+  summary: CloudSyncRunSummary,
+): string | null {
+  const capacityConflict = summary.conflicts.find((conflict) =>
+    [
+      "QUOTA_EXCEEDED",
+      "CAPACITY_EXCEEDED",
+      "FILE_SIZE_LIMIT_EXCEEDED",
+    ].includes(conflict.code),
+  );
+  if (capacityConflict) {
+    const capacity = capacityConflict.capacity;
+    if (capacity?.dimension === "sync_active_items") {
+      return `Cloud active-item limit reached (${capacity.used + capacity.reserved} of ${capacity.limit}). Remove files or increase your Cloud capacity.`;
+    }
+    if (capacity?.dimension === "sync_active_bytes") {
+      return `Cloud storage limit reached (${formatCloudBytes(capacity.used + capacity.reserved)} of ${formatCloudBytes(capacity.limit)}). Remove files or increase your Cloud capacity.`;
+    }
+    if (capacity?.dimension === "sync_max_file_bytes") {
+      return `A file exceeds the ${formatCloudBytes(capacity.limit)} Cloud file-size limit.`;
+    }
+    return "Cloud capacity reached. Remove files or increase your Cloud capacity.";
+  }
+
+  if (summary.bootstrap_conflicts.length > 0) {
+    const count = summary.bootstrap_conflicts.length;
+    return `Cloud sync needs attention: ${count} ${count === 1 ? "file differs" : "files differ"} on this device and in Cloud.`;
+  }
+  if (summary.local_conflicts.length > 0) {
+    const count = summary.local_conflicts.length;
+    return `Cloud sync kept both versions of ${count} changed ${count === 1 ? "file" : "files"}. Review the conflict copies.`;
+  }
+  if (summary.conflicts.length > 0) {
+    const count = summary.conflicts.length;
+    return `Cloud sync needs attention: ${count} ${count === 1 ? "change could" : "changes could"} not be applied.`;
+  }
+
+  return null;
+}
+
+function formatCloudBytes(bytes: number): string {
+  if (bytes < 1_024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1_024;
+  let unit = units[0];
+  for (const candidate of units.slice(1)) {
+    if (value < 1_024) break;
+    value /= 1_024;
+    unit = candidate;
+  }
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${unit}`;
 }

--- a/packages/bridge-contract/package.json
+++ b/packages/bridge-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/bridge-contract",
   "private": true,
-  "version": "2.32.0",
+  "version": "2.33.0",
   "type": "module",
   "exports": {
     "./bridge": "./src/bridge.ts",

--- a/packages/bridge-contract/src/bridge.ts
+++ b/packages/bridge-contract/src/bridge.ts
@@ -143,6 +143,7 @@ export interface ZenBridge {
   linkCloudVault(vaultId: string): Promise<CloudVaultLink>
   createAndLinkCloudVault(name: string): Promise<CloudVaultLink>
   unlinkCloudVault(): Promise<void>
+  deleteCloudVault(): Promise<void>
   syncCloudVault(): Promise<CloudSyncRunSummary>
   getCloudSettingsConflict(): Promise<CloudSyncSettingsConflict | null>
   resolveCloudSettingsConflict(choice: CloudSyncSettingsChoice): Promise<void>

--- a/packages/bridge-contract/src/cloud-sync.ts
+++ b/packages/bridge-contract/src/cloud-sync.ts
@@ -51,7 +51,18 @@ export type CloudSyncConflictCode =
   | "REVISION_CONFLICT"
   | "PATH_CONFLICT"
   | "ITEM_DELETED"
-  | "QUOTA_EXCEEDED";
+  | "QUOTA_EXCEEDED"
+  | "CAPACITY_EXCEEDED"
+  | "FILE_SIZE_LIMIT_EXCEEDED";
+
+export interface CloudSyncCapacityConflict {
+  dimension: string;
+  used: number;
+  reserved: number;
+  limit: number;
+  projected: number;
+  can_retry_after_reduction: boolean;
+}
 
 export interface CloudSyncConflict {
   operation_id: string;
@@ -59,6 +70,7 @@ export interface CloudSyncConflict {
   code: CloudSyncConflictCode;
   current_revision: number | null;
   current_path: string | null;
+  capacity?: CloudSyncCapacityConflict;
 }
 
 export interface CloudSyncMutationResponse {
@@ -310,6 +322,10 @@ export interface CloudUsage {
   sync: {
     vaults: number;
     items: number;
+    markdown_items?: number;
+    binary_items?: number;
+    other_items?: number;
+    metadata_items?: number;
   };
   backup: {
     snapshots: number;

--- a/packages/bridge-contract/src/ipc.ts
+++ b/packages/bridge-contract/src/ipc.ts
@@ -122,6 +122,7 @@ export const IPC = {
   CLOUD_VAULT_LINK_SET: 'cloud-vault-link:set',
   CLOUD_VAULT_LINK_CREATE: 'cloud-vault-link:create',
   CLOUD_VAULT_LINK_DELETE: 'cloud-vault-link:delete',
+  CLOUD_VAULT_DELETE: 'cloud-vault:delete',
   CLOUD_VAULT_SYNC: 'cloud-vault:sync',
   CLOUD_VAULT_SETTINGS_CONFLICT_GET: 'cloud-vault-settings-conflict:get',
   CLOUD_VAULT_SETTINGS_CONFLICT_RESOLVE: 'cloud-vault-settings-conflict:resolve',

--- a/packages/shared-domain/package.json
+++ b/packages/shared-domain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-domain",
   "private": true,
-  "version": "2.32.0",
+  "version": "2.33.0",
   "type": "module",
   "exports": {
     "./*": "./src/*.ts"

--- a/packages/shared-domain/src/cloud-sync-api.test.ts
+++ b/packages/shared-domain/src/cloud-sync-api.test.ts
@@ -140,6 +140,25 @@ describe('CloudSyncApiClient', () => {
     )
   })
 
+  it('permanently deletes an encoded cloud vault', async () => {
+    const requests: CloudSyncHttpRequest[] = []
+    const client = new CloudSyncApiClient({
+      async request<Response>(request: CloudSyncHttpRequest): Promise<Response> {
+        requests.push(request)
+        return {} as Response
+      }
+    })
+
+    await client.deleteVault('vault/1')
+
+    expect(requests).toEqual([
+      {
+        method: 'DELETE',
+        path: '/api/v1/vaults/vault%2F1'
+      }
+    ])
+  })
+
   it('addresses backup schedules, snapshot items, and one-note restores', async () => {
     const requests: CloudSyncHttpRequest[] = []
     const client = new CloudSyncApiClient({

--- a/packages/shared-domain/src/cloud-sync-api.ts
+++ b/packages/shared-domain/src/cloud-sync-api.ts
@@ -49,6 +49,13 @@ export class CloudSyncApiClient {
     return this.http.request({ method: 'POST', path: '/api/v1/vaults', body: { name } })
   }
 
+  async deleteVault(vaultId: string): Promise<void> {
+    await this.http.request({
+      method: 'DELETE',
+      path: `/api/v1/vaults/${encodeURIComponent(vaultId)}`
+    })
+  }
+
   async listPublishedNotes(): Promise<CloudPublishedNoteCollection> {
     return this.http.request({ method: 'GET', path: '/api/v1/shares' })
   }

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-ui",
   "private": true,
-  "version": "2.32.0",
+  "version": "2.33.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
Cloud sync follow-up after 2.31.0's direct uploads. One commit, rebased onto `main` at 2.32.0. No linked issue; maintainer-driven.

## Sync admits when it is incomplete

When the cloud rejected an upload for capacity (storage quota, active-item limit, or a file over the size cap) the status bar still said "Synced just now" and the settings summary filed the rejection under "1 conflict needs review", though nothing had uploaded and there was nothing to review. Real conflicts were equally invisible from the status bar, which only knew `ready` and `error`.

A sync summary now has a third outcome, `attention`. Capacity rejections carry their structured details (dimension, used, reserved, limit, projected), so the message can say "Cloud storage limit reached (4.8 GB of 5.0 GB)" and that the change is waiting and will retry automatically. Bootstrap conflicts, keep-both copies, and unapplied changes each get their own sentence. The status bar shows **Sync incomplete** in the warning tone with a **Review** action that opens Cloud settings, and keeps the last successful sync time. A manual sync clears the previous summary before it starts, so a timeout cannot leave an earlier green box on screen. `CAPACITY_EXCEEDED` and `FILE_SIZE_LIMIT_EXCEEDED` join the conflict codes; missing details degrade to a generic capacity message.

## Unlink this device vs Delete Cloud vault

One-click **Unlink** left people guessing whether their cloud copy survived, and there was no way to delete a cloud vault from the app. They are now two buttons with two confirmations. **Unlink this device** stops sync here and says the cloud vault and backups stay for other devices. **Delete Cloud vault** is the danger action: `DELETE /api/v1/vaults/:id` through a new `CLOUD_VAULT_DELETE` handler (vault root from main-process state, as always), then unlink, with a toast. Local files are never touched. The web bridge reports `deleteCloudVault` as not implemented because Cloud is desktop-only.

## Smaller

- The usage card counts **Synced files** (not "notes") and breaks them down into Markdown, binary, other, and ZenNotes metadata, since images, PDFs, and vault.json count toward capacity too.
- `listPublishedNotes` returns an empty list when the account is disconnected or the plan has no publishing (`FEATURE_NOT_ENTITLED`), instead of throwing from the sidebar badges, the publish dialog, and Cloud settings. Other failures still surface.

## Server dependency

The client reads the capacity detail fields and calls the vault `DELETE` endpoint; the cloud service needs to ship both before this is released. Without the details the UI degrades to the generic wording rather than breaking the run.

## Verification

Repo typecheck clean. New and updated tests across shared-domain (`cloud-sync-api`), desktop main (`cloud-sync-client`, `cloud-sync-service`), and app-core (`CloudSettings`, `StatusBar`, `cloud-auto-sync`): 64 tests pass, covering structured capacity details from a direct-upload conflict, delete-then-unlink ordering, the unlink/delete confirmation split, capacity rejections presented as queued uploads, the stale-summary clear on a timed-out manual sync, and the status bar's incomplete/review state.

https://claude.ai/code/session_01L1yahiA1JRUKBh5mp3xoBP
