### PR TITLE
ZenNotes 2.34.0: folder sessions behave

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/desktop",
   "productName": "ZenNotes",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "ZenNotes desktop shell",
   "private": true,
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -673,7 +673,7 @@ function queueMarkdownFileOpen(
 function handleStartupMarkdownArgs(
   argv: string[],
   reuseMainWindow: boolean,
-): void {
+): number {
   // Candidates include directories (temporary folder session); the opener stats
   // each path and ignores anything that isn't a markdown file or a folder. The
   // app's own path is filtered by value (#579): launchers that run
@@ -681,18 +681,46 @@ function handleStartupMarkdownArgs(
   // skipping by index alone let the app dir through as a folder to open.
   const isUnpackagedElectronLaunch =
     (process as NodeJS.Process & { defaultApp?: boolean }).defaultApp === true;
+  let queued = 0;
   for (const candidate of candidatePathsFromArgv(
     argv,
     isUnpackagedElectronLaunch,
     app.getAppPath(),
   )) {
     queueMarkdownFileOpen(candidate, reuseMainWindow);
+    queued += 1;
   }
+  return queued;
 }
 
 // Returns true when at least one file produced (or focused) a window, so
 // the caller can skip opening a redundant default-vault window.
-async function flushPendingFileOpens(): Promise<boolean> {
+// Flushes still opening their windows. `second-instance` waits on these
+// before deciding whether a default window is needed at all (#649).
+const inFlightFileOpens = new Set<Promise<boolean>>();
+
+function flushPendingFileOpens(): Promise<boolean> {
+  const run = drainPendingFileOpens();
+  inFlightFileOpens.add(run);
+  void run.finally(() => inFlightFileOpens.delete(run));
+  return run;
+}
+
+async function settleFileOpens(): Promise<void> {
+  while (inFlightFileOpens.size > 0) {
+    await Promise.allSettled([...inFlightFileOpens]);
+  }
+}
+
+function hasWorkspaceWindow(): boolean {
+  // Count only real workspace windows: a hidden quick-capture panel (or
+  // other utility window) must not pass for a usable window.
+  return BrowserWindow.getAllWindows().some(
+    (win) => !win.isDestroyed() && isWorkspaceWindow(win),
+  );
+}
+
+async function drainPendingFileOpens(): Promise<boolean> {
   if (!app.isReady() || pendingFileOpens.length === 0) return false;
   const items = pendingFileOpens.splice(0);
   let openedAny = false;
@@ -5091,13 +5119,8 @@ app.whenReady().then(async () => {
   }
 
   app.on("activate", () => {
-    // Count only real workspace windows: a hidden quick-capture panel
-    // (or other utility window) must not stop the dock click from
-    // bringing back a usable window.
-    const hasWorkspaceWindow = BrowserWindow.getAllWindows().some(
-      (win) => !win.isDestroyed() && isWorkspaceWindow(win),
-    );
-    if (!hasWorkspaceWindow) void ensureMainWindow();
+    // A dock click must bring back a usable window when none is left.
+    if (!hasWorkspaceWindow()) void ensureMainWindow();
   });
 
   app.on("new-window-for-tab", () => {
@@ -5139,8 +5162,20 @@ app.on("open-file", (event, filePath) => {
 // process.
 app.on("second-instance", (_event, argv) => {
   const deepLinkResult = handleStartupDeepLinks(argv);
-  handleStartupMarkdownArgs(argv, false);
+  const queued = handleStartupMarkdownArgs(argv, false);
   if (deepLinkResult === "quick-capture") return;
+  if (queued > 0) {
+    // Every forwarded path opens or focuses a window of its own. Raising the
+    // main window on top of that used to resurrect the last vault next to the
+    // folder `zn open` asked for whenever every window had been closed first
+    // (macOS keeps the app alive without windows, #649). A default window is
+    // only the right answer when nothing could be opened and no workspace
+    // window is left to show.
+    void settleFileOpens().then(() => {
+      if (!hasWorkspaceWindow()) return ensureMainWindow();
+    });
+    return;
+  }
   if (mainWindow && !mainWindow.isDestroyed()) {
     focusWindow(mainWindow);
     return;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -83,6 +83,7 @@ import {
   moveNote,
   moveAsset,
   moveToTrash,
+  trashNoteToSystem,
   readNoteComments,
   readNote,
   renameFolder,
@@ -3493,12 +3494,13 @@ function registerIpc(): void {
       return await requireRemoteWorkspaceClient().moveToTrash(relPath);
     }
     const v = requireVault();
-    // Trash would create a `trash/` folder inside a temporary session's folder.
-    // Keep it pristine: refuse rather than litter (edits still save in place).
+    // A vault trash would create a `trash/` folder inside a temporary
+    // session's folder. Keep it pristine, but do not refuse: refusing used to
+    // be silent, so the note stayed put with nothing to explain why (#650).
+    // The operating system's Trash takes the file instead, and can give it
+    // back.
     if (isEphemeralRoot(v.root)) {
-      throw new Error(
-        "Move to Trash is not available in a temporary folder session.",
-      );
+      return await trashNoteToSystem(v.root, relPath);
     }
     return await moveToTrash(v.root, relPath);
   });

--- a/apps/desktop/src/main/vault-trash-system.test.ts
+++ b/apps/desktop/src/main/vault-trash-system.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, mkdir, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The OS trash is the only Electron surface this path touches; the mock moves
+// the file aside so "gone from the folder" and "still recoverable" both hold.
+const trashItem = vi.fn(async (abs: string) => {
+  await rename(abs, `${abs}.in-system-trash`)
+})
+vi.mock('electron', () => ({
+  app: { getPath: () => os.tmpdir(), isPackaged: false },
+  shell: { trashItem: (abs: string) => trashItem(abs) }
+}))
+
+const { ensureVaultLayout, listNotes, trashNoteToSystem } = await import('./vault')
+
+const roots: string[] = []
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true })
+  trashItem.mockClear()
+})
+
+describe('trashNoteToSystem (temporary folder sessions, #650)', () => {
+  it('hands the note to the OS trash without growing a trash folder in the session', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'zen-ephemeral-'))
+    roots.push(root)
+    await ensureVaultLayout(root)
+    await mkdir(path.join(root, 'quick'), { recursive: true })
+    await writeFile(path.join(root, 'quick', 'Scratch.md'), '# Scratch\n\n#todo later\n')
+
+    const meta = await trashNoteToSystem(root, 'quick/Scratch.md')
+
+    expect(trashItem).toHaveBeenCalledWith(path.join(root, 'quick', 'Scratch.md'))
+    expect(meta.title).toBe('Scratch')
+    expect(meta.folder).toBe('quick')
+    expect(meta.tags).toContain('todo')
+    const entries = await readdir(path.join(root, 'quick'))
+    expect(entries).toEqual(['Scratch.md.in-system-trash'])
+    const notes = await listNotes(root)
+    expect(notes.map((n) => n.path)).not.toContain('quick/Scratch.md')
+  })
+
+  it('refuses paths that escape the session folder', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'zen-ephemeral-'))
+    roots.push(root)
+    await ensureVaultLayout(root)
+    await expect(trashNoteToSystem(root, '../outside.md')).rejects.toThrow()
+    expect(trashItem).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/vault.ts
+++ b/apps/desktop/src/main/vault.ts
@@ -3,7 +3,7 @@ import { execFile, spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import path from 'node:path'
 import { promisify } from 'node:util'
-import { app } from 'electron'
+import { app, shell } from 'electron'
 import { recordMainPerf } from './perf'
 import { resolveCommandViaLoginShell } from './login-shell-path'
 import { isEphemeralRoot } from './ephemeral-vaults'
@@ -3680,6 +3680,23 @@ async function moveBetweenFolders(
 
 export function moveToTrash(root: string, rel: string): Promise<NoteMeta> {
   return moveBetweenFolders(root, rel, 'trash')
+}
+
+/**
+ * Send a note to the operating system's Trash instead of the vault's own
+ * `trash/` folder. Temporary folder sessions use this: they must not grow a
+ * trash folder inside whatever directory was opened, yet Move to Trash has to
+ * do something visible (#650). The OS can still bring the file back. The
+ * returned meta describes the note as it was, since nothing remains in place.
+ */
+export async function trashNoteToSystem(root: string, rel: string): Promise<NoteMeta> {
+  const abs = resolveSafe(root, rel)
+  const folder = (await folderOf(root, abs)) ?? 'inbox'
+  const meta = await readMeta(root, abs, folder)
+  await shell.trashItem(abs)
+  invalidateNoteMetaCache(root, rel)
+  invalidateVaultTextSearchCache(root)
+  return meta
 }
 
 export function restoreFromTrash(root: string, rel: string): Promise<NoteMeta> {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/server",
   "private": true,
-  "version": "2.33.0",
+  "version": "2.34.0",
   "scripts": {
     "dev": "node ../../tooling/scripts/run-go-server-dev.mjs",
     "prepare-web": "node ../../tooling/scripts/prepare-server-web-dist.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/web",
   "private": true,
-  "version": "2.33.0",
+  "version": "2.34.0",
   "type": "module",
   "description": "ZenNotes web client for self-hosted and hosted deployments",
   "homepage": "https://zennotes.org",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zennotes-monorepo",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zennotes-monorepo",
-      "version": "2.33.0",
+      "version": "2.34.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "@zennotes/desktop",
-      "version": "2.33.0",
+      "version": "2.34.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
@@ -99,11 +99,11 @@
     },
     "apps/server": {
       "name": "@zennotes/server",
-      "version": "2.33.0"
+      "version": "2.34.0"
     },
     "apps/web": {
       "name": "@zennotes/web",
-      "version": "2.33.0",
+      "version": "2.34.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -17123,7 +17123,7 @@
     },
     "packages/app-core": {
       "name": "@zennotes/app-core",
-      "version": "2.33.0",
+      "version": "2.34.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -17187,11 +17187,11 @@
     },
     "packages/bridge-contract": {
       "name": "@zennotes/bridge-contract",
-      "version": "2.33.0"
+      "version": "2.34.0"
     },
     "packages/shared-domain": {
       "name": "@zennotes/shared-domain",
-      "version": "2.33.0",
+      "version": "2.34.0",
       "dependencies": {
         "@zennotes/bridge-contract": "*",
         "lz-string": "^1.5.0"
@@ -17199,7 +17199,7 @@
     },
     "packages/shared-ui": {
       "name": "@zennotes/shared-ui",
-      "version": "2.33.0"
+      "version": "2.34.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zennotes-monorepo",
   "private": true,
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "ZenNotes monorepo for desktop, web, and self-hosted server builds",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/app-core",
   "private": true,
-  "version": "2.33.0",
+  "version": "2.34.0",
   "type": "module",
   "exports": {
     "./main": "./src/main.tsx"

--- a/packages/app-core/src/components/CalendarPanel.tsx
+++ b/packages/app-core/src/components/CalendarPanel.tsx
@@ -37,6 +37,7 @@ import { resolveWeekStartDay } from '../lib/week-start'
 import { ChevronLeftIcon, ChevronRightIcon } from './icons'
 import { confirmApp } from '../lib/confirm-requests'
 import { confirmMoveToTrash } from '../lib/confirm-trash'
+import { moveNoteToTrash } from '../lib/trash-note'
 import { usePanelResize } from '../lib/use-panel-resize'
 import { PanelResizeHandle } from './PanelResizeHandle'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu'
@@ -387,7 +388,10 @@ export function CalendarPanel({ note }: { note: NoteContent }): JSX.Element {
   // --- Context menu --------------------------------------------------------
   const [menu, setMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null)
   const trashNote = useCallback(async (meta: NoteMeta) => {
-    if (await confirmMoveToTrash(meta.title)) await window.zen.moveToTrash(meta.path)
+    if (!(await confirmMoveToTrash(meta.title))) return
+    await moveNoteToTrash(meta.path, {
+      temporarySession: useStore.getState().vault?.temporary === true
+    })
   }, [])
   const openDayMenu = useCallback(
     (e: React.MouseEvent, day: Date, iso: string) => {

--- a/packages/app-core/src/components/Sidebar.tsx
+++ b/packages/app-core/src/components/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
 } from "../store";
 import { Button } from "./ui/Button";
 import { confirmMoveToTrash } from "../lib/confirm-trash";
+import { moveNoteToTrash } from "../lib/trash-note";
 import { buildMoveNotePrompt, parseMoveNoteTarget } from "../lib/move-note";
 import { buildTagTree, extractTags, flattenTagTree } from "../lib/tags";
 import { isTypstPreamblePath, resolveTypstPreambleFolder } from "../lib/typst-preamble";
@@ -1746,7 +1747,9 @@ export function Sidebar(): JSX.Element {
           });
           if (!ok) return;
           for (const note of liveNotes) {
-            await window.zen.moveToTrash(note.path);
+            await moveNoteToTrash(note.path, {
+              temporarySession: vault?.temporary === true,
+            });
           }
           if (selectedActiveNote) await selectNote(null);
           await refreshAndClear();
@@ -2433,7 +2436,12 @@ export function Sidebar(): JSX.Element {
         danger: true,
         onSelect: async () => {
           if (!(await confirmMoveToTrash(n.title))) return;
-          await window.zen.moveToTrash(n.path);
+          if (
+            !(await moveNoteToTrash(n.path, {
+              temporarySession: vault?.temporary === true,
+            }))
+          )
+            return;
           await refreshNotes();
           if (selectedPath === n.path) await selectNote(null);
         },
@@ -2454,7 +2462,12 @@ export function Sidebar(): JSX.Element {
         danger: true,
         onSelect: async () => {
           if (!(await confirmMoveToTrash(n.title))) return;
-          await window.zen.moveToTrash(n.path);
+          if (
+            !(await moveNoteToTrash(n.path, {
+              temporarySession: vault?.temporary === true,
+            }))
+          )
+            return;
           await refreshNotes();
           if (selectedPath === n.path) await selectNote(null);
         },

--- a/packages/app-core/src/lib/ipc-error.ts
+++ b/packages/app-core/src/lib/ipc-error.ts
@@ -1,0 +1,8 @@
+/** A user-showable message from a rejected bridge call. Electron wraps main
+ *  process rejections as "Error invoking remote method 'x': Error: <real>";
+ *  a toast should carry only the real sentence. */
+export function humanIpcError(err: unknown, fallback: string): string {
+  const raw = err instanceof Error ? err.message : ''
+  const message = raw.replace(/^Error invoking remote method '[^']*':\s*(Error:\s*)?/, '').trim()
+  return message || fallback
+}

--- a/packages/app-core/src/lib/trash-note.test.ts
+++ b/packages/app-core/src/lib/trash-note.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NoteMeta } from '@shared/ipc'
+import { moveNoteToTrash } from './trash-note'
+import { useToastStore } from './toast'
+
+const meta: NoteMeta = {
+  path: 'quick/Scratch.md',
+  title: 'Scratch',
+  folder: 'quick',
+  siblingOrder: 0,
+  createdAt: 1,
+  updatedAt: 1,
+  size: 12,
+  tags: []
+} as unknown as NoteMeta
+
+const moveToTrash = vi.fn<(path: string) => Promise<NoteMeta>>()
+
+beforeEach(() => {
+  moveToTrash.mockReset()
+  useToastStore.setState({ toasts: [] })
+  Object.defineProperty(window, 'zen', { value: { moveToTrash }, configurable: true })
+})
+
+describe('moveNoteToTrash', () => {
+  it('returns the moved meta and stays quiet in an ordinary vault', async () => {
+    moveToTrash.mockResolvedValue(meta)
+    await expect(moveNoteToTrash('quick/Scratch.md')).resolves.toEqual(meta)
+    expect(moveToTrash).toHaveBeenCalledWith('quick/Scratch.md')
+    expect(useToastStore.getState().toasts).toEqual([])
+  })
+
+  it('tells a temporary folder session where the note went', async () => {
+    moveToTrash.mockResolvedValue(meta)
+    await moveNoteToTrash('quick/Scratch.md', { temporarySession: true })
+    const [toast] = useToastStore.getState().toasts
+    expect(toast?.type).toBe('info')
+    expect(toast?.message).toContain('system Trash')
+  })
+
+  it('surfaces a refusal as an error toast instead of a console line (#650)', async () => {
+    moveToTrash.mockRejectedValue(
+      new Error(
+        "Error invoking remote method 'vault:move-to-trash': Error: Move to Trash is not available here."
+      )
+    )
+    await expect(moveNoteToTrash('quick/Scratch.md')).resolves.toBeNull()
+    const [toast] = useToastStore.getState().toasts
+    expect(toast?.type).toBe('error')
+    expect(toast?.message).toBe('Could not move to Trash: Move to Trash is not available here.')
+  })
+})

--- a/packages/app-core/src/lib/trash-note.ts
+++ b/packages/app-core/src/lib/trash-note.ts
@@ -1,0 +1,41 @@
+import type { NoteMeta } from '@shared/ipc'
+import { humanIpcError } from './ipc-error'
+import { useToastStore } from './toast'
+
+/**
+ * Move a note to the Trash and say so when that could not happen. Every
+ * surface with a Move to Trash action routes through here: a rejected move
+ * used to end in console.error and a note that quietly stayed put (#650).
+ * Returns the moved note's meta, or null when the host refused.
+ *
+ * A temporary folder session (a folder opened with `zn open` or dropped on the
+ * app) keeps no trash folder of its own, so the host sends the file to the
+ * system Trash instead. That deserves a word, because the app's Trash view
+ * will not list it. Callers pass the session kind; this module stays free of
+ * the store so the store can import it.
+ */
+export async function moveNoteToTrash(
+  path: string,
+  options: { temporarySession?: boolean } = {}
+): Promise<NoteMeta | null> {
+  try {
+    const meta = await window.zen.moveToTrash(path)
+    if (options.temporarySession) {
+      useToastStore
+        .getState()
+        .addToast(
+          'Moved to the system Trash. A temporary folder session keeps no Trash folder of its own.',
+          'info'
+        )
+    }
+    return meta
+  } catch (err) {
+    useToastStore
+      .getState()
+      .addToast(
+        `Could not move to Trash: ${humanIpcError(err, 'the note could not be moved.')}`,
+        'error'
+      )
+    return null
+  }
+}

--- a/packages/app-core/src/store.ts
+++ b/packages/app-core/src/store.ts
@@ -101,6 +101,8 @@ import type { CustomCodeLanguage } from '@shared/custom-code-languages'
 import { customCodeLanguageRegistry } from './lib/custom-code-languages'
 import { formatMarkdown } from './lib/format-markdown'
 import { confirmMoveToTrash } from './lib/confirm-trash'
+import { humanIpcError } from './lib/ipc-error'
+import { moveNoteToTrash } from './lib/trash-note'
 import { confirmApp } from './lib/confirm-requests'
 import { pickServerDirectoryApp } from './lib/server-directory-picker-requests'
 import { promptApp } from './lib/prompt-requests'
@@ -3529,15 +3531,6 @@ const PATH_SAVE_DEBOUNCE_MS = 350
 const lastWrittenByPath = new Map<string, string>()
 
 // --- CSV database debounced persistence + echo suppression ---
-/** A user-showable message from a rejected bridge call. Electron wraps main
- *  process rejections as "Error invoking remote method 'x': Error: <real>";
- *  a toast should carry only the real sentence. */
-function humanIpcError(err: unknown, fallback: string): string {
-  const raw = err instanceof Error ? err.message : ''
-  const message = raw.replace(/^Error invoking remote method '[^']*':\s*(Error:\s*)?/, '').trim()
-  return message || fallback
-}
-
 const DATABASE_SAVE_DEBOUNCE_MS = 400
 const databaseSaveTimers = new Map<string, ReturnType<typeof setTimeout>>()
 /** A pending write that touched the schema must persist the sidecar too. */
@@ -5089,11 +5082,7 @@ export const useStore = create<Store>((set, get) => {
 
     if (trashNotes) {
       for (const pagePath of prunedPaths) {
-        try {
-          await window.zen.moveToTrash(pagePath)
-        } catch (err) {
-          console.error('trash record page failed', err)
-        }
+        await moveNoteToTrash(pagePath, { temporarySession: get().vault?.temporary === true })
       }
     }
   },
@@ -5534,13 +5523,10 @@ export const useStore = create<Store>((set, get) => {
     if (task.kind === 'file') {
       if (!(await confirmMoveToTrash(task.noteTitle))) return
       set((s) => ({ vaultTasks: s.vaultTasks.filter((t) => t.sourcePath !== path) }))
-      try {
-        await window.zen.moveToTrash(path)
+      if (await moveNoteToTrash(path, { temporarySession: get().vault?.temporary === true })) {
         await get().refreshNotes()
-      } catch (err) {
-        console.error('deleteTaskFromList moveToTrash failed', err)
-        void get().refreshTasks()
       }
+      else void get().refreshTasks()
       return
     }
     const openBuffer = get().noteContents[path]
@@ -6747,8 +6733,8 @@ export const useStore = create<Store>((set, get) => {
     if (!path) return
     const title = state.notes.find((note) => note.path === path)?.title
     if (!(await confirmMoveToTrash(title))) return
-    try {
-      await window.zen.moveToTrash(path)
+    if (!(await moveNoteToTrash(path, { temporarySession: state.vault?.temporary === true }))) return
+    {
       set((s) => {
         const nextLayout = rewritePathsInTree(s.paneLayout, (p) => (p === path ? null : p))
         const ensured = ensureActivePane(nextLayout, s.activePaneId)
@@ -6767,8 +6753,6 @@ export const useStore = create<Store>((set, get) => {
         }
       })
       await get().refreshNotes()
-    } catch (err) {
-      console.error('moveToTrash failed', err)
     }
   },
 

--- a/packages/bridge-contract/package.json
+++ b/packages/bridge-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/bridge-contract",
   "private": true,
-  "version": "2.33.0",
+  "version": "2.34.0",
   "type": "module",
   "exports": {
     "./bridge": "./src/bridge.ts",

--- a/packages/shared-domain/package.json
+++ b/packages/shared-domain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-domain",
   "private": true,
-  "version": "2.33.0",
+  "version": "2.34.0",
   "type": "module",
   "exports": {
     "./*": "./src/*.ts"

--- a/packages/shared-domain/src/cloud-sync-host-service.test.ts
+++ b/packages/shared-domain/src/cloud-sync-host-service.test.ts
@@ -69,6 +69,7 @@ function setup(vaults: CloudSyncVault[] = []) {
         updated_at: '2026-08-10T12:00:00.000Z'
       }
     })),
+    deleteVault: vi.fn(async () => undefined),
     manifest: vi.fn(async () => ({ data: [], cursor: 0, next_page: null })),
     changes: vi.fn(async () => ({ data: [], cursor: 0, has_more: false })),
     mutate: vi.fn(async (_vaultId: string, body: CloudSyncMutationRequest) => ({
@@ -204,6 +205,26 @@ describe('CloudSyncHostService', () => {
     expect(client.manifest).toHaveBeenCalledTimes(1)
     expect(first).toEqual(second)
     expect(hostVault.refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('deletes the remote vault before dropping the link', async () => {
+    const { client, hostVault, service } = setup()
+
+    await service.createAndLink(hostVault, 'My Notes')
+    await service.deleteLinkedVault(hostVault)
+
+    expect(client.deleteVault).toHaveBeenCalledWith('vault-created')
+    await expect(service.linkedVault(hostVault)).resolves.toBeNull()
+  })
+
+  it('keeps the link when the remote delete fails', async () => {
+    const { client, hostVault, service } = setup()
+
+    await service.createAndLink(hostVault, 'My Notes')
+    client.deleteVault.mockRejectedValueOnce(new Error('offline'))
+
+    await expect(service.deleteLinkedVault(hostVault)).rejects.toThrow('offline')
+    await expect(service.linkedVault(hostVault)).resolves.toMatchObject({ vault_id: 'vault-created' })
   })
 
   it('refuses to sync a link from a different cloud origin', async () => {

--- a/packages/shared-domain/src/cloud-sync-host-service.ts
+++ b/packages/shared-domain/src/cloud-sync-host-service.ts
@@ -25,6 +25,7 @@ type SyncClient = Pick<
   | 'account'
   | 'listVaults'
   | 'createVault'
+  | 'deleteVault'
   | 'manifest'
   | 'changes'
   | 'mutate'
@@ -118,6 +119,18 @@ export class CloudSyncHostService {
 
   async unlink(vault: CloudSyncHostVault): Promise<void> {
     await this.dependencies.persistence.deleteLink(vault.key)
+  }
+
+  /**
+   * Delete the cloud copy this vault is linked to, then drop the link.
+   * Mirrors the desktop service: the remote call goes first so a failure
+   * leaves the link (and the user's ability to retry) intact. Local files are
+   * never touched.
+   */
+  async deleteLinkedVault(vault: CloudSyncHostVault): Promise<void> {
+    const { client, link } = await this.linkedConnection(vault)
+    await client.deleteVault(link.vault_id)
+    await this.unlink(vault)
   }
 
   async listBackups(vault: CloudSyncHostVault): Promise<CloudBackupSnapshot[]> {

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-ui",
   "private": true,
-  "version": "2.33.0",
+  "version": "2.34.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
The 2.34.0 release branch. Two `zn open` fixes from @rrpolanco's first day with the CLI, plus the shared-domain half of a mobile parity fix.

## The fixes

- [#649](https://github.com/ZenNotes/zennotes/issues/649) `zn open` opens one window, not two: on macOS ZenNotes keeps running after its last window closes, and handing it a folder in that state opened the folder **and** resurrected the last vault's window, because `second-instance` always raised the main window after queuing the paths it was given. Forwarded paths now open or focus their own windows; a default window is only created when nothing could be opened and no workspace window is left.
- [#650](https://github.com/ZenNotes/zennotes/issues/650) Move to Trash works in a temporary folder session: the session deliberately never writes a `trash/` folder into someone's project directory, but the refusal was silent (the note stayed, the reason only reached the console). The note now goes to the operating system's Trash with a toast that says so, and every Move to Trash surface reports a refusal as an error toast from now on.

## For mobile parity

`CloudSyncHostService.deleteLinkedVault` (shared-domain) is the portable twin of the desktop delete that 2.33.0 shipped, so the iOS and Android shells can honor the Delete Cloud vault button that the shared settings UI now shows (their PRs: zennotesios#6, zennotesandroid#18).

## Verification

Both fixes were reproduced and then verified against the built app over CDP plus the main-process inspector (vault open, every window closed, a second instance launched with a folder path exactly as `zn open` does: two windows before, one after; the real right-click → Move to Trash → confirm flow in a folder session ends with the note in the system Trash and the toast on screen). New unit tests cover the system-trash path, the renderer trash helper, and the host-service delete; full app-core, desktop, and shared-domain suites green; repo typecheck clean.

Full release notes land on the GitHub release when CI finishes the installers.

https://claude.ai/code/session_01L1yahiA1JRUKBh5mp3xoBP
