### PR TITLE
Release 2.39.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/desktop",
   "productName": "ZenNotes",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "ZenNotes desktop shell",
   "private": true,
   "main": "./out/main/index.js",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/server",
   "private": true,
-  "version": "2.38.0",
+  "version": "2.39.0",
   "scripts": {
     "dev": "node ../../tooling/scripts/run-go-server-dev.mjs",
     "prepare-web": "node ../../tooling/scripts/prepare-server-web-dist.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/web",
   "private": true,
-  "version": "2.38.0",
+  "version": "2.39.0",
   "type": "module",
   "description": "ZenNotes web client for self-hosted and hosted deployments",
   "homepage": "https://zennotes.org",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zennotes-monorepo",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zennotes-monorepo",
-      "version": "2.38.0",
+      "version": "2.39.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "@zennotes/desktop",
-      "version": "2.38.0",
+      "version": "2.39.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
@@ -98,11 +98,11 @@
     },
     "apps/server": {
       "name": "@zennotes/server",
-      "version": "2.38.0"
+      "version": "2.39.0"
     },
     "apps/web": {
       "name": "@zennotes/web",
-      "version": "2.38.0",
+      "version": "2.39.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -16884,7 +16884,7 @@
     },
     "packages/app-core": {
       "name": "@zennotes/app-core",
-      "version": "2.38.0",
+      "version": "2.39.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",
         "@codemirror/commands": "^6.7.1",
@@ -16947,11 +16947,11 @@
     },
     "packages/bridge-contract": {
       "name": "@zennotes/bridge-contract",
-      "version": "2.38.0"
+      "version": "2.39.0"
     },
     "packages/shared-domain": {
       "name": "@zennotes/shared-domain",
-      "version": "2.38.0",
+      "version": "2.39.0",
       "dependencies": {
         "@zennotes/bridge-contract": "*",
         "lz-string": "^1.5.0"
@@ -16959,7 +16959,7 @@
     },
     "packages/shared-ui": {
       "name": "@zennotes/shared-ui",
-      "version": "2.38.0"
+      "version": "2.39.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zennotes-monorepo",
   "private": true,
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "ZenNotes monorepo for desktop, web, and self-hosted server builds",
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/app-core",
   "private": true,
-  "version": "2.38.0",
+  "version": "2.39.0",
   "type": "module",
   "exports": {
     "./main": "./src/main.tsx"

--- a/packages/bridge-contract/package.json
+++ b/packages/bridge-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/bridge-contract",
   "private": true,
-  "version": "2.38.0",
+  "version": "2.39.0",
   "type": "module",
   "exports": {
     "./bridge": "./src/bridge.ts",

--- a/packages/shared-domain/package.json
+++ b/packages/shared-domain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-domain",
   "private": true,
-  "version": "2.38.0",
+  "version": "2.39.0",
   "type": "module",
   "exports": {
     "./*": "./src/*.ts"

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zennotes/shared-ui",
   "private": true,
-  "version": "2.38.0",
+  "version": "2.39.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
Version bump for 2.39.0. The release content itself landed on `main` through #687 (twelve commits, verified over CDP, packaged launch gate passed).

Release notes: `docs/releases/v2.39.0/RELEASE_NOTES.md` (local). Headline: resize pictures by hand, copy links from a right-click, MCP follows a connected server, video embeds stop hijacking the keyboard, plus #685 #686 #691, the Cloud multi-save catch-up fix, and the Sync incomplete file list.