### PR TITLE
Fix(editor): arrow keys navigate the @, / and [[ menus again

### DIFF
--- a/packages/app-core/src/components/EditorPane.tsx
+++ b/packages/app-core/src/components/EditorPane.tsx
@@ -62,7 +62,7 @@ import { forwardOnCheckboxArrow } from '../lib/cm-forward-task'
 import { markerHopCommands } from '../lib/cm-marker-hop'
 import { isInMarkdownCode } from '../lib/cm-auto-pairs'
 import { toggleCheckbox } from '../lib/cm-toggle-checkbox'
-import { completionKeymapForEditor, completionNavKeymap } from '../lib/cm-completion-nav'
+import { completionKeymapExtension, completionNavKeymap } from '../lib/cm-completion-nav'
 import { vimAwareDefaultKeymap, vimAwareMarkdownKeymap, vimAwareSearchKeymap } from '../lib/cm-vim-default-keymap'
 import { isVimAwaitingArgument } from '../lib/vim-nav'
 import { toCodeMirrorKey, vimHalfPageKeymap } from '../lib/vim-half-page-keymap'
@@ -404,8 +404,7 @@ function buildEditorKeymap(vimMode: boolean, overrides: KeymapOverrides): Extens
     indentWithTab,
     ...vimAwareDefaultKeymap(vimMode),
     ...historyKeymap,
-    ...vimAwareSearchKeymap(vimMode),
-    ...completionKeymapForEditor
+    ...vimAwareSearchKeymap(vimMode)
   ])
 }
 
@@ -1787,7 +1786,7 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
             // Don't install @codemirror/autocomplete's stock keymap — it binds
             // mac-only `Alt-`` / `Alt-i` to completion and swallows the char
             // those combos type on AltGr-style layouts (#429). Our filtered
-            // `completionKeymapForEditor` (in buildEditorKeymap) covers the rest.
+            // `completionKeymapExtension` (mounted below) covers the rest.
             defaultKeymap: false,
             override: [
               slashCommandSource,
@@ -1812,6 +1811,7 @@ export function EditorPane({ pane }: { pane: PaneLeaf }): JSX.Element {
             }
           }),
           completionNavKeymap,
+          completionKeymapExtension,
           editorKeymapCompartment.of(buildEditorKeymap(s0.vimMode, s0.keymapOverrides)),
           EditorView.domEventHandlers({
             mousedown: (event, view) => {

--- a/packages/app-core/src/components/PinnedReferencePane.tsx
+++ b/packages/app-core/src/components/PinnedReferencePane.tsx
@@ -55,7 +55,7 @@ import {
 } from '../lib/cm-wikilinks'
 import { hashtagSource } from '../lib/cm-hashtag-complete'
 import { frontmatterTagSource } from '../lib/cm-frontmatter-tag-complete'
-import { completionKeymapForEditor, completionNavKeymap } from '../lib/cm-completion-nav'
+import { completionKeymapExtension, completionNavKeymap } from '../lib/cm-completion-nav'
 import { classifyLocalAssetHref, hrefFragment, type LocalAssetKind } from '../lib/local-assets'
 import { LazyPreview as Preview } from './LazyPreview'
 import { CloseIcon, PanelLeftIcon, PinIcon } from './icons'
@@ -261,6 +261,7 @@ export function PinnedReferencePane(): JSX.Element | null {
             }
           }),
           completionNavKeymap,
+          completionKeymapExtension,
           keymap.of([
             {
               key: 'Mod-f',
@@ -274,8 +275,7 @@ export function PinnedReferencePane(): JSX.Element | null {
             indentWithTab,
             ...vimAwareDefaultKeymap(s0.vimMode),
             ...historyKeymap,
-            ...vimAwareSearchKeymap(s0.vimMode),
-            ...completionKeymapForEditor
+            ...vimAwareSearchKeymap(s0.vimMode)
           ]),
           EditorView.updateListener.of((upd) => {
             if (!upd.docChanged) return

--- a/packages/app-core/src/components/QuickCaptureApp.tsx
+++ b/packages/app-core/src/components/QuickCaptureApp.tsx
@@ -60,7 +60,7 @@ import {
   closeCompletion,
   completionStatus
 } from '@codemirror/autocomplete'
-import { completionKeymapForEditor, completionNavKeymap } from '../lib/cm-completion-nav'
+import { completionKeymapExtension, completionNavKeymap } from '../lib/cm-completion-nav'
 import { slashCommandRender, templateSlashCommandSource } from '../lib/cm-slash-commands'
 import { calloutTypeSource } from '../lib/cm-callouts'
 import type { NoteMeta } from '@shared/ipc'
@@ -499,6 +499,7 @@ export function QuickCaptureApp(): JSX.Element {
                 : 'slash-cmd-option'
           }),
           completionNavKeymap,
+          completionKeymapExtension,
           // Esc closes an open slash menu instead of bubbling to the window-level
           // Esc that saves + hides the capture window. Runs before everything,
           // and only when a completion is actually open.
@@ -516,7 +517,6 @@ export function QuickCaptureApp(): JSX.Element {
           ),
           keymap.of([
             indentWithTab,
-            ...completionKeymapForEditor,
             ...vimAwareDefaultKeymap(prefs.vimMode),
             ...historyKeymap,
             ...vimAwareSearchKeymap(prefs.vimMode)

--- a/packages/app-core/src/components/TemplateEditorModal.tsx
+++ b/packages/app-core/src/components/TemplateEditorModal.tsx
@@ -29,7 +29,7 @@ import { editorTabSize } from '../lib/editor-tab-size'
 import { templateVariableSource, TEMPLATE_VARIABLES } from '../lib/cm-template-variables'
 import { templateSlashCommandSource, slashCommandRender } from '../lib/cm-slash-commands'
 import { calloutTypeSource } from '../lib/cm-callouts'
-import { completionKeymapForEditor, completionNavKeymap } from '../lib/cm-completion-nav'
+import { completionKeymapExtension, completionNavKeymap } from '../lib/cm-completion-nav'
 import { Modal } from './ui/Modal'
 import { Button } from './ui/Button'
 
@@ -158,9 +158,9 @@ export function TemplateEditorModal({
               : 'slash-cmd-option'
         }),
         completionNavKeymap,
+        completionKeymapExtension,
         keymap.of([
           indentWithTab,
-          ...completionKeymapForEditor,
           ...vimAwareDefaultKeymap(vimModeRef.current),
           ...historyKeymap
         ]),

--- a/packages/app-core/src/lib/cm-completion-nav-arrows.test.ts
+++ b/packages/app-core/src/lib/cm-completion-nav-arrows.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import {
+  autocompletion,
+  currentCompletions,
+  selectedCompletionIndex,
+  startCompletion,
+  type CompletionContext,
+  type CompletionResult
+} from '@codemirror/autocomplete'
+import { defaultKeymap } from '@codemirror/commands'
+import { EditorState } from '@codemirror/state'
+import { EditorView, keymap } from '@codemirror/view'
+import { describe, expect, it } from 'vitest'
+import { completionKeymapExtension, completionNavKeymap } from './cm-completion-nav'
+
+/** Stands in for the `@` date/note sources: three options, no filtering. */
+function source(context: CompletionContext): CompletionResult | null {
+  const match = context.matchBefore(/@\w*/)
+  if (!match) return null
+  return {
+    from: match.from + 1,
+    options: [{ label: 'Today' }, { label: 'Tomorrow' }, { label: 'Yesterday' }],
+    filter: false
+  }
+}
+
+function mount(): EditorView {
+  return new EditorView({
+    state: EditorState.create({
+      doc: 'line one\nline two\n@\nline four',
+      selection: { anchor: 19 },
+      extensions: [
+        autocompletion({ defaultKeymap: false, override: [source] }),
+        completionNavKeymap,
+        completionKeymapExtension,
+        keymap.of([...defaultKeymap])
+      ]
+    }),
+    parent: document.body
+  })
+}
+
+function press(view: EditorView, key: string): void {
+  view.contentDOM.dispatchEvent(
+    new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+  )
+}
+
+/** Past `interactionDelay` (75ms), before which the popup ignores navigation. */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 250))
+
+describe('completion arrow navigation', () => {
+  it('moves the highlighted option instead of the caret', async () => {
+    const view = mount()
+    startCompletion(view)
+    await settle()
+    expect(currentCompletions(view.state).length).toBe(3)
+    expect(selectedCompletionIndex(view.state)).toBe(0)
+    const caret = view.state.selection.main.head
+
+    press(view, 'ArrowDown')
+    expect(selectedCompletionIndex(view.state)).toBe(1)
+    press(view, 'ArrowDown')
+    expect(selectedCompletionIndex(view.state)).toBe(2)
+    press(view, 'ArrowUp')
+    expect(selectedCompletionIndex(view.state)).toBe(1)
+
+    // Mounted below `defaultKeymap` instead, its ArrowUp/ArrowDown caret motions
+    // win and the caret move closes the menu — the regression this guards.
+    expect(currentCompletions(view.state).length).toBe(3)
+    expect(view.state.selection.main.head).toBe(caret)
+
+    view.destroy()
+  })
+
+  it('lets the arrows through when no completion is open', () => {
+    let reached = 0
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: 'line one',
+        extensions: [
+          autocompletion({ defaultKeymap: false, override: [source] }),
+          completionNavKeymap,
+          completionKeymapExtension,
+          keymap.of([
+            {
+              key: 'ArrowDown',
+              run: () => {
+                reached += 1
+                return true
+              }
+            }
+          ])
+        ]
+      }),
+      parent: document.body
+    })
+
+    press(view, 'ArrowDown')
+    expect(reached).toBe(1)
+
+    view.destroy()
+  })
+})

--- a/packages/app-core/src/lib/cm-completion-nav.ts
+++ b/packages/app-core/src/lib/cm-completion-nav.ts
@@ -6,7 +6,7 @@ import {
   selectedCompletion
 } from '@codemirror/autocomplete'
 import { Prec } from '@codemirror/state'
-import { EditorView, type KeyBinding } from '@codemirror/view'
+import { EditorView, keymap, type KeyBinding } from '@codemirror/view'
 
 /**
  * macOS AltGr-style keyboard layouts (custom Ukelele `.keylayout` files, a
@@ -24,6 +24,16 @@ import { EditorView, type KeyBinding } from '@codemirror/view'
 const MAC_TEXT_ENTRY_CHORDS = new Set(['Alt-`', 'Alt-i'])
 export const completionKeymapForEditor: readonly KeyBinding[] = completionKeymap.filter(
   (binding) => !(typeof binding.mac === 'string' && MAC_TEXT_ENTRY_CHORDS.has(binding.mac))
+)
+
+/**
+ * Mount this instead of spreading the bindings into an editor's general
+ * `keymap.of([...])`, where they lose to anything listed earlier — the arrows
+ * then move the caret, which closes the popup. `Prec.highest` is what
+ * `@codemirror/autocomplete` gives its own keymap.
+ */
+export const completionKeymapExtension = Prec.highest(
+  keymap.of([...completionKeymapForEditor])
 )
 
 /**


### PR DESCRIPTION
## What

Arrow keys navigate an open completion menu again — the `@` date/note suggestions, the `/` slash menu, the `[[` reference picker and the callout `[!` type picker. Before this, ↑/↓ moved the caret instead, and the caret move closed the menu, so the only way to pick an item was Ctrl+N/Ctrl+P.

## Why it broke

`autocompletion({ defaultKeymap: false })` skips the stock completion keymap so mac AltGr-style layouts keep their `` Alt-` ``/`Alt-i` characters. The filtered replacement (`completionKeymapForEditor`) was re-added by spreading it into the editor's general `keymap.of([...])`.

Upstream mounts that keymap at `Prec.highest`. The spread put it at default precedence and **last** in the array — and CodeMirror runs same-key bindings in array order (`buildKeymap` pushes onto `binding.run`). So `defaultKeymap`'s `ArrowUp`/`ArrowDown` (`cursorLineUp`/`cursorLineDown`) ran first, returned `true`, and the completion never saw the key.

`EditorPane` and `PinnedReferencePane` spread it last, so they were broken. `QuickCaptureApp` and `TemplateEditorModal` happened to spread it first, so they worked — which is why the behaviour differed between the main editor and the Quick Note window.

## The fix

A new `completionKeymapExtension` mounts the same filtered bindings at `Prec.highest`, matching what `@codemirror/autocomplete` does for its own keymap. All four editors mount it next to `completionNavKeymap` instead of inlining the spread, which removes the ordering trap for future edits.

No behaviour change for the AltGr fix — the two mac chords stay filtered out.

## Testing

- New `cm-completion-nav-arrows.test.ts`: ↓↓↑ moves the highlighted option, the menu stays open and the caret does not move; with no menu open the arrows fall through to the next binding.
- Verified the old wiring fails that test and the new wiring passes.
- `npm run typecheck`, `npm run test:run` (1827 passed) and `npm run build` all pass locally on Node 22.

## Before / After

**Before** — ↓ moves the caret and the `@` menu closes.

https://github.com/user-attachments/assets/199e7e7a-d3f5-4c79-805f-731e6774e78a

**After** — ↓/↑ move the highlighted item, the menu stays open.

https://github.com/user-attachments/assets/d77264d0-4d32-4138-9940-a3a991c86225
