### PR TITLE
packaging: publish v2.40.0 channel metadata

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zennotes-bin
 	pkgdesc = Keyboard-first, local-first Markdown notes with vim motions and live preview
-	pkgver = 2.39.0
+	pkgver = 2.40.0
 	pkgrel = 1
 	url = https://github.com/ZenNotes/zennotes
 	arch = x86_64
@@ -13,7 +13,7 @@ pkgbase = zennotes-bin
 	provides = zennotes
 	conflicts = zennotes
 	options = !strip
-	source = ZenNotes-2.39.0-linux-x64.tar.gz::https://github.com/ZenNotes/zennotes/releases/download/v2.39.0/ZenNotes-2.39.0-linux-x64.tar.gz
-	sha256sums = 85a8c47d81fb462b9395e732d9d9ca2ca4e23070cb2a87da203daf59a5ee476e
+	source = ZenNotes-2.40.0-linux-x64.tar.gz::https://github.com/ZenNotes/zennotes/releases/download/v2.40.0/ZenNotes-2.40.0-linux-x64.tar.gz
+	sha256sums = e0aa1939723013f6a5f04196179128403be8ae92be1160c57248bf45f6b175cb
 
 pkgname = zennotes-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -10,7 +10,7 @@
 
 pkgname=zennotes-bin
 _appname=ZenNotes
-pkgver=2.39.0
+pkgver=2.40.0
 pkgrel=1
 pkgdesc="Keyboard-first, local-first Markdown notes with vim motions and live preview"
 arch=('x86_64')
@@ -30,7 +30,7 @@ source=(
 
 # sha256 of the uploaded ZenNotes-${pkgver}-linux-x64.tar.gz release asset
 # (GitHub's authoritative asset digest; no Arch tooling needed).
-sha256sums=('85a8c47d81fb462b9395e732d9d9ca2ca4e23070cb2a87da203daf59a5ee476e')
+sha256sums=('e0aa1939723013f6a5f04196179128403be8ae92be1160c57248bf45f6b175cb')
 
 package() {
   cd "${srcdir}"

--- a/packaging/homebrew/Casks/zennotes.rb
+++ b/packaging/homebrew/Casks/zennotes.rb
@@ -1,9 +1,9 @@
 cask "zennotes" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.39.0"
-  sha256 arm:   "3c0c85421b7699dbf00a135172e173b5f2a2b7568f73fe8ecd771fe094f87bcc",
-         intel: "f4801ed1cf6f124df6eb3003964b8b6b1264e0a0f8fbec8cf8b27cfe2082ea49"
+  version "2.40.0"
+  sha256 arm:   "fd6f800a9a3e69e841291272f1be624b73b30d41491cac49efbb611ba5f9661e",
+         intel: "00177e3547e7173c4ab09f625425499740018087819f6f38801918282251916f"
 
   url "https://github.com/ZenNotes/zennotes/releases/download/v#{version}/ZenNotes-#{version}-mac-#{arch}.dmg"
   name "ZenNotes"


### PR DESCRIPTION
## Summary
- update the canonical AUR package to v2.40.0 and pin the published Linux tarball SHA-256
- update the canonical Homebrew cask to v2.40.0 and pin both published DMG SHA-256 digests

## Verification
- canonical AUR files match the publisher clone
- canonical Homebrew cask matches the tap clone
- `bash -n packaging/aur/PKGBUILD`
- `ruby -c packaging/homebrew/Casks/zennotes.rb`
- release asset URLs and GitHub digests verified against v2.40.0