### PR TITLE
fix(export): resolve wikilink images during PDF exports

### DIFF
--- a/apps/desktop/src/renderer/export-window.tsx
+++ b/apps/desktop/src/renderer/export-window.tsx
@@ -14,6 +14,7 @@ import {
   resolveCustomThemeMode
 } from '@renderer/lib/custom-themes'
 import { withExportTitle } from '@shared/export-title'
+import { rewriteWikilinkImageEmbeds } from '@shared/embed-size'
 import '@renderer/styles/index.css'
 
 const PREFS_KEY = 'zen:prefs:v2'
@@ -446,7 +447,9 @@ function ExportNoteWindow({ notePath }: { notePath: string }): JSX.Element {
       `}</style>
       <main className="export-note-shell">
         <Preview
-          markdown={withExportTitle(note.body, note.title).markdown}
+          markdown={rewriteWikilinkImageEmbeds(
+            withExportTitle(note.body, note.title).markdown
+          )}
           notePath={note.path}
           onRendered={() => setExportState('ready')}
         />

--- a/apps/web/src/export-window.tsx
+++ b/apps/web/src/export-window.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import type { AssetMeta, NoteContent, NoteMeta, VaultInfo } from '@shared/ipc'
 import { LazyPreview as Preview } from '@renderer/components/LazyPreview'
 import { useStore } from '@renderer/store'
+import { rewriteWikilinkImageEmbeds } from '@shared/embed-size'
 import '@renderer/styles/index.css'
 
 const PREFS_KEY = 'zen:prefs:v2'
@@ -244,7 +245,11 @@ function ExportNoteWindow({ notePath }: { notePath: string }): JSX.Element {
         }
       `}</style>
       <main className="export-note-shell">
-        <Preview markdown={note.body} notePath={note.path} onRendered={() => void triggerPrint()} />
+        <Preview
+          markdown={rewriteWikilinkImageEmbeds(note.body)}
+          notePath={note.path}
+          onRendered={() => void triggerPrint()}
+        />
       </main>
     </>
   )

--- a/packages/app-core/src/lib/local-assets-vault-root.test.ts
+++ b/packages/app-core/src/lib/local-assets-vault-root.test.ts
@@ -90,6 +90,20 @@ describe('#459 — vault-root wikilink embeds resolve from the root', () => {
     const img = root.querySelector<HTMLImageElement>('img')!
     expect(img.dataset.localAssetUrl).toBe('zen-asset://v/assets/image.png')
   })
+
+  it('leaves a missing image unresolved without throwing', async () => {
+    const { useStore, enhanceLocalAssetNodes } = await load()
+    useStore.setState({ assetFiles: [{ path: 'assets/other.png' }] as never })
+    const root = document.createElement('div')
+    root.innerHTML = '<p><img src="missing image.png" alt="Missing image"></p>'
+
+    expect(() =>
+      enhanceLocalAssetNodes(root, { vaultRoot: '/v', notePath: DAILY_NOTE })
+    ).not.toThrow()
+    const img = root.querySelector<HTMLImageElement>('img')!
+    expect(img.dataset.localAssetUrl).toBe('zen-asset://v/missing image.png')
+    expect(img.getAttribute('alt')).toBe('Missing image')
+  })
 })
 
 // #462: imported Obsidian vaults use per-folder `attachments/` directories and

--- a/packages/shared-domain/src/embed-size.test.ts
+++ b/packages/shared-domain/src/embed-size.test.ts
@@ -37,6 +37,14 @@ describe('rewriteWikilinkImageEmbeds', () => {
     expect(rewriteWikilinkImageEmbeds('![[chart.png|Quarter|600x400]]')).toBe('![Quarter|600x400](chart.png)')
     expect(rewriteWikilinkImageEmbeds('![[assets/my chart.png]]')).toBe('![](<assets/my chart.png>)')
   })
+  it('supports nested paths, spaces, alt text, and dimension labels used by PDF export', () => {
+    expect(rewriteWikilinkImageEmbeds('![[subfolder/team photo.png|Team photo]]')).toBe(
+      '![Team photo](<subfolder/team photo.png>)'
+    )
+    expect(rewriteWikilinkImageEmbeds('![[subfolder/team photo.png|300]]')).toBe(
+      '![|300](<subfolder/team photo.png>)'
+    )
+  })
   it('leaves note embeds and fenced code alone', () => {
     const doc = '![[Some note]]\n\n```md\n![[chart.png]]\n```\n\n![[chart.png]]'
     expect(rewriteWikilinkImageEmbeds(doc)).toBe('![[Some note]]\n\n```md\n![[chart.png]]\n```\n\n![](chart.png)')


### PR DESCRIPTION
# Fix wikilink image rendering in PDF exports

## Summary

Fixes PDF exports rendering embedded wikilink images such as `![[image.png]]` as raw text instead of images.

Both desktop and web PDF export pipelines now preprocess wikilink image embeds into standard Markdown image syntax before passing the note to the existing preview renderer.

## Changes

- Applied the existing shared `rewriteWikilinkImageEmbeds` preprocessor in the desktop PDF export window.
- Applied the same preprocessing in the web PDF export window.
- Reused the existing vault-aware asset resolution pipeline instead of introducing duplicate path-resolution logic.
- Preserved support for:
  - filenames containing spaces
  - nested asset paths
  - alt text
  - width and dimension hints
  - missing assets without crashing the export
- Added regression tests for nested paths, spaces, alt text, dimension parameters, and missing files.
- Left normal note preview behavior and unrelated export functionality unchanged.

## Examples

The PDF pipeline now converts wikilink image embeds such as:

```md
![[image.png]]
![[subfolder/team photo.png|Team photo]]
![[image.png|300]]
![[image.png|Quarterly chart|600x400]]
```

into standard Markdown image nodes before rendering:

```md
![](image.png)
![Team photo](<subfolder/team photo.png>)
![|300](image.png)
![Quarterly chart|600x400](image.png)
```

The existing asset resolver then maps each image target to the appropriate vault-relative asset URL. It supports note-relative paths, vault-root paths, and unique filename matches.

If an asset is missing, the export continues without throwing and retains the image's fallback alt text.

## Testing

- Focused PDF/wikilink regression tests: 81 passed
- Load-sensitive full-suite tests rerun in isolation: 106 passed
- Shared-domain typecheck: passed
- App-core typecheck: passed
- Desktop typecheck: passed
- Web typecheck: passed
- `git diff --check`: passed
- Manual verification on Fedora Linux: passed

The full parallel monorepo test run initially reported four unrelated load-sensitive failures, including two timeouts. All four passed when rerun together in isolation.
