### PR TITLE
Chore(deps): js-yaml 3.15.2 / 4.3.2 and svgo 3.3.5 (today's advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9547,9 +9547,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -10397,9 +10397,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -14573,9 +14573,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
-      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.5.tgz",
+      "integrity": "sha512-8SQMzdrvWaD8deUmrnYB+ASyxBVgWUOilg+A75nE/76WdLpj6LopCwiAVvkzkcqy/9b7t2Mg7faFLjg0ZRcZ3w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",


### PR DESCRIPTION
Lockfile-only bump for three advisories published today that turn the production audit red, here and in the phone shells, which audit this checkout at their pin.

- **js-yaml**, GHSA-2883-xcg3-v3hh (high): 3.15.1 → 3.15.2 for gray-matter's copy, 4.3.1 → 4.3.2 for the root copy.
- **svgo**, GHSA-w27v-7q3p-w38r and GHSA-4vpr-x523-8j87 (high): 3.3.4 → 3.3.5, reached through node-tikzjax in the desktop app.

Every move stays inside the dependents' existing ranges, so package.json is untouched. hono's moderate advisories remain, below the gate.

### Verification

- `npm audit --omit=dev --audit-level=high` exits 0 (one moderate left).
- `npm run typecheck`: 7/7 tasks.

The iOS and Android shells re-pin to the squash commit once this lands.
