### PR TITLE
Chore(deps): smol-toml 1.8.0 and hono 4.13.7 (today's advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9901,9 +9901,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
-      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -14308,9 +14308,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"


### PR DESCRIPTION
Lockfile-only. smol-toml GHSA-7w5x-hrqm-74c2 (high, DoS via malformed TOML documents; patched in 1.7.1) turns the production audit red today. The mobile shells audit this lockfile at their pin, so their CI went red on the next push. hono's three moderate advisories (GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc, GHSA-crvj-82cr-hjcx) now have a fix inside the existing ranges too, so it moves along.

| package | from | to | range kept |
|---|---|---|---|
| smol-toml | 1.7.0 | 1.8.0 | `^1.7.0` |
| hono | 4.13.3 | 4.13.7 | `^4` / `^4.11.4` |

Both bumps stay inside the dependents' ranges, so package.json is untouched. The desktop only imports smol-toml's `parse`; 1.7.1 -> 1.8.0 adds stringify support for temporal objects and parser performance work.

Verified locally: integrity hashes match the registry, `npm install --package-lock-only` is a no-op on the result, `npm ci --dry-run` passes, `npm audit --omit=dev --audit-level=high` reports 0 vulnerabilities, and the desktop tests for `app-config`, `custom-themes`, `vault-ops`, and `packaging` (49 tests) pass with 1.8.0 installed. Both mobile shells typecheck against this tree.
