### PR TITLE
packaging(nix): use the top-level X11 libraries, not the deprecated xorg set

### DIFF
--- a/packaging/nix/package-desktop.nix
+++ b/packaging/nix/package-desktop.nix
@@ -35,7 +35,18 @@
   pango,
   systemd,
   wayland,
-  xorg,
+  libx11,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxrandr,
+  libxrender,
+  libxscrnsaver,
+  libxtst,
+  libxcb,
 
   commandLineArgs ? "",
 }:
@@ -86,18 +97,18 @@ stdenv.mkDerivation (finalAttrs: {
     nss
     pango
     stdenv.cc.cc # libstdc++
-    xorg.libX11
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXScrnSaver
-    xorg.libXtst
-    xorg.libxcb
+    libx11
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxrandr
+    libxrender
+    libxscrnsaver
+    libxtst
+    libxcb
   ];
 
   # dlopen'd at runtime (not in DT_NEEDED), so keep them on the wrapper's path.


### PR DESCRIPTION
On nixpkgs 26.05 and later, evaluating `zennotes-desktop` prints 12 `The xorg package set has been deprecated` warnings, one per `xorg.*` library in `packaging/nix/package-desktop.nix`. This renames those 12 to their top-level names and touches nothing else. It is the rename from #422 without the other changes, with the build output and nixpkgs rev that review asked for; unlike #422 it uses the lowercase names (see below).

On the default config this does not fix a broken build, as the review on #432 said: the derivation is identical. It removes the warnings, and it makes the file evaluate with `allowAliases = false`, where the current one fails with `Function called without required argument "xorg"`.

**Verification** (x86_64-linux, the flake's pinned nixpkgs `9ae611a455b9`, 26.11 development, last modified 2026-06-10):

| rev | warnings | drvPath |
|---|---|---|
| `main` 431907d | 12 | `/nix/store/d7d77qz728xdjjizxh5g92f3ahyzlcik-zennotes-desktop-2.47.0.drv` |
| this PR | 0 | same |

`nix build .#zennotes-desktop` at this commit exits 0 with `/nix/store/kis0vmfkkiwwvx8s7jv2sgv4l490inij-zennotes-desktop-2.47.0`, and the checks from `nix-build.yml`'s "Validate desktop package" step pass on it when run locally: the interpreter is patched into the store, `chrome-sandbox` is removed, and `ldd` reports no unresolved libraries.

**Tradeoff: requires nixpkgs >= 25.11, drops 25.05.** 25.05 has no lowercase top-level `libx11`, so there this fails with `Function called without required argument "libx11"`. That hits the README's copy-the-file route and flake consumers who point `zennotes.inputs.nixpkgs.follows` at a 25.05 nixpkgs; the flake's own lock is unaffected. The capitalized names (`libX11`, …) would also clear the warnings and keep 25.05 working, but on current nixpkgs they are aliases themselves (`libX11 = libx11; # Added 2026-02-06` in `aliases.nix`). So they fail under `allowAliases = false` and would need renaming again when those aliases go, and I used the canonical ones. 25.05 has been end-of-life since 2025-12-31 and 25.11 since 2026-06-30. On 25.11 the drvPath is unchanged by this PR.

I did not run `npm run typecheck`, `test:run` or `build` locally: outside `packaging/nix/` only `flake.nix` reads this file, no npm workspace does, and `ci.yml` runs all three (`build:prod`) on pull requests.
